### PR TITLE
add swmp ppl cmd

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -5,6 +5,4 @@
 - cd client dir
 - pip install -e
 - run "swcli --help" or "python -m starwhale --help"
-
-# VSCode Debug:
-- DEBUG model
+- docker run -it -v ~/.cache/minio:/data -p 9000:9000 -p 9001:9001 quay.io/minio/minio:latest server /data --console-address ":9001"

--- a/client/starwhale/api/_impl/loader.py
+++ b/client/starwhale/api/_impl/loader.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from posixpath import expanduser
 import typing as t
 from pathlib import Path
 from collections import namedtuple
@@ -9,7 +8,6 @@ import loguru
 from loguru import logger as _logger
 import boto3
 from botocore.client import Config as S3Config
-from numpy import pad
 
 from starwhale.utils.error import NoSupportError
 
@@ -116,7 +114,9 @@ class S3DataLoader(DataLoader):
             "s3", endpoint_url=self.service["endpoint"],
             aws_access_key_id=self.secret["access_key"],
             aws_secret_access_key=self.secret["secret_key"],
-            config=S3Config(signature_version="s3v4", retries={"max_attempts": 1000}),
+            config=S3Config(
+                signature_version="s3v4",
+                retries={"max_attempts": 30}),
             region_name=self.service["region"])
 
     #TODO: tune return typing hint

--- a/client/starwhale/cli/mngt.py
+++ b/client/starwhale/cli/mngt.py
@@ -21,6 +21,7 @@ def add_mngt_command(cli):
 
     @cli.command("quickstart", help="StarWhale Quickstart")
     def _quickstart():
+        #TODO: init git repo, add some gitignore
         pass
 
     @cli.command("autocomplete", help="Generate zsh/bash command auto complete")

--- a/client/starwhale/cli/model.py
+++ b/client/starwhale/cli/model.py
@@ -1,6 +1,8 @@
+from email.policy import default
 import click
 
 from starwhale.consts import DEFAULT_MODEL_YAML_NAME
+from starwhale.consts.env import SW_ENV
 from starwhale.swmp.model import ModelPackage
 from starwhale.swmp.store import ModelPackageLocalStore
 
@@ -67,3 +69,27 @@ def _gendep():
               help="Dry-run swmp gc")
 def _gc(dry_run):
     ModelPackageLocalStore().gc(dry_run)
+
+
+@model_cmd.command("extract", help="Extract local swmp tar file into workdir")
+@click.argument("swmp")
+@click.option("--force", default=False, help="force pull swmp")
+def _extract(swmp, force):
+    ModelPackageLocalStore().extract(swmp, force)
+
+
+@model_cmd.command("ppl", help="Run swmp pipeline")
+@click.argument("swmp")
+@click.option("-f", "--model-yaml", default=DEFAULT_MODEL_YAML_NAME,
+              help="mode yaml filename, default use ${workdir}/model.yaml file")
+@click.option("--status-dir", envvar=SW_ENV.STATUS_D, help=f"ppl status dir, env is {SW_ENV.STATUS_D}")
+@click.option("--log-dir", envvar=SW_ENV.LOG_D, help=f"ppl log dir, env is {SW_ENV.LOG_D}")
+@click.option("--result-dir", envvar=SW_ENV.RESULT_D, help=f"ppl result dir, env is {SW_ENV.RESULT_D}")
+@click.option("--swds-config", envvar=SW_ENV.SWDS_CONFIG, help=f"ppl swds config.json path, env is {SW_ENV.SWDS_CONFIG}")
+def _ppl(swmp, model_yaml, status_dir, log_dir, result_dir, swds_config):
+    #TODO: add local mock swds_config
+    ModelPackage.ppl(swmp, model_yaml,
+                     {"status_dir": status_dir,
+                      "log_dir": log_dir,
+                      "result_dir": result_dir,
+                      "swds_config": swds_config})

--- a/client/starwhale/consts/env.py
+++ b/client/starwhale/consts/env.py
@@ -1,0 +1,7 @@
+from collections import namedtuple
+
+
+SW_ENV = namedtuple("SW_ENV", ["TASK_ID", "JOB_ID", "STATUS_D", "LOG_D", "RESULT_D", "SWDS_CONFIG"])(
+    "SW_TASK_ID", "SW_JOB_ID", "SW_TASK_STATUS_DIR", "SW_TASK_LOG_DIR", "SW_TASK_RESULT_DIR",
+    "SW_TASK_SWDS_CONFIG"
+)

--- a/client/starwhale/swmp/model.py
+++ b/client/starwhale/swmp/model.py
@@ -12,12 +12,15 @@ from fs.walk import Walker
 from fs import open_fs
 
 from starwhale import __version__
-from starwhale.utils.error import FileTypeError, FileFormatError
+from starwhale.utils.error import (
+    FileTypeError, FileFormatError, NotFoundError
+)
 from starwhale.utils import gen_uniq_version
 from starwhale.utils.fs import ensure_dir, ensure_file, ensure_link
 from starwhale.utils.venv import (
     detect_pip_req, dump_python_dep_env, SUPPORTED_PIP_REQ
 )
+from starwhale.utils.load import import_cls
 from starwhale.consts import (
     DEFAULT_STARWHALE_API_VERSION, FMT_DATETIME,
     DEFAULT_MANIFEST_NAME, DEFAULT_MODEL_YAML_NAME,
@@ -30,18 +33,20 @@ class ModelRunConfig(object):
 
     #TODO: use attr to tune class
     def __init__(self, ppl: str, args: str="", runtime: str="",
-                 base_image: str="", env: str="", pip_req: str="",
-                 pkg_data: t.Union[list, None]=None, exclude_pkg_data: t.Union[list, None]=None,
-                 smoketest: str=""):
+                 base_image: str="", pkg_system: str="", pip_req: str="",
+                 pkg_data: t.Union[t.List[str], None]=None,
+                 exclude_pkg_data: t.Union[t.List[str], None]=None,
+                 smoketest: str="", envs:t.Union[t.List[str], None]=None):
         self.ppl = ppl.strip()
         self.args = args
         self.runtime = runtime.strip()
         self.base_image = base_image.strip()
-        self.env = env
+        self.pkg_system = pkg_system
         self.pip_req = pip_req
         self.pkg_data = pkg_data or []
         self.exclude_pkg_data = exclude_pkg_data or []
         self.smoketest = smoketest
+        self.envs = envs or []
 
         self._validator()
 
@@ -102,7 +107,7 @@ class ModelConfig(object):
 
 class ModelPackage(object):
 
-    def __init__(self, workdir: str, model_yaml_fname: str, skip_gen_env: bool) -> None:
+    def __init__(self, workdir: str, model_yaml_fname: str=DEFAULT_MODEL_YAML_NAME, skip_gen_env: bool=False) -> None:
         #TODO: format workdir path?
         self.workdir = Path(workdir)
         self._skip_gen_env = skip_gen_env
@@ -117,14 +122,58 @@ class ModelPackage(object):
         self._name = self._swmp_config.name
         self._manifest = {} #TODO: use manifest classget_conda_env
 
+        self._load_config_envs()
+
     def __str__(self) -> str:
         return f"Model Package: {self._name}"
 
     def __repr__(self) -> str:
         return f"Model Package: name -> {self._name}, version-> {self._version}"
 
+    def _load_config_envs(self) -> None:
+        for _env in self._swmp_config.run.envs:
+            _env = _env.strip()
+            if not _env:
+                continue
+            _t = _env.split("=", 1)
+            _k, _v = _t[0], "".join(_t[1:])
+
+            if _k not in os.environ:
+                os.environ[_k] = _v
+
     @classmethod
-    def build(cls, workdir: str, mname: str, skip_gen_env: bool):
+    def ppl(cls, swmp: str=".", _model_yaml_fname: str=DEFAULT_MODEL_YAML_NAME, kw: dict={}) -> None:
+        if swmp.count(":") == 1:
+            _name, _version = swmp.split(":")
+            #TODO: tune model package local store init twice
+            #TODO: guess _version?
+            _workdir = ModelPackageLocalStore().workdir / _name / _version
+            _model_yaml_fname = DEFAULT_MODEL_YAML_NAME
+        else:
+            _workdir = Path(swmp)
+
+        _model_fpath = _workdir / _model_yaml_fname
+
+        if not _model_fpath.exists():
+            raise NotFoundError(f"swmp model.yaml({_model_fpath}) not found")
+
+        mp = ModelPackage(str(_workdir.resolve()), _model_yaml_fname, skip_gen_env=True)
+        mp._do_validate()
+        mp._do_run_ppl(kw)
+
+    def _do_run_ppl(self, kw: dict={}):
+        from starwhale.api._impl.model import _RunConfig
+        _RunConfig.set_env(kw)
+
+        _s = f"{self._swmp_config.run.ppl}@{self.workdir}"
+        logger.info(f"try to import {_s}...")
+        _cls = import_cls(self.workdir, self._swmp_config.run.ppl)
+        _obj = _cls()
+        _obj.starwhale_internal_run()
+        logger.info(f"finish run ppl {_s}, {_obj}")
+
+    @classmethod
+    def build(cls, workdir: str, mname: str, skip_gen_env: bool) -> None:
         mp = ModelPackage(workdir, mname, skip_gen_env)
         mp._do_validate()
         mp._do_build()
@@ -138,9 +187,6 @@ class ModelPackage(object):
         for path in sw.model:
             if not (self.workdir / path).exists():
                 raise FileFormatError(f"model - {path} is not existed")
-
-        if not (self.workdir / sw.run.ppl).exists():
-            raise FileExistsError(f"run ppl - {sw.run.ppl} is not existed")
 
         #TODO: add more model.yaml section validation
         #TODO: add 'swcli model check' cmd

--- a/client/starwhale/swmp/model.py
+++ b/client/starwhale/swmp/model.py
@@ -147,8 +147,8 @@ class ModelPackage(object):
             _name, _version = swmp.split(":")
             #TODO: tune model package local store init twice
             #TODO: guess _version?
-            _workdir = ModelPackageLocalStore().workdir / _name / _version
-            _model_yaml_fname = DEFAULT_MODEL_YAML_NAME
+            #TODO: model.yaml auto-detect
+            _workdir = ModelPackageLocalStore().workdir / _name / _version / "src"
         else:
             _workdir = Path(swmp)
         _model_fpath = _workdir / _model_yaml_fname

--- a/client/starwhale/swmp/store.py
+++ b/client/starwhale/swmp/store.py
@@ -170,3 +170,7 @@ class ModelPackageLocalStore(LocalStorage):
             click.confirm(f"continue to delete {pkg_fpath}?", abort=True)
             latest = self.pkgdir / _model
             pkg_fpath.unlink()
+
+    def extract(self, swmp: str, force: bool=False) -> None:
+        #TODO: extract swmp into workdir
+        ...

--- a/client/starwhale/utils/__init__.py
+++ b/client/starwhale/utils/__init__.py
@@ -35,6 +35,11 @@ def get_external_python_version():
         ], stderr=sys.stderr
     )
 
+def in_dev() -> bool:
+    return not in_production()
+
+def in_production() -> bool:
+    return os.environ.get("SW_PRODUCTION", "") == "1"
 
 def is_venv() -> bool:
     #TODO: refactor for get external venv attr

--- a/client/starwhale/utils/load.py
+++ b/client/starwhale/utils/load.py
@@ -1,0 +1,29 @@
+from statistics import mode
+import typing as t
+import sys
+from pathlib import Path
+import importlib
+
+from loguru import logger
+
+
+def import_cls(workdir: Path, mc: str, parentClass: t.Any=object) -> t.Any:
+    _module_name, _cls_name = mc.split(":", 1)
+    _changed = False
+
+    _w = str(workdir.absolute())
+    if _w not in sys.path:
+        sys.path.insert(0, _w)
+        _changed = True
+
+    try:
+        _module = importlib.import_module(_module_name, package=_w)
+        _cls = getattr(_module, _cls_name, None)
+        if not _cls or not issubclass(_cls, parentClass):
+            raise Exception(f"{mc} is not subclass of {parentClass}")
+    except Exception:
+        if _changed:
+            sys.path.remove(_w)
+        raise
+
+    return _cls

--- a/example/mnist/Makefile
+++ b/example/mnist/Makefile
@@ -1,3 +1,7 @@
+TEST_ROOT := test
+TASK_VOLUME_ROOT := $(TEST_ROOT)/task_volume
+SW_TASK_ENV := env SW_TASK_STATUS_DIR=$(TASK_VOLUME_ROOT)/status SW_TASK_LOG_DIR=$(TASK_VOLUME_ROOT)/log SW_TASK_RESULT_DIR=$(TASK_VOLUME_ROOT)/result
+
 venv-create:
 	python3 -m venv venv
 
@@ -24,16 +28,16 @@ train:
 test:
 	python mnist/test.py
 
-inference:
+clean:
 	rm -rf test/task_volume/*
-	python mnist/ppl.py
 
-ppl-fuse-test:
-	SW_TASK_SWDS_CONFIG=./test/swds_fuse.json SW_TASK_STATUS_DIR=./test/task_volume/status \
-	SW_TASK_LOG_DIR=./test/task_volume/log SW_TASK_RESULT_DIR=./test/task_volume/result \
-	python mnist/ppl.py
+inference: clean
+	$(SW_TASK_ENV) swcli model ppl . --swds-config $(TEST_ROOT)/swds_s3_smoke.json
 
-ppl-s3-test:
-	SW_TASK_SWDS_CONFIG=./test/swds_s3.json SW_TASK_STATUS_DIR=./test/task_volume/status \
-	SW_TASK_LOG_DIR=./test/task_volume/log SW_TASK_RESULT_DIR=./test/task_volume/result \
-	python mnist/ppl.py
+inference-s3: clean
+	$(SW_TASK_ENV) swcli model ppl . --swds-config $(TEST_ROOT)/swds_s3.json
+
+inference-fuse: clean
+	$(SW_TASK_ENV) swcli model ppl . --swds-config $(TEST_ROOT)/swds_fuse.json
+
+inference-all: inference inference-fuse inference-s3

--- a/example/mnist/mnist/ppl.py
+++ b/example/mnist/mnist/ppl.py
@@ -7,7 +7,7 @@ from PIL import Image
 
 from starwhale.api.model import PipelineHandler
 
-from model import Net
+from .model import Net
 
 ROOTDIR = Path(__file__).parent.parent
 IMAGE_WIDTH = 28

--- a/example/mnist/model.yaml
+++ b/example/mnist/model.yaml
@@ -9,9 +9,8 @@ config:
 
 run:
   runtime: python3.8
-  ppl: ppl.py
+  ppl: mnist.ppl:MNISTInference
   pip_req: requirements.txt
-  args: --predictor
 
 desc: mnist by pytorch
 

--- a/example/mnist/test/swds_fuse.json
+++ b/example/mnist/test/swds_fuse.json
@@ -14,20 +14,6 @@
                 "data": "data_ubyte_1.swds_bin:0",
                 "label": "label_ubyte_1.swds_bin:0"
             }
-        },
-        {
-            "bucket": "~/.cache/starwhale/dataset/mnist/gbrggnldg44gcmrxgjswmzbyhb2da5i/data",
-            "key": {
-                "data": "data_ubyte_2.swds_bin:0",
-                "label": "label_ubyte_2.swds_bin:0"
-            }
-        },
-        {
-            "bucket": "~/.cache/starwhale/dataset/mnist/gbrggnldg44gcmrxgjswmzbyhb2da5i/data",
-            "key": {
-                "data": "data_ubyte_3.swds_bin:0",
-                "label": "label_ubyte_3.swds_bin:0"
-            }
         }
     ]
 }

--- a/example/mnist/test/swds_s3_smoke.json
+++ b/example/mnist/test/swds_s3_smoke.json
@@ -1,0 +1,20 @@
+{
+    "backend": "s3",
+    "secret": {
+        "access_key": "minioadmin",
+        "secret_key": "minioadmin"
+    },
+    "service": {
+        "endpoint": "http://localhost:9000",
+        "region": "local"
+    },
+    "swds": [
+        {
+            "bucket": "starwhale",
+            "key": {
+                "data": "dataset/mnist/gu3tezlgmrrgcnrsmiztcmjxny2dq4i/data/data_ubyte_1.swds_bin:122784:204639",
+                "label": "dataset/mnist/gu3tezlgmrrgcnrsmiztcmjxny2dq4i/data/label_ubyte_1.swds_bin:12192:20319"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Description
- add `swcli model ppl` command,  which can run ppl from model.yaml
   -  EXAMPLE: in example/mnist dir , run `swcli model ppl . --swds-config   test/swds_s3_smoke.json `
![image](https://user-images.githubusercontent.com/590748/161528421-dd15dc1f-32d6-4f6f-85b0-c178a08b7517.png)

- ppl some swmp directly: `swcli model ppl mnist:g4zgimrthfrwcnrtmftdgyjzha2wg2a --swds-config test/swds_s3_smoke.json`
![image](https://user-images.githubusercontent.com/590748/161575178-6e088d0a-90eb-48d0-8f6a-4ceead82321c.png)

- refactor swmp/swds code
- add `SW_PRODUCTION` env to check dev/prod env
- refactor MNIST Example
- fix swmp build without model/config files bug

## Modules
- [x] Client
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
