### PR TITLE
add probe for agent and controller

### DIFF
--- a/docker/charts/templates/_helpers.tpl
+++ b/docker/charts/templates/_helpers.tpl
@@ -152,6 +152,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: SW_AGENT_PORT
+              value: "{{ .Values.agent.containerPort }}"
             - name: SW_CONTROLLER_URL
               value: "http://{{ include "common.names.fullname" . }}-controller:{{ .Values.controller.containerPort }}/"
             - name: SW_BASE_PATH
@@ -190,6 +192,24 @@ spec:
             - name: agent-storage
               mountPath: "/var/lib/docker"
               subPath: dind
+          ports:
+            - name: liveness-port
+              containerPort: {{ .Values.agent.containerPort }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: liveness-port
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 90
+            successThreshold: 1
+            failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: liveness-port
+            failureThreshold: 30
+            periodSeconds: 1
         - name: taskset
           image: "{{ .Values.image.registry}}/{{ .Values.image.org }}/{{ .Values.image.taskset.repo }}:{{ .Values.image.taskset.tag }}"
           env:

--- a/docker/charts/templates/controller-deployment.yaml
+++ b/docker/charts/templates/controller-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: {{ .Values.controller.containerPort }}
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/docker/charts/values.yaml
+++ b/docker/charts/values.yaml
@@ -89,6 +89,9 @@ controller:
     password: abcd1234
   containerPort: 8082
 
+agent:
+  containerPort: 8088
+
 storage:
   agentHostPathRoot: "/mnt/data/starwhale"
 

--- a/server/agent/pom.xml
+++ b/server/agent/pom.xml
@@ -29,6 +29,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <!-- monitor -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
         <!-- JSR 303 validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/server/controller/pom.xml
+++ b/server/controller/pom.xml
@@ -24,6 +24,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <!-- monitor -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
         <!-- JSR 303 validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Description
Closes #214 
agent and controller will have a default api: /actuator/health, and the response now is:
```
{
    "status": "UP"
}
```
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
