### PR TITLE
bug: fix multilabel word typo 

### DIFF
--- a/client/starwhale/api/_impl/metric.py
+++ b/client/starwhale/api/_impl/metric.py
@@ -35,7 +35,7 @@ def multi_classification(confusion_matrix_normalize: str="all",
             mcm = multilabel_confusion_matrix(y_true, y_pred, labels=all_labels)
             _r["confusion_matrix"] = {
                 "binarylabel": cm.tolist(),
-                "mutlilabel": mcm.tolist(),
+                "multilabel": mcm.tolist(),
             }
             if show_hamming_loss:
                 _r["summary"]["hamming_loss"] = hamming_loss(y_true, y_pred)

--- a/client/starwhale/cluster/view.py
+++ b/client/starwhale/cluster/view.py
@@ -146,7 +146,7 @@ class ClusterView(ClusterModel):
             mtable.add_column("Label", style="cyan")
             for n in ("TP", "TN", "FP", "FN"):
                 mtable.add_column(n)
-            for idx, ml in enumerate(cm.get("mutlilabel", [])):
+            for idx, ml in enumerate(cm.get("multilabel", [])):
                 mtable.add_row(sort_label_names[idx], *[str(_) for _ in ml[0] + ml[1]])
 
             console.rule(f"[bold green]{report['kind'].upper()} Confusion Matrix")

--- a/console/src/components/Indicator/types.d.ts
+++ b/console/src/components/Indicator/types.d.ts
@@ -63,4 +63,4 @@ export type IMultiLabel = {
 export type ILabel = IBinaryLabel & IMultiLabel
 export type ILabels = Record<string, ILabel>
 export type IConfusionMatrixBinarylabel = number[]
-export type IConfusionMatrixMutlilabel = number[][] // 2*2
+export type IConfusionMatrixMultilabel = number[][] // 2*2

--- a/console/src/pages/Job/JobResult.tsx
+++ b/console/src/pages/Job/JobResult.tsx
@@ -107,7 +107,7 @@ function JobResult() {
                 case INDICATORTYPE.LABELS:
                     _.forIn(v as ILabels, (subV, subK) => {
                         const [tp, fp, tn, fn] = _.flatten(
-                            jobResult?.data?.[INDICATORTYPE.CONFUSION_MATRIX]?.mutlilabel?.[Number(subK)]
+                            jobResult?.data?.[INDICATORTYPE.CONFUSION_MATRIX]?.multilabel?.[Number(subK)]
                         )
 
                         /* eslint-disable no-param-reassign */


### PR DESCRIPTION
## Description
fix typo `mutlilabel` -> `multilabel`

## Modules
- [x] UI
- [x] Client
- [x] Python-SDK

## Related:
#198 

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
