### PR TITLE
fix swmp push size limited to 2G

### DIFF
--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/LargeFileInputStream.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/LargeFileInputStream.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * when you are trying to upload a file that is larger than Integer.MAX_VALUE bytes which is about 2G,
+ * you should wrapp the inputStream with a  LargeFileInputStream
+ */
+public class LargeFileInputStream extends InputStream {
+
+    final InputStream inputStream;
+    final long size;
+    public long size(){
+        return size;
+    }
+    public LargeFileInputStream(InputStream inputStream,long size){
+        this.inputStream = inputStream;
+        this.size = size;
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return inputStream.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return inputStream.read(b, off, len);
+    }
+
+    @Override
+    public byte[] readAllBytes() throws IOException {
+        return inputStream.readAllBytes();
+    }
+
+    @Override
+    public byte[] readNBytes(int len) throws IOException {
+        return inputStream.readNBytes(len);
+    }
+
+    @Override
+    public int readNBytes(byte[] b, int off, int len) throws IOException {
+        return inputStream.readNBytes(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return inputStream.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return inputStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        inputStream.close();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        inputStream.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        inputStream.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return inputStream.markSupported();
+    }
+
+    @Override
+    public long transferTo(OutputStream out) throws IOException {
+        return inputStream.transferTo(out);
+    }
+
+    @Override
+    public int read() throws IOException {
+        return inputStream.read();
+    }
+}

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/s3/StorageAccessServiceS3.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/s3/StorageAccessServiceS3.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.storage.s3;
 
+import ai.starwhale.mlops.storage.LargeFileInputStream;
 import ai.starwhale.mlops.storage.StorageAccessService;
 import ai.starwhale.mlops.storage.StorageObjectInfo;
 import java.io.IOException;
@@ -86,9 +87,19 @@ public class StorageAccessServiceS3 implements StorageAccessService {
         return stringBuilder.toString();
     }
 
+    /**
+     * when you are trying to upload a file that is larger than Integer.MAX_VALUE bytes which is about 2G,
+     * you should wrapp the inputStream with a  LargeFileInputStream
+     */
     @Override
     public void put(String path,InputStream inputStream) throws IOException {
-        s3client.putObject(PutObjectRequest.builder().bucket(s3Config.getBucket()).key(path).build(),RequestBody.fromInputStream(inputStream,inputStream.available()));
+        long fileSize;
+        if(inputStream instanceof LargeFileInputStream){
+            fileSize = ((LargeFileInputStream)inputStream).size();
+        }else {
+            fileSize = inputStream.available();
+        }
+        s3client.putObject(PutObjectRequest.builder().bucket(s3Config.getBucket()).key(path).build(),RequestBody.fromInputStream(inputStream, fileSize));
     }
 
     @Override


### PR DESCRIPTION
## Description
- fix swmp push size limited to 2G
## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [x] add necessary doc
