### PR TITLE
add label handle method for PipelineHandler

### DIFF
--- a/client/starwhale/api/_impl/model.py
+++ b/client/starwhale/api/_impl/model.py
@@ -76,7 +76,7 @@ class PipelineHandler(object):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, merge_label: bool=False,
+    def __init__(self, merge_label: bool=True,
                  output_type: str= RESULT_OUTPUT_TYPE.JSONL,
                  ignore_error: bool=False) -> None:
         #TODO: add args for compare result and label directly
@@ -136,7 +136,11 @@ class PipelineHandler(object):
 
     @abstractmethod
     def handle(self, data: bytes, batch_size: int, **kw) -> t.Any:
+        #TODO: how to handle each batch element is not equal.
         raise NotImplementedError
+
+    def handle_label(self, label: bytes, batch_size: int, **kw) -> t.Any:
+        return label.decode()
 
     def starwhale_internal_run(self) -> None:
         #TODO: forbid inherit object override this method
@@ -183,8 +187,8 @@ class PipelineHandler(object):
 
             try:
                 self._do_record(output, data, label, exception)
-            except Exception:
-                self._sw_logger.exception(f"{data.index} data record")
+            except Exception as e:
+                self._sw_logger.exception(f"{data.index} data record exception: {e}")
 
     def _do_record(self, output: t.Any, data: DATA_FIELD, label: DATA_FIELD, exception: t.Union[None, Exception]):
         self._status_writer.write({
@@ -201,11 +205,18 @@ class PipelineHandler(object):
             "result": output,
             "batch": data.batch_size,
         }
-        #TODO: user define label parser
         if self.merge_label:
-            result["label"] = label.data.decode(),
-        self._result_writer.write(result)
+            try:
+                result["label"] = self.handle_label(label.data, label.batch_size, index=label.index, size=label.data_size)
+            except Exception as e:
+                self._sw_logger.exception(f"{label.data} label handle exception:{e}")
+                if not self.ignore_error:
+                    self._update_status(self.STATUS.FAILED)
+                    raise
+                else:
+                    result["label"] = ""
 
+        self._result_writer.write(result)
         self._update_status(self.STATUS.RUNNING)
 
     def _update_status(self, status: str) -> None:

--- a/example/mnist/mnist/ppl.py
+++ b/example/mnist/mnist/ppl.py
@@ -26,6 +26,9 @@ class MNISTInference(PipelineHandler):
         output = self.model(data)
         return self._post(output)
 
+    def handle_label(self, label, batch_size, **kw):
+        return [int(l) for l in label]
+
     def _pre(self, input: bytes, batch_size: int):
         images = []
         for i in range(0, batch_size):


### PR DESCRIPTION
## Description
user can define label handler which can make compare with result easily. default label will output as str type.

In our MNIST example, we define `handle_label` method,
```python
def handle_label(self, label, batch_size, **kw):
     return [int(l) for l in label]
```
![image](https://user-images.githubusercontent.com/590748/161766895-6ad36d20-3f9c-4528-838e-7718f63ba2da.png)


## Modules
- [x] Python-SDK

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
