### PR TITLE
add taskset dockerfile for dind

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -11,7 +11,7 @@ ENV TZ=Etc/UTC
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         wget locales make cmake build-essential software-properties-common curl sudo ca-certificates apt-transport-https iputils-ping net-tools openssh-server net-tools gcc-aarch64-linux-gnu \
-        zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev shellcheck git apt-utils \
+        zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev shellcheck git apt-utils gpg-agent \
     && locale-gen en_US.UTF-8 \
     && apt-get clean all \
     && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/docker/Dockerfile.taskset
+++ b/docker/Dockerfile.taskset
@@ -1,0 +1,46 @@
+ARG BASE_IMAGE=starwhaleai/base:latest
+FROM ${BASE_IMAGE}
+
+# docker in docker
+RUN curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+    && curl -s -L "https://nvidia.github.io/libnvidia-container/$(. /etc/os-release;echo $ID$VERSION_ID)/libnvidia-container.list" | \
+       sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+       sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - \
+    && apt-key fingerprint 0EBFCD88 \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce=5:20.10.14~3-0~ubuntu-focal docker-ce-cli=5:20.10.14~3-0~ubuntu-focal nvidia-docker2 \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+VOLUME /var/lib/docker
+EXPOSE 2375 2376
+COPY external/dind-dockerd-entrypoint.sh /usr/local/bin/
+COPY external/docker_daemon.json /etc/docker/daemon.json
+
+# cuda runtime
+ENV NVARCH x86_64
+ENV NVIDIA_REQUIRE_CUDA "cuda>=11.4 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=440,driver<441 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=460,driver<461"
+ENV NV_CUDA_CUDART_VERSION 11.4.43-1
+ENV NV_CUDA_COMPAT_PACKAGE cuda-compat-11-4
+ENV CUDA_VERSION 11.4.0
+
+ENV NV_ML_REPO_ENABLED 1
+ENV NV_ML_REPO_URL https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/${NVARCH}
+
+RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/${NVARCH}/7fa2af80.pub | apt-key add - \
+    && echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/${NVARCH} /" > /etc/apt/sources.list.d/cuda.list \
+    && if [ ! -z ${NV_ML_REPO_ENABLED} ]; then echo "deb ${NV_ML_REPO_URL} /" > /etc/apt/sources.list.d/nvidia-ml.list; fi \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends cuda-cudart-11-4=${NV_CUDA_CUDART_VERSION} ${NV_CUDA_COMPAT_PACKAGE} \
+    && ln -s cuda-11.4 /usr/local/cuda \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+ENTRYPOINT ["dind-dockerd-entrypoint.sh"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,6 @@
-BASE_IMAGE :=starwhaleai/base:0.1.0-nightly-2022041301
-SW_IMAGE := starwhaleai/starwhale:0.1.0-nightly-2022041403
+BASE_IMAGE :=starwhaleai/base:0.1.0-nightly-2022041501
+SW_IMAGE := starwhaleai/starwhale:0.1.0-nightly-2022041501
+SW_TASKSET_IMAGE := starwhaleai/taskset:0.1.0-nightly-2022041601
 SW_VERSION := 0.1.0.dev9
 
 build-base:
@@ -11,3 +12,7 @@ build-starwhale:
 release:
 	docker push $(BASE_IMAGE)
 	docker push $(SW_IMAGE)
+	docker push $(SW_TASKSET_IMAGE)
+
+build-taskset:
+	docker build --build-arg BASE_IMAGE=$(BASE_IMAGE) -f Dockerfile.taskset -t $(SW_TASKSET_IMAGE) .

--- a/docker/external/dind-dockerd-entrypoint.sh
+++ b/docker/external/dind-dockerd-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+
+echo "===================================="
+echo "StarWhale @docker in docker"
+echo "Date: `date -u +%Y-%m-%dT%H:%M:%SZ`"
+echo "===================================="
+
+exec docker-init -- dockerd \
+    --config-file=/etc/docker/daemon.json \
+    "$@"

--- a/docker/external/docker_daemon.json
+++ b/docker/external/docker_daemon.json
@@ -1,0 +1,26 @@
+{
+  "hosts": [
+      "tcp://0.0.0.0:2376",
+      "unix:///var/run/docker.sock"
+  ],
+  "insecure-registries": [
+    "10.0.0.0/8",
+    "127.0.0.0/8",
+    "192.0.0.0/8"
+  ],
+  "live-restore": true,
+  "max-concurrent-downloads": 20,
+  "max-concurrent-uploads": 20,
+  "registry-mirrors": [
+    "https://docker.mirrors.ustc.edu.cn",
+    "https://hub-mirror.c.163.com"
+  ],
+  "mtu": 1450,
+  "runtimes": {
+      "nvidia": {
+          "path": "nvidia-container-runtime",
+          "runtimeArgs": []
+        }
+  },
+  "storage-driver": "overlay2"
+}


### PR DESCRIPTION
## Description
`taskset` is dind(docker-in-docker) container, which can be as a sidecar for agent pod. 
support some features:
 - gpu allocate
 - nvidia-smi cmd
 - docker daemon config

## Feature Show
- run `taskset` in host: `docker run --rm --name dind -it -v /usr/bin/nvidia-smi:/tmp/nvidia-smi -v /mnt/data/tmp/dind:/var/lib/docker --gpus all --privileged starwhaleai/taskset:0.1.0-nightly-2022041601`
![image](https://user-images.githubusercontent.com/590748/163673156-e3a1d359-fedf-421a-ac4b-92454c2a52a9.png)

- run a new container in `dind container``
![image](https://user-images.githubusercontent.com/590748/163673230-59fc47df-1238-4df9-bba2-b734fd3e42ec.png)

- inspect gpu info in `dind` container
![image](https://user-images.githubusercontent.com/590748/163673247-a8a31a73-241f-4917-9ea6-af3edfb1a051.png)

- in `dind` container, we create a new container which use `No. 0` GPU.  cmd is `docker run --rm --gpus 1 nvidia/cuda:11.0-base nvidia-smi` .
![image](https://user-images.githubusercontent.com/590748/163673411-dd3a9437-5e4d-4a61-994b-ce4e1f5c9b30.png)


## Modules
- [x] Agent
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
