### PR TITLE
enhance: add pip cache dir for standalone job

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -5,6 +5,7 @@ ulimit -n 65535 || true
 
 CONDA_BIN="/opt/miniconda3/bin"
 WORKDIR=${SW_SWMP_WORKDIR:=/opt/starwhale/swmp}
+PIP_CACHE_DIR=${SW_PIP_CACHE_DIR:=/root/.cache/pip}
 _MANIFEST_RUNTIME=$(cat ${WORKDIR}/_manifest.yaml| grep "python:" | awk '{print $2}' | awk -F '.' '{print $1"."$2}') || true
 _MODEL_RUNTIME=$(cat ${WORKDIR}/model.yaml | grep 'runtime' | awk '{print $2}') || true
 VERBOSE="-v"
@@ -42,6 +43,10 @@ EOF
     else
         echo -e "\t ** use image builtin pip.conf"
     fi
+
+    echo "\t ** set pip cache dir:"
+    python3 -m pip cache set global.cache-dir ${PIP_CACHE_DIR} || true
+    python3 -m pip cache dir
 
     if [ "${SW_RESET_CONDA_CONFIG}" = "1" ]; then
         echo -e "\t ** REMOVE CONDA custom config, use default"

--- a/client/starwhale/consts/__init__.py
+++ b/client/starwhale/consts/__init__.py
@@ -99,3 +99,5 @@ YAML_TYPES = (".yaml", ".yml")
 
 DEFAULT_SW_TASK_RUN_IMAGE = "ghcr.io/star-whale/starwhale:latest"
 SW_IGNORE_FILE_NAME = ".swignore"
+
+CNTR_DEFAULT_PIP_CACHE_DIR = "/root/.cache/pip"

--- a/client/starwhale/core/job/executor.py
+++ b/client/starwhale/core/job/executor.py
@@ -16,6 +16,7 @@ from starwhale.consts import (
     VERSION_PREFIX_CNT,
     DEFAULT_MANIFEST_NAME,
     DEFAULT_INPUT_JSON_FNAME,
+    CNTR_DEFAULT_PIP_CACHE_DIR,
 )
 from starwhale.base.uri import URI
 from starwhale.utils.fs import ensure_dir, ensure_file
@@ -260,6 +261,11 @@ class EvalExecutor(object):
                 "-v",
                 f"{self._ppl_workdir / RunSubDirType.RESULT}:{_CNTR_WORKDIR}/{RunSubDirType.PPL_RESULT}",
             ]
+
+        cntr_cache_dir = os.environ.get("SW_PIP_CACHE_DIR", CNTR_DEFAULT_PIP_CACHE_DIR)
+        host_cache_dir = os.path.expanduser("~/.cache/starwhale-pip")
+
+        cmd += ["-v", f"{host_cache_dir}:{cntr_cache_dir}"]
 
         if self.docker_verbose:
             cmd += ["-e", "DEBUG=1"]

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -160,14 +160,22 @@ def conda_export(path: t.Union[str, Path], env: str = "") -> None:
     check_call(f"{cmd} {env} > {path}", shell=True)
 
 
-def get_external_python_version() -> t.Any:
-    return subprocess.check_output(
+def get_external_python_version() -> str:
+    out = subprocess.check_output(
         [
             "python3",
             "-c",
             "import sys; _v = sys.version_info; print(f'{_v,major}.{_v.minor}.{_v.micro}')",
         ],
     )
+    return out.decode().strip()
+
+
+def get_pip_cache_dir() -> str:
+    out = subprocess.check_output(
+        ["python3", "-m", "pip", "cache", "dir"],
+    )
+    return out.decode().strip()
 
 
 def conda_restore(

--- a/client/tests/core/test_executor.py
+++ b/client/tests/core/test_executor.py
@@ -1,3 +1,4 @@
+import os
 import json
 from unittest.mock import patch, MagicMock
 
@@ -5,7 +6,11 @@ import yaml
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from starwhale.utils import config as sw_config
-from starwhale.consts import VERSION_PREFIX_CNT, DEFAULT_MANIFEST_NAME
+from starwhale.consts import (
+    VERSION_PREFIX_CNT,
+    DEFAULT_MANIFEST_NAME,
+    CNTR_DEFAULT_PIP_CACHE_DIR,
+)
 from starwhale.base.uri import URI
 from starwhale.utils.fs import ensure_dir, ensure_file
 from starwhale.base.type import URIType
@@ -121,6 +126,7 @@ class StandaloneEvalExecutor(TestCase):
         pull_cmd = m_call.call_args_list[0][0][0]
         ppl_cmd = m_call.call_args_list[1][0][0]
         cmp_cmd = m_call.call_args_list[3][0][0]
+        host_cache_dir = os.path.expanduser("~/.cache/starwhale-pip")
         assert pull_cmd == "docker pull ghcr.io/star-whale/starwhale:latest"
         assert ppl_cmd == " ".join(
             [
@@ -131,6 +137,7 @@ class StandaloneEvalExecutor(TestCase):
                 f"-v {project_dir}/workdir/runtime/mnist/ga/ga4doztfg4yw11111111111111/dep:/opt/starwhale/swmp/dep",
                 f"-v {project_dir}/workdir/runtime/mnist/ga/ga4doztfg4yw11111111111111/_manifest.yaml:/opt/starwhale/swmp/_manifest.yaml",
                 f"-v {project_dir}/dataset:/opt/starwhale/dataset",
+                f"-v {host_cache_dir}:{CNTR_DEFAULT_PIP_CACHE_DIR}",
                 "ghcr.io/star-whale/starwhale:latest ppl",
             ]
         )
@@ -143,6 +150,7 @@ class StandaloneEvalExecutor(TestCase):
                 f"-v {project_dir}/workdir/runtime/mnist/ga/ga4doztfg4yw11111111111111/dep:/opt/starwhale/swmp/dep",
                 f"-v {project_dir}/workdir/runtime/mnist/ga/ga4doztfg4yw11111111111111/_manifest.yaml:/opt/starwhale/swmp/_manifest.yaml",
                 f"-v {project_dir}/job/{build_version[:VERSION_PREFIX_CNT]}/{build_version}/ppl/result:/opt/starwhale/ppl_result",
+                f"-v {host_cache_dir}:{CNTR_DEFAULT_PIP_CACHE_DIR}",
                 "ghcr.io/star-whale/starwhale:latest cmp",
             ]
         )


### PR DESCRIPTION
## Description
- support pip cache for standalone job
- add `SW_PIP_CACHE_DIR` env for `sw-docker-entrypoint` to set global pip cache dir. 

related issue: https://github.com/star-whale/starwhale/issues/274

## Feature Show
![image](https://user-images.githubusercontent.com/590748/172525143-4602fabb-c348-47d0-920a-3cd2d8ad4625.png)


## Modules
- [x] Client


## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
