### PR TITLE
ci: add python ci

### DIFF
--- a/.github/file-filter.yml
+++ b/.github/file-filter.yml
@@ -1,0 +1,28 @@
+client:
+  - '**/*.py'
+  - 'client/**'
+
+console:
+  - 'console/**'
+
+docker:
+  - 'docker/**'
+
+server:
+  - '**/*.java'
+  - 'server/**'
+
+docs:
+  - 'docs/**'
+
+scripts:
+  - 'script/**'
+
+js:
+  - '**/*.js'
+  - '**/*.jsx'
+  - '**/*.ts'
+  - '**/*.tsx'
+
+scss:
+  - '**/*.scss'

--- a/.github/file-filter.yml
+++ b/.github/file-filter.yml
@@ -26,3 +26,6 @@ js:
 
 scss:
   - '**/*.scss'
+
+java:
+  - '**/*.java'

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -17,6 +17,7 @@ jobs:
       client: ${{ steps.filter.outputs.client }}
 
     steps:
+      - uses: actions/checkout@v3
       - name: Check for python files changed
         uses: getsentry/paths-filter@v2
         id: filter
@@ -57,8 +58,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./client
-        run: |
-          pip install .
+        run: make install-req
 
       - name: Black format check
         working-directory: ./client
@@ -83,12 +83,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Check for python files changed
-        uses: getsentry/paths-filter@v2
-        id: python-changes
-        with:
-          filters: .github/python-file-filters.yml
-
       - name: Setup python
         uses: actions/setup-python@v3
         with:
@@ -108,8 +102,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./client
-        run: |
-          pip install .
+        run: make install-req
 
       - name: Run Unittest
         working-directory: ./client

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./client
-        run: make install-req
+        run: |
+          make install-req
+          make install-dev-req
 
       - name: Black format check
         working-directory: ./client
@@ -102,7 +104,9 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./client
-        run: make install-req
+        run: |
+          make install-req
+          make install-dev-req
 
       - name: Run Unittest
         working-directory: ./client

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,38 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '23 22 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java', 'javascript', 'python', 'typescript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,8 +3,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   schedule:
     - cron: '23 22 * * 4'
 

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -19,6 +19,7 @@ jobs:
       scss: ${{ steps.filter.outputs.scss }}
 
     steps:
+      - uses: actions/checkout@v3
       - name: Check for console files changed
         uses: getsentry/paths-filter@v2
         id: filter

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -19,7 +19,7 @@ jobs:
       scss: ${{ steps.filter.outputs.scss }}
 
     steps:
-      - name: Check for python files changed
+      - name: Check for console files changed
         uses: getsentry/paths-filter@v2
         id: filter
         with:

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -1,17 +1,38 @@
-name: Console With Typescript
+name: Console UI
 
 on:
   push:
     branches:
       - main
-      - feat/*
   pull_request:
     branches:
       - main
 
 jobs:
+
+  filter:
+    runs-on: ubuntu-latest
+
+    outputs:
+      console: ${{ steps.filter.outputs.console }}
+      js: ${{ steps.filter.outputs.js }}
+      scss: ${{ steps.filter.outputs.scss }}
+
+    steps:
+      - name: Check for python files changed
+        uses: getsentry/paths-filter@v2
+        id: filter
+        with:
+          base: main
+          filters: .github/file-filter.yml
+
   build:
     runs-on: ubuntu-latest
+
+    needs:
+      - filter
+    if: ${{ (github.event_name == 'pull_request' && needs.filter.outputs.console == 'true') || github.event_name == 'push' }}
+
 
     strategy:
       matrix:

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,18 +1,37 @@
 name: Maven Package
 
-on: 
+on:
   push:
     branches:
       - main
-      - feat/*
   pull_request:
     branches:
       - main
 
 jobs:
-  build:
 
+  filter:
     runs-on: ubuntu-latest
+
+    outputs:
+      server: ${{ steps.filter.outputs.server }}
+      java: ${{ steps.filter.outputs.java }}
+
+    steps:
+      - name: Check for java files changed
+        uses: getsentry/paths-filter@v2
+        id: filter
+        with:
+          base: main
+          filters: .github/file-filter.yml
+
+  build:
+    runs-on: ubuntu-latest
+
+    needs:
+      - filter
+    if: ${{ (github.event_name == 'pull_request' && needs.filter.outputs.server == 'true') || github.event_name == 'push' }}
+
     permissions:
       contents: read
       packages: write
@@ -25,6 +44,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -18,6 +18,7 @@ jobs:
       java: ${{ steps.filter.outputs.java }}
 
     steps:
+      - uses: actions/checkout@v3
       - name: Check for java files changed
         uses: getsentry/paths-filter@v2
         id: filter

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,99 @@
+name: python
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+
+  codestyle:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+
+      - name: Get pip cache
+        id: pip-cache-path
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ${{ steps.pip-cache-path.outputs.dir }}
+          key: ${{ runner.os }}-codestyle-${{ hashFiles('client/requirements-dev.txt')}}
+
+      - name: Install dependencies
+        working-directory: ./client
+        run: |
+          pip install .
+          pip install -r requirements-dev.txt
+
+      - name: Black format check
+        working-directory: ./client
+        run: make ci-format
+      - name: Lint check
+        working-directory: ./client
+        run: make ci-lint
+      - name: Type Check
+        working-directory: ./client
+        run: make ci-type
+
+  unittest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+
+      - name: Get pip cache
+        id: pip-cache-path
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ${{ steps.pip-cache-path.outputs.dir }}
+          key: ${{ runner.os }}-unittest-${{ hashFiles('client/requirements-dev.txt')}}
+
+      - name: Install dependencies
+        working-directory: ./client
+        run: |
+          pip install .
+          pip install -r requirements-dev.txt
+
+      - name: Run Unittest
+        working-directory: ./client
+        run: make ut
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          name: codecov
+          fail_ci_if_error: false
+          directory: ./client/coverage/reports/
+          files: ./coverage.xml
+          flags: unittests
+          verbose: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,4 @@
-name: python
+name: Python Client/SDK
 
 on:
   push:
@@ -10,11 +10,30 @@ on:
 
 jobs:
 
+  filter:
+    runs-on: ubuntu-latest
+
+    outputs:
+      client: ${{ steps.filter.outputs.client }}
+
+    steps:
+      - name: Check for python files changed
+        uses: getsentry/paths-filter@v2
+        id: filter
+        with:
+          base: main
+          filters: .github/file-filter.yml
+
+
   codestyle:
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
+
+    needs:
+      - filter
+    if: ${{ (github.event_name == 'pull_request' && needs.filter.outputs.client == 'true') || github.event_name == 'push' }}
 
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +59,6 @@ jobs:
         working-directory: ./client
         run: |
           pip install .
-          pip install -r requirements-dev.txt
 
       - name: Black format check
         working-directory: ./client
@@ -58,8 +76,18 @@ jobs:
       run:
         shell: bash
 
+    needs:
+      - filter
+    if: ${{ (github.event_name == 'pull_request' && needs.filter.outputs.client == 'true') || github.event_name == 'push' }}
+
     steps:
       - uses: actions/checkout@v3
+
+      - name: Check for python files changed
+        uses: getsentry/paths-filter@v2
+        id: python-changes
+        with:
+          filters: .github/python-file-filters.yml
 
       - name: Setup python
         uses: actions/setup-python@v3
@@ -82,7 +110,6 @@ jobs:
         working-directory: ./client
         run: |
           pip install .
-          pip install -r requirements-dev.txt
 
       - name: Run Unittest
         working-directory: ./client

--- a/client/Makefile
+++ b/client/Makefile
@@ -28,3 +28,6 @@ ci-type:
 
 ut:
 	echo "ut"
+
+install-req:
+	python3 -m pip install .

--- a/client/Makefile
+++ b/client/Makefile
@@ -14,7 +14,7 @@ upload-pypi:
 build-dev-wheel:
 	python3 -m pip install -e .
 
-dev-dep:
+install-dev-req:
 	python3 -m pip install -r requirements-dev.txt
 
 ci-format:

--- a/client/Makefile
+++ b/client/Makefile
@@ -16,3 +16,15 @@ build-dev-wheel:
 
 dev-dep:
 	python3 -m pip install -r requirements-dev.txt
+
+ci-format:
+	echo "ci format"
+
+ci-lint:
+	echo "ci lint"
+
+ci-type:
+	echo "ci type"
+
+ut:
+	echo "ut"

--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -1,1 +1,6 @@
 twine==4.0.0
+black==22.3.0
+flake8==4.0.1
+mypy==0.950
+mypy-extensions==0.4.3
+profimp==0.1.0


### PR DESCRIPTION
## Description
- add codeQL analysis for python/java/js/ts
- add python ci framework
- add path filter for python/java/js, which can reduce useless ci  

## Related:
- #223 

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc

cc @goldenxinxing  @waynelwz 