### PR TITLE
upgrade new base image and remove aliyun pypi mirror

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
-BASE_IMAGE :=starwhaleai/base:0.1.0-nightly-2022041501
-SW_IMAGE := starwhaleai/starwhale:0.1.0-nightly-2022042601
+BASE_IMAGE :=starwhaleai/base:0.1.0-nightly-2022042701
+SW_IMAGE := starwhaleai/starwhale:0.1.0-nightly-2022042701
 SW_TASKSET_IMAGE := starwhaleai/taskset:0.1.0-nightly-2022041601
 SW_CONTROLLER_IMAGE := starwhaleai/controller:0.1.0-nightly-2022042601
 SW_AGENT_IMAGE := starwhaleai/agent:0.1.0-nightly-2022042602

--- a/docker/external/pip.conf
+++ b/docker/external/pip.conf
@@ -1,12 +1,10 @@
 [global]
-index-url=http://mirrors.aliyun.com/pypi/simple/
+index-url=https://pypi.doubanio.com/simple/
 extra-index-url=https://pypi.tuna.tsinghua.edu.cn/simple/
                 http://pypi.mirrors.ustc.edu.cn/simple/
-                https://pypi.doubanio.com/simple/
-                https://pypi.org/
+                https://pypi.org/simple
 [install]
 trusted-host=mirrors.aliyun.com
              pypi.tuna.tsinghua.edu.cn
-             pypi.mirrors.ustc.edu.cn
              pypi.doubanio.com
              pypi.org


### PR DESCRIPTION
## Description
- remove `aliyun` pypi cache, which will install some wrong package 
- rebuild base image

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
