### PR TITLE
hottfix: fix release_version env typo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Build and push docker image
         working-directory: ./docker
         env:
-          VERSION_FORMAT: ${{ steps.tag.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.tag.outputs.tag }}
           PYPI_RELEASE_VERSION: ${{ steps.tag.outputs.tag }}
         run: |
           make build-server


### PR DESCRIPTION
## Description
fix `RELEASE_VERSION` typo in release.yaml

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
