### PR TITLE
enhanced: always pull starwhale docker image for latest tag

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./client
         run: |
-          make install-req
+          make install-sw
           make install-dev-req
 
       - name: Black Format Check
@@ -103,7 +103,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./client
         run: |
-          make install-req
+          make install-sw
           make install-dev-req
 
       - name: Run Unittest

--- a/client/Makefile
+++ b/client/Makefile
@@ -13,7 +13,7 @@ build-wheel: check clean
 upload-pypi:
 	twine upload dist/*
 
-install-dev-wheel:
+install-sw:
 	python3 -m pip install -e .
 
 install-dev-req:
@@ -37,8 +37,5 @@ ci-mypy:
 ut:
 	echo "ut"
 	pytest tests -vvrfEsx --cov-config=.coveragerc --cov=starwhale --cov-report=xml:coverage.xml --cov-report=term-missing
-
-install-req:
-	python3 -m pip install .
 
 all-check: ci-format-checker ci-lint ci-mypy ut

--- a/client/README.md
+++ b/client/README.md
@@ -3,7 +3,7 @@
 # How to develop
 
 - create conda env: `conda create -n starwhale python=3.7`
-- install req: `make install-req`
+- install req: `make install-sw`
 - install dev-req: `make install-dev-req`
 - write some code
 - debug starwhale cli: `swcli --help` or some other swcli cmds

--- a/client/starwhale/eval/executor.py
+++ b/client/starwhale/eval/executor.py
@@ -243,7 +243,7 @@ class EvalExecutor(object):
 
         rundir = self._workdir / typ
 
-        cmd = ["docker", "run", "--net=host"]
+        cmd = ["docker", "run", "--net=host", "--pull=always"]
         cmd += [
             "-v",
             f"{rundir}:{_CNTR_WORKDIR}",

--- a/client/starwhale/eval/executor.py
+++ b/client/starwhale/eval/executor.py
@@ -26,7 +26,7 @@ from starwhale.utils.process import check_call
 from starwhale.utils.progress import run_with_progress_bar
 from starwhale.api._impl.model import PipelineHandler
 
-DEFAULT_SW_TASK_RUN_IMAGE = "starwhaleai/starwhale:latest"
+DEFAULT_SW_TASK_RUN_IMAGE = "ghcr.io/star-whale/starwhale:latest"
 
 
 class EvalTaskType:


### PR DESCRIPTION
## Description
use `latest` tag , so we need always pull image for eval local run.

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
