### PR TITLE
add base image dockerfile

### DIFF
--- a/client/starwhale/__init__.py
+++ b/client/starwhale/__init__.py
@@ -1,6 +1,8 @@
+import os
 import importlib_metadata
 
 __version__: str = importlib_metadata.version("starwhale")
+os.environ["SW_VERSION"] = __version__
 
 
 #TODO: only export api

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,38 @@
+FROM ubuntu:20.04
+
+COPY external/sources.list /etc/apt/sources.list
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV TZ=Etc/UTC
+
+#os dependence
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        wget locales make cmake build-essential software-properties-common curl sudo ca-certificates apt-transport-https iputils-ping net-tools openssh-server net-tools gcc-aarch64-linux-gnu \
+        zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev shellcheck git apt-utils \
+    && locale-gen en_US.UTF-8 \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+#python: python3.7/3.8/3.9, virtualenv, conda
+RUN add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y python3.7 python3.8 python3.9 python3-pip\
+    && pip config set global.index-url https://pypi.doubanio.com/simple/ \
+    && pip config set install.trusted-host pypi.doubanio.com \
+    && python3.7 -m pip install virtualenv \
+    && python3.8 -m pip install virtualenv \
+    && python3.9 -m pip install virtualenv \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+ENV PATH /opt/miniconda3/bin:$PATH
+RUN curl -s -o /tmp/conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && bash /tmp/conda.sh -b -p /opt/miniconda3 \
+    && conda init --all \
+    && conda clean -a -y -f \
+    && rm -rf /tmp/conda.sh
+
+#TODO: gpu/cuda

--- a/docker/Dockerfile.sw
+++ b/docker/Dockerfile.sw
@@ -1,0 +1,7 @@
+ARG BASE_IMAGE=starwhaleai/base:latest
+FROM ${BASE_IMAGE}
+
+ARG SW_VERSION=0.1.0
+ENV SW_VERSION ${SW_VERSION}
+
+RUN pip install starwhale==${SW_VERSION}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,3 @@
+build-base:
+	docker build -f Dockerfile.base -t starwhaleai/base:0.1.0-nightly-2022040701 .
+

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,3 +1,13 @@
-build-base:
-	docker build -f Dockerfile.base -t starwhaleai/base:0.1.0-nightly-2022040701 .
+BASE_IMAGE :=starwhaleai/base:0.1.0-nightly-2022040701
+SW_IMAGE := starwhaleai/starwhale:0.1.0-nightly-2022040801
+SW_VERSION := 0.1.0.dev0
 
+build-base:
+	docker build -f Dockerfile.base -t $(BASE_IMAGE) .
+
+build-starwhale:
+	docker build --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg SW_VERSION=$(SW_VERSION) -f Dockerfile.sw -t $(SW_IMAGE) .
+
+release:
+	docker push $(BASE_IMAGE)
+	docker push $(SW_IMAGE)

--- a/docker/external/sources.list
+++ b/docker/external/sources.list
@@ -1,0 +1,21 @@
+deb http://mirrors.aliyun.com/ubuntu/ focal main restricted
+deb http://mirrors.aliyun.com/ubuntu/ focal-updates main restricted
+deb http://mirrors.aliyun.com/ubuntu/ focal universe
+deb http://mirrors.aliyun.com/ubuntu/ focal-updates universe
+deb http://mirrors.aliyun.com/ubuntu/ focal multiverse
+deb http://mirrors.aliyun.com/ubuntu/ focal-updates multiverse
+deb http://mirrors.aliyun.com/ubuntu/ focal-backports main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ focal-security main restricted
+deb http://mirrors.aliyun.com/ubuntu/ focal-security universe
+deb http://mirrors.aliyun.com/ubuntu/ focal-security multiverse
+
+deb http://archive.ubuntu.com/ubuntu/ focal main restricted
+deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted
+deb http://archive.ubuntu.com/ubuntu/ focal universe
+deb http://archive.ubuntu.com/ubuntu/ focal-updates universe
+deb http://archive.ubuntu.com/ubuntu/ focal multiverse
+deb http://archive.ubuntu.com/ubuntu/ focal-updates multiverse
+deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
+deb http://security.ubuntu.com/ubuntu/ focal-security main restricted
+deb http://security.ubuntu.com/ubuntu/ focal-security universe
+deb http://security.ubuntu.com/ubuntu/ focal-security multiverse


### PR DESCRIPTION
## Description
support base image, which include basic software, python3.7/3.8/3.9 and conda.

run `docker pull starwhaleai/base:0.1.0-nightly-2022040701` to pull base image in your computer

![image](https://user-images.githubusercontent.com/590748/162201010-142b7ca9-9b07-455b-87cd-a4ec2b93a6ed.png)


## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
