### PR TITLE
job split simple implementation

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/ResponseMessage.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/ResponseMessage.java
@@ -20,17 +20,22 @@ public class ResponseMessage<T> {
      */
     public static final Code CODE_SUCCESS = Code.success;
 
-    private Code code;
+    private String code;
     private String message;
     private T data;
 
     public ResponseMessage(Code code, String message, T data) {
-        setCode(code);
+        setCode(code.getType());
         setMessage(message);
         setData(data);
     }
 
     public ResponseMessage(Code code, String message) {
+        setCode(code.getType());
+        setMessage(message);
+    }
+
+    public ResponseMessage(String code, String message) {
         setCode(code);
         setMessage(message);
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/configuration/CommonExceptionHandler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/configuration/CommonExceptionHandler.java
@@ -9,6 +9,8 @@ package ai.starwhale.mlops.configuration;
 
 import ai.starwhale.mlops.api.protocol.ResponseMessage;
 import ai.starwhale.mlops.api.protocol.Code;
+import ai.starwhale.mlops.exception.StarWhaleApiException;
+import ai.starwhale.mlops.exception.StarWhaleException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
@@ -51,6 +53,15 @@ public class CommonExceptionHandler {
         return ResponseEntity
                 .internalServerError()
                 .body(new ResponseMessage<>(Code.internalServerError, ex.getMessage()));
+    }
+
+    @ExceptionHandler(StarWhaleApiException.class)
+    public ResponseEntity<ResponseMessage<String>> handleStarWhaleException(HttpServletRequest request, StarWhaleApiException ex) {
+        logger.error("handleInternalServerError {}\n", request.getRequestURI(), ex);
+
+        return ResponseEntity
+            .status(ex.getHttpStatus())
+            .body(new ResponseMessage<>(ex.getCode(), ex.getTip()));
     }
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/Job.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/Job.java
@@ -9,6 +9,7 @@ package ai.starwhale.mlops.domain.job;
 
 import ai.starwhale.mlops.domain.swds.SWDataSet;
 import ai.starwhale.mlops.domain.swmp.SWModelPackage;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.List;
  *
  */
 @Data
+@Builder
 public class Job {
 
     Long id;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobRuntime.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobRuntime.java
@@ -8,12 +8,14 @@
 package ai.starwhale.mlops.domain.job;
 
 import ai.starwhale.mlops.domain.node.Device;
+import lombok.Builder;
 import lombok.Data;
 
 /**
  *
  */
 @Data
+@Builder
 public class JobRuntime {
 
     /**

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobSpliter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobSpliter.java
@@ -9,6 +9,7 @@ package ai.starwhale.mlops.domain.job;
 
 import ai.starwhale.mlops.domain.task.Task;
 
+import ai.starwhale.mlops.domain.task.TaskTrigger;
 import java.util.List;
 
 /**
@@ -16,5 +17,5 @@ import java.util.List;
  */
 public interface JobSpliter {
 
-    List<Task> split(Job job);
+    List<TaskTrigger> split(Job job);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/SimpleJobSpliter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/SimpleJobSpliter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022.1-2022
+ * StarWhale.ai All right reserved. This software is the confidential and proprietary information of
+ * StarWhale.ai ("Confidential Information"). You shall not disclose such Confidential Information and shall use it only
+ * in accordance with the terms of the license agreement you entered into with StarWhale.ai.
+ */
+
+package ai.starwhale.mlops.domain.job;
+
+import ai.starwhale.mlops.domain.swds.SWDataSet;
+import ai.starwhale.mlops.domain.swds.SWDataSetSlice;
+import ai.starwhale.mlops.domain.task.Task;
+import ai.starwhale.mlops.domain.task.TaskTrigger;
+import ai.starwhale.mlops.exception.SWValidationException;
+import ai.starwhale.mlops.exception.SWValidationException.ValidSubject;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SimpleJobSpliter implements JobSpliter {
+
+    @Override
+    public List<TaskTrigger> split(Job job) {
+        Integer deviceAmount = job.getJobRuntime().getDeviceAmount();
+        //allocatedTasks.size() == deviceAmount
+        List<Task> allocatedTasks = allocateTasks(job.getId(), deviceAmount);
+        List<SWDataSet> swDataSets = job.getSwDataSets();
+        //slicePointsPerDS.size() == swDataSets.size()
+        List<List<Integer>> slicePointsPerDS = swDataSets.stream()
+            .map(ds -> slicePoints(ds.getSize(), deviceAmount))
+            .collect(Collectors.toList());
+        List<TaskTrigger> taskTriggers = new ArrayList<>(getInitialCapacity(deviceAmount));
+        for (int i = 0; i < deviceAmount; i++) {
+            int swdsSize = swDataSets.size();
+            List<SWDataSetSlice> swDataSetSlices = new ArrayList<>(getInitialCapacity(
+                swdsSize));
+            for (int j = 0; j < swdsSize; j++) {
+                List<Integer> slicePoints = slicePointsPerDS.get(j);
+                boolean lastSlice = i == deviceAmount - 1;
+                SWDataSetSlice swdsSlice = SWDataSetSlice.builder()
+                    .swDataSet(swDataSets.get(j))
+                    .start(slicePoints.get(i))
+                    .end(lastSlice ? slicePoints.get(i + 1) : slicePoints.get(i + 1) - 1)
+                    .build();
+                swDataSetSlices.add(swdsSlice);
+            }
+            TaskTrigger taskTrigger = TaskTrigger.builder().task(allocatedTasks.get(i))
+                .swModelPackage(job.getSwmp())
+                .swDataSetSlice(swDataSetSlices)
+                .build();
+            taskTriggers.add(taskTrigger);
+        }
+        return taskTriggers;
+    }
+
+    private int getInitialCapacity(Integer expectedSize) {
+        return Double.valueOf(Math.ceil((expectedSize) * 1.4)).intValue();
+    }
+
+    private List<Task> allocateTasks(Long id, Integer deviceAmount) {
+        //TODO tasks should be saved into DB in this step, here is a mock
+
+        List<Task> tasks = new LinkedList<>();
+        for (int i = 0; i < deviceAmount; i++) {
+            tasks.add(Task.builder().jobId(id).id(1L).build());
+        }
+        return tasks;
+    }
+
+    /**
+     * (8,3) -> (0 3 6 7); (8,4) -> (0 2 4 6 7); (3,4) -> (0 1 2); slicePoints.size() == sliceAmount +
+     * 1  || slicePoints.size() == total + 1
+     */
+    private List<Integer> slicePoints(final Integer total, final Integer sliceAmount) {
+        if (sliceAmount <= 0) {
+            log.error("invalid slice amount expected greater than 0");
+            throw new SWValidationException(ValidSubject.JOB);
+        }
+        //if sliceAmount > total ,sliceSize is 1 and eventually we got (total + 1) slicePoints instead of (sliceAmount + 1)
+        final int sliceSizeRound = total / sliceAmount;
+        final int sliceSize = total % sliceAmount == 0 ? sliceSizeRound : sliceSizeRound + 1;
+        int slicePoint = 0;
+        List<Integer> slicePoints = new ArrayList<>(getInitialCapacity(sliceAmount + 1));
+        do {
+            slicePoints.add(slicePoint);
+            slicePoint += sliceSize;
+        } while (slicePoint < total - 1);
+        slicePoints.add(total - 1);
+        return slicePoints;
+    }
+
+
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SWDataSet.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SWDataSet.java
@@ -7,12 +7,14 @@
 
 package ai.starwhale.mlops.domain.swds;
 
+import lombok.Builder;
 import lombok.Data;
 
 /**
  * Star Whale Data Set
  */
 @Data
+@Builder
 public class SWDataSet {
 
     /**

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SWDataSetSlice.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SWDataSetSlice.java
@@ -7,12 +7,14 @@
 
 package ai.starwhale.mlops.domain.swds;
 
+import lombok.Builder;
 import lombok.Data;
 
 /**
  * a slice of an SWDS
  */
 @Data
+@Builder
 public class SWDataSetSlice {
 
     /**

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SWModelPackage.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SWModelPackage.java
@@ -7,12 +7,14 @@
 
 package ai.starwhale.mlops.domain.swmp;
 
+import lombok.Builder;
 import lombok.Data;
 
 /**
  * Star Whale Model Package
  */
 @Data
+@Builder
 public class SWModelPackage {
 
     Long id;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/Task.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/Task.java
@@ -7,12 +7,14 @@
 
 package ai.starwhale.mlops.domain.task;
 
+import lombok.Builder;
 import lombok.Data;
 
 /**
  * Tasks are derived from a Job. Tasks are the executing units of a Job.
  */
 @Data
+@Builder
 public class Task {
 
     /**

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/TaskTrigger.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/TaskTrigger.java
@@ -9,12 +9,17 @@ package ai.starwhale.mlops.domain.task;
 
 import ai.starwhale.mlops.domain.swds.SWDataSetSlice;
 import ai.starwhale.mlops.domain.swmp.SWModelPackage;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * sufficient information for an Agent to run a Task
  */
 @Data
+@Builder
 public class TaskTrigger {
 
     /**
@@ -30,5 +35,5 @@ public class TaskTrigger {
     /**
      * swds slice meta info
      */
-    SWDataSetSlice swDataSetSlice;
+    List<SWDataSetSlice> swDataSetSlice;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/exception/SWValidationException.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/exception/SWValidationException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022.1-2022
+ * StarWhale.ai All right reserved. This software is the confidential and proprietary information of
+ * StarWhale.ai ("Confidential Information"). You shall not disclose such Confidential Information and shall use it only
+ * in accordance with the terms of the license agreement you entered into with StarWhale.ai.
+ */
+
+package ai.starwhale.mlops.exception;
+
+public class SWValidationException extends StarWhaleException {
+
+    static final String PREFIX_CODE="400";
+
+    static final String PREFIX_TIP="invalid request on subject ";
+
+    private String code;
+    private String tip;
+
+    public SWValidationException(ValidSubject validSubject){
+        this.code = PREFIX_CODE + validSubject.code;
+        this.tip = PREFIX_TIP + validSubject.tipSubject;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getTip() {
+        return this.tip;
+    }
+
+    public enum ValidSubject{
+        JOB("001","JOB"),
+        TASK("002","TASK"),
+        USER("003","USER"),
+        NODE("004","NODE"),
+        SWDS("005","Star Whale Data Set"),
+        SDMP("006","Star Whale Model Package");
+        String code;
+        String tipSubject;
+        ValidSubject(String code,String tipSubject){
+            this.code = code;
+            this.tipSubject = tipSubject;
+        }
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/exception/StarWhaleApiException.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/exception/StarWhaleApiException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022.1-2022
+ * StarWhale.ai All right reserved. This software is the confidential and proprietary information of
+ * StarWhale.ai ("Confidential Information"). You shall not disclose such Confidential Information and shall use it only
+ * in accordance with the terms of the license agreement you entered into with StarWhale.ai.
+ */
+
+package ai.starwhale.mlops.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class StarWhaleApiException extends StarWhaleException {
+
+    /**
+     * every api exception should has a HttpStatus to be exposed to user.
+     * @return user oriented error code
+     */
+    public abstract HttpStatus getHttpStatus();
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/JobScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/JobScheduler.java
@@ -11,6 +11,7 @@ import ai.starwhale.mlops.domain.job.Job;
 import ai.starwhale.mlops.domain.node.Node;
 import ai.starwhale.mlops.domain.task.Task;
 
+import ai.starwhale.mlops.domain.task.TaskTrigger;
 import java.util.List;
 
 /**
@@ -29,5 +30,5 @@ public interface JobScheduler {
      * @param node the node load info
      * @return tasks to be assigned to the node
      */
-    List<Task> schedule(Node node);
+    List<TaskTrigger> schedule(Node node);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/SimpleJobScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/SimpleJobScheduler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022.1-2022
+ * StarWhale.ai All right reserved. This software is the confidential and proprietary information of
+ * StarWhale.ai ("Confidential Information"). You shall not disclose such Confidential Information and shall use it only
+ * in accordance with the terms of the license agreement you entered into with StarWhale.ai.
+ */
+
+package ai.starwhale.mlops.schedule;
+
+import static ai.starwhale.mlops.domain.job.Job.JobStatus.CREATED;
+
+import ai.starwhale.mlops.domain.job.Job;
+import ai.starwhale.mlops.domain.job.Job.JobStatus;
+import ai.starwhale.mlops.domain.job.JobSpliter;
+import ai.starwhale.mlops.domain.node.Device;
+import ai.starwhale.mlops.domain.node.Device.Clazz;
+import ai.starwhale.mlops.domain.node.Node;
+import ai.starwhale.mlops.domain.task.Task;
+import ai.starwhale.mlops.domain.task.TaskTrigger;
+import ai.starwhale.mlops.exception.SWValidationException;
+import ai.starwhale.mlops.exception.SWValidationException.ValidSubject;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * a simple implementation of JobScheduler
+ */
+@Slf4j
+public class SimpleJobScheduler implements JobScheduler {
+
+    JobSpliter jobSpliter;
+
+    final Map<Device.Clazz, ConcurrentLinkedQueue<TaskTrigger>> taskQueueTable;
+
+    public SimpleJobScheduler(JobSpliter jobSpliter) {
+        this.jobSpliter = jobSpliter;
+        Map<Device.Clazz, ConcurrentLinkedQueue<TaskTrigger>> taskQueueTableInitialization = new HashMap<>();
+        taskQueueTableInitialization.put(Clazz.CPU, new ConcurrentLinkedQueue<>());
+        taskQueueTableInitialization.put(Clazz.GPU, new ConcurrentLinkedQueue<>());
+        this.taskQueueTable = Collections.unmodifiableMap(taskQueueTableInitialization);
+    }
+
+    @Override
+    public void takeJob(Job job) {
+        validJob(job);
+        List<TaskTrigger> splitTasks = jobSpliter.split(job);
+        taskQueueTable.get(job.getJobRuntime().getDeviceClass()).addAll(splitTasks);
+        job.setStatus(JobStatus.SPLIT);
+        //save job status TODO
+    }
+
+    @Override
+    public List<TaskTrigger> schedule(Node node) {
+        validNode(node);
+        return node.getDeviceHolders()
+            .stream()
+            .filter(deviceHolder -> null == deviceHolder.getHolder()) //only schedule devices that is free
+            .map(deviceHolder -> taskQueueTable.get(deviceHolder.getDevice().getClazz()).poll())// pull task from the device corresponding queue
+            .filter(Objects::nonNull)//remove null tasks got from empty queue
+            .collect(Collectors.toList());
+    }
+
+    private void validNode(Node node) {
+        //assuming that all DeviceHolders are valid
+        if (null == node || null == node.getDeviceHolders()) {
+            log.error("bad node scheduled, null or null field");
+            throw new SWValidationException(ValidSubject.NODE);
+        }
+    }
+
+    public void validJob(Job job) {
+        if (null == job
+            || null == job.getStatus()
+            || null == job.getJobRuntime()
+            || null == job.getJobRuntime().getDeviceClass()) {
+            log.error("bad job taken, null or null field");
+            throw new SWValidationException(ValidSubject.JOB);
+        }
+        if (CREATED != job.getStatus()) {
+            log.error("only CREATED status job shall be scheduled but the status is {}",
+                job.getStatus());
+            throw new SWValidationException(ValidSubject.JOB);
+        }
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/test/job/TestSimpleJobSpliter.java
+++ b/server/controller/src/test/java/ai/starwhale/test/job/TestSimpleJobSpliter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022.1-2022
+ * StarWhale.ai All right reserved. This software is the confidential and proprietary information of
+ * StarWhale.ai ("Confidential Information"). You shall not disclose such Confidential Information and shall use it only
+ * in accordance with the terms of the license agreement you entered into with StarWhale.ai.
+ */
+
+package ai.starwhale.test.job;
+
+import ai.starwhale.mlops.domain.job.Job;
+import ai.starwhale.mlops.domain.job.Job.JobStatus;
+import ai.starwhale.mlops.domain.job.JobRuntime;
+import ai.starwhale.mlops.domain.job.SimpleJobSpliter;
+import ai.starwhale.mlops.domain.node.Device.Clazz;
+import ai.starwhale.mlops.domain.swds.SWDataSet;
+import ai.starwhale.mlops.domain.swmp.SWModelPackage;
+import ai.starwhale.mlops.domain.task.TaskTrigger;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestSimpleJobSpliter {
+
+    SimpleJobSpliter simpleJobSpliter = new SimpleJobSpliter();
+
+    public void testOneDataSet(final int deviceAmount,final int dataSetSize){
+        Job job = mockOneDSJob(deviceAmount, dataSetSize);
+        List<TaskTrigger> taskTriggers = simpleJobSpliter.split(job);
+        Assertions.assertEquals(taskTriggers.size(),deviceAmount);
+        final int sliceSizeRound = dataSetSize / deviceAmount;
+        int sliceSize = dataSetSize % deviceAmount == 0? sliceSizeRound : sliceSizeRound + 1;
+        int dataRemaining = dataSetSize;
+        for(int i=0;i<deviceAmount;i++){
+            System.out.println(dataRemaining);
+            TaskTrigger taskTrigger = taskTriggers.get(i);
+            Assertions.assertEquals(taskTrigger.getSwDataSetSlice().size(),1);
+            if(i == deviceAmount -1){
+                Assertions.assertEquals(taskTrigger.getSwDataSetSlice().get(0).getEnd() - taskTrigger.getSwDataSetSlice().get(0).getStart() ,dataRemaining -1 );
+            }else {
+                Assertions.assertEquals(taskTrigger.getSwDataSetSlice().get(0).getEnd() - taskTrigger.getSwDataSetSlice().get(0).getStart()  ,sliceSize - 1);
+            }
+            dataRemaining -= sliceSize;
+        }
+    }
+    @Test
+    public void testSplit(){
+        testOneDataSet(3,2000);
+        testOneDataSet(4,2000);
+    }
+
+    private Job mockOneDSJob(int deviceAmount,int dataSetSize) {
+        return Job.builder()
+            .id(1L)
+            .jobRuntime(JobRuntime.builder().deviceAmount(deviceAmount).deviceClass(Clazz.CPU).build())
+            .status(JobStatus.CREATED)
+            .swDataSets(Arrays.asList(SWDataSet.builder().size(dataSetSize).build()))
+            .swmp(SWModelPackage.builder().build())
+            .build();
+    }
+
+
+}


### PR DESCRIPTION
## Description
- add a simple implementation of Job Scheduling
- change type of `code `in `ResponseMessage `from `Code `to `String`
- add `handleStarWhaleException `in `CommonExceptionHandler`
- add `StarWhaleApiException `and `SWValidationException`
## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
