### PR TITLE
keep playbook environment variables the same as helm uses

### DIFF
--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -32,11 +32,3 @@ all-check: ci-format-checker ci-lint
 
 ansible-lint:
 	ansible-lint
-
-# make check {your admin name}
-ansible-check:
-	ansible-playbook starwhale/playbook/bootstrap.yaml -i hosts --user $(user) --check
-
-# make play {your admin name}
-ansible-play:
-	ansible-playbook starwhale/playbook/bootstrap.yaml -i hosts --user $(user)

--- a/bootstrap/starwhale_bootstrap/cmd.py
+++ b/bootstrap/starwhale_bootstrap/cmd.py
@@ -43,6 +43,16 @@ def bootstrap_cmd() -> None:
     help="",
 )
 @click.option(
+    "--mysql-user",
+    default=default.MYSQL_USER,
+    help="",
+)
+@click.option(
+    "--mysql-password",
+    default=default.MYSQL_PWD,
+    help="",
+)
+@click.option(
     "--mysql-data-dir",
     default=default.MYSQL_DATA_DIR,
     help="A path relative to root-path "
@@ -178,6 +188,8 @@ def _deploy(
     mysql_image: str,
     mysql_port: str,
     mysql_root_password: str,
+    mysql_user: str,
+    mysql_password: str,
     mysql_data_dir: str,
     use_default_oss: bool,
     oss_image: str,
@@ -224,6 +236,8 @@ def _deploy(
             "mysql_image": mysql_image,
             "mysql_port": mysql_port,
             "mysql_root_pwd": mysql_root_password,
+            "mysql_user": mysql_user,
+            "mysql_pwd": mysql_password,
             "mysql_data_dir": "{{ base_root_path }}/" + mysql_data_dir,
             # minio
             "minio_image": oss_image,

--- a/bootstrap/starwhale_bootstrap/default.py
+++ b/bootstrap/starwhale_bootstrap/default.py
@@ -12,6 +12,8 @@ SW_REPOSITORY = "starwhaleai"  # or else ghcr.io/star-whale
 MYSQL_IMAGE = "mysql:8.0-debian"
 MYSQL_PORT = "3406"
 MYSQL_ROOT_PWD = "starwhale"
+MYSQL_USER = "starwhale"
+MYSQL_PWD = "starwhale"
 MYSQL_DATA_DIR = "local-storage-mysql"
 
 # minio

--- a/bootstrap/starwhale_bootstrap/playbook/roles/controller/tasks/main.yaml
+++ b/bootstrap/starwhale_bootstrap/playbook/roles/controller/tasks/main.yaml
@@ -15,7 +15,8 @@
       #
       SW_METADATA_STORAGE_IP: "{{ hostvars['storage.starwhale.com']['ansible_eth0']['ipv4']['address'] }}"
       SW_METADATA_STORAGE_PORT: "{{ mysql_port }}"
-      SW_METADATA_STORAGE_PASSWORD: "{{ mysql_root_pwd }}"
+      SW_METADATA_STORAGE_USER: "{{ mysql_user }}"
+      SW_METADATA_STORAGE_PASSWORD: "{{ mysql_pwd }}"
       SW_STORAGE_BUCKET: "{{ minio_default_bucket }}"
       SW_STORAGE_ACCESSKEY: "{{ minio_access_key }}"
       SW_STORAGE_SECRETKEY: "{{ minio_secret_key }}"

--- a/bootstrap/starwhale_bootstrap/playbook/roles/mysql/tasks/main.yaml
+++ b/bootstrap/starwhale_bootstrap/playbook/roles/mysql/tasks/main.yaml
@@ -12,5 +12,7 @@
       - "{{ mysql_port }}:3306"
     env:
       MYSQL_ROOT_PASSWORD: "{{ mysql_root_pwd }}"
+      MYSQL_USER: "{{ mysql_user }}"
+      MYSQL_PASSWORD: "{{ mysql_pwd }}"
     volumes:
       - "{{ mysql_data_dir }}:/var/lib/mysql"

--- a/docker/charts/templates/_helpers.tpl
+++ b/docker/charts/templates/_helpers.tpl
@@ -152,6 +152,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: SW_AGENT_PORT
+              value: "{{ .Values.agent.containerPort }}"
             - name: SW_CONTROLLER_URL
               value: "http://{{ include "common.names.fullname" . }}-controller:{{ .Values.controller.containerPort }}/"
             - name: SW_BASE_PATH
@@ -190,6 +192,24 @@ spec:
             - name: agent-storage
               mountPath: "/var/lib/docker"
               subPath: dind
+          ports:
+            - name: liveness-port
+              containerPort: {{ .Values.agent.containerPort }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: liveness-port
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 90
+            successThreshold: 1
+            failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: liveness-port
+            failureThreshold: 30
+            periodSeconds: 1
         - name: taskset
           image: "{{ .Values.image.registry}}/{{ .Values.image.org }}/{{ .Values.image.taskset.repo }}:{{ .Values.image.taskset.tag }}"
           env:

--- a/docker/charts/templates/controller-deployment.yaml
+++ b/docker/charts/templates/controller-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: {{ .Values.controller.containerPort }}
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/docker/charts/values.yaml
+++ b/docker/charts/values.yaml
@@ -89,6 +89,9 @@ controller:
     password: abcd1234
   containerPort: 8082
 
+agent:
+  containerPort: 8088
+
 storage:
   agentHostPathRoot: "/mnt/data/starwhale"
 

--- a/server/agent/pom.xml
+++ b/server/agent/pom.xml
@@ -29,6 +29,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <!-- monitor -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
         <!-- JSR 303 validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/server/controller/pom.xml
+++ b/server/controller/pom.xml
@@ -24,6 +24,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <!-- monitor -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
         <!-- JSR 303 validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Description
keep playbook environment variables the same as helm uses

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
