### PR TITLE
use memoryview to tune split performance

### DIFF
--- a/example/mnist/test/swds_s3_simple.json
+++ b/example/mnist/test/swds_s3_simple.json
@@ -29,6 +29,6 @@
                 "data": "dataset/mnist/gbrggnldg44gcmrxgjswmzbyhb2da5i/data/data_ubyte_0.swds_bin:0",
                 "label": "dataset/mnist/gbrggnldg44gcmrxgjswmzbyhb2da5i/data/label_ubyte_0.swds_bin:0"
             }
-        },
+        }
     ]
 }


### PR DESCRIPTION
## Description
use `memoryview` to tune byte/bytearray split memory copy. `memoryview` is zero-copy.

## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
