### PR TITLE
support include-editable for runtime build

### DIFF
--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -62,14 +62,20 @@ def _create(
 @click.option(
     "--gen-all-bundles", is_flag=True, help="gen conda or venv files into runtime"
 )
+@click.option("--include-editable", is_flag=True, help="include editable package")
 def _build(
-    workdir: str, project: str, runtime_yaml: str, gen_all_bundles: bool
+    workdir: str,
+    project: str,
+    runtime_yaml: str,
+    gen_all_bundles: bool,
+    include_editable: bool,
 ) -> None:
     RuntimeTermView.build(
         workdir=workdir,
         project=project,
         yaml_name=runtime_yaml,
         gen_all_bundles=gen_all_bundles,
+        include_editable=include_editable,
     )
 
 

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -205,6 +205,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                     pip_req_path=_pip_req_path,
                     python_version=_python_version,
                     mode=_swrt_config.mode,
+                    include_editable=kw.get("include_editable", False),
                 ),
             ),
             (
@@ -237,6 +238,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         pip_req_path: str = DUMP_USER_PIP_REQ_FNAME,
         python_version: str = DEFAULT_PYTHON_VERSION,
         mode: str = PythonRunEnv.AUTO,
+        include_editable: bool = False,
     ) -> None:
         logger.info("[step:dep]start dump python dep...")
         _dep = dump_python_dep_env(
@@ -245,6 +247,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             gen_all_bundles=gen_all_bundles,
             expected_runtime=python_version,
             mode=mode,
+            include_editable=include_editable,
         )
         self._manifest["dep"] = _dep
         logger.info("[step:dep]finish dump dep")

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -56,12 +56,27 @@ class RuntimeTermView(BaseTermView):
         project: str = "",
         yaml_name: str = DefaultYAMLName.RUNTIME,
         gen_all_bundles: bool = False,
+        include_editable: bool = False,
     ) -> None:
         _runtime_uri = cls.prepare_build_bundle(
             workdir, project, yaml_name, URIType.RUNTIME
         )
+        if include_editable:
+            console.print(
+                ":bell: [red bold]runtime will include pypi editable package[/] :bell:"
+            )
+        else:
+            console.print(
+                ":bird: [red bold]runtime will ignore pypi editable package[/]"
+            )
+
         _rt = Runtime.get_runtime(_runtime_uri)
-        _rt.build(Path(workdir), yaml_name, gen_all_bundles=gen_all_bundles)
+        _rt.build(
+            Path(workdir),
+            yaml_name,
+            gen_all_bundles=gen_all_bundles,
+            include_editable=include_editable,
+        )
 
     def extract(self, force: bool = False, target: t.Union[str, Path] = "") -> None:
         console.print(":oncoming_police_car: try to extract ...")

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -92,7 +92,7 @@ class StandaloneRuntimeTestCase(TestCase):
         assert m_call.call_args[0][0] == [
             "conda",
             "create",
-            "--namespace",
+            "--name",
             name,
             "--yes",
             "python=3.7",


### PR DESCRIPTION
## Description
- fix runtime conda create typo
- add `--include-editable` flag for runtime build.
- add conda  include-editable check
- issue: https://github.com/star-whale/starwhale/issues/208

## Feature Show
- enable
  - ![image](https://user-images.githubusercontent.com/590748/172541337-74172f57-cf1c-49ac-82f7-b8682432bbd9.png)
- disable
  -  ![image](https://user-images.githubusercontent.com/590748/172541663-75efc2c5-27f9-4c20-a54c-e26fbac564f3.png)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
