### PR TITLE
fix bug: the ’modelName‘ field in the modelList API is not required

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/SWModelPackageApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/SWModelPackageApi.java
@@ -68,7 +68,7 @@ public interface SWModelPackageApi {
         @RequestParam(value = "versionId", required = false)
             String versionId,
         @Parameter(
-            in = ParameterIn.PATH,
+            in = ParameterIn.QUERY,
             description = "Model name prefix to search for",
             schema = @Schema())
         @Valid


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
