### PR TITLE
enhance: smart import user venv/conda sys.path

### DIFF
--- a/client/starwhale/utils/error.py
+++ b/client/starwhale/utils/error.py
@@ -44,3 +44,7 @@ class FormatError(Exception):
 
 class EnvironmentError(Exception):
     pass
+
+
+class PythonEnvironmentError(Exception):
+    pass

--- a/client/starwhale/utils/load.py
+++ b/client/starwhale/utils/load.py
@@ -3,24 +3,50 @@ import typing as t
 import importlib
 from pathlib import Path
 
+import pkg_resources
+from loguru import logger
 
-def import_cls(workdir: Path, mc: str, parentClass: t.Any = object) -> t.Any:
-    _module_name, _cls_name = mc.split(":", 1)
-    _changed = False
+from starwhale.utils import console
+from starwhale.utils.venv import (
+    guess_current_py_env,
+    get_user_python_sys_paths,
+    check_python_interpreter_consistency,
+)
 
-    _w = str(workdir.absolute())
-    if _w not in sys.path:
-        sys.path.insert(0, _w)
-        _changed = True
+
+def import_cls(
+    workdir: Path, mc: str, parentClass: t.Any = object, py_env: str = ""
+) -> t.Any:
+    workdir_path = str(workdir.absolute())
+    external_paths = [workdir_path]
+    py_env = py_env or guess_current_py_env()
+    _ok, _cur_py, _ex_py = check_python_interpreter_consistency(py_env)
+    if not _ok:
+        console.print(
+            f":speaking_head: [red]swcli python prefix:{_cur_py}, runtime env python prefix:{_ex_py}[/], swcli will inject sys.path"
+        )
+        external_paths.extend(get_user_python_sys_paths(py_env))
+
+    prev_paths = sys.path[:]
+    sys_changed = False
+
+    for _path in external_paths[::-1]:
+        if _path not in sys.path:
+            logger.debug(f"insert sys.path: '{_path}'")
+            sys.path.insert(0, _path)
+            pkg_resources.working_set.add_entry(_path)
+            sys_changed = True
 
     try:
-        _module = importlib.import_module(_module_name, package=_w)
-        _cls = getattr(_module, _cls_name, None)
+        module_name, cls_name = mc.split(":", 1)
+        _module = importlib.import_module(module_name, package=workdir_path)
+        _cls = getattr(_module, cls_name, None)
         if not _cls or not issubclass(_cls, parentClass):
             raise Exception(f"{mc} is not subclass of {parentClass}")
-    except Exception:
-        if _changed:
-            sys.path.remove(_w)
+    except Exception as e:
+        logger.exception(e)
+        if sys_changed:
+            sys.path[:] = prev_paths
         raise
 
     return _cls

--- a/client/tests/utils/test_load.py
+++ b/client/tests/utils/test_load.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from pyfakefs.fake_filesystem_unittest import TestCase
+
+from starwhale.consts import ENV_VENV
+from starwhale.utils.fs import ensure_dir, ensure_file
+from starwhale.utils.load import import_cls
+
+
+class MockPPL:
+    class Handler:
+        x = 1
+
+
+class ImportClsTestCase(TestCase):
+    def setUp(self) -> None:
+        self.setUpPyfakefs()
+        self.workdir = "/home/starwhale/test"
+        self.inject_paths = [
+            "/home/starwhale/anaconda3/envs/starwhale/bin",
+            "/home/starwhale/anaconda3/envs/starwhale/lib/python37.zip",
+            "/home/starwhale/anaconda3/envs/starwhale/lib/python3.7",
+            "/home/starwhale/anaconda3/envs/starwhale/lib/python3.7/lib-dynload",
+            "",
+            "/home/starwhale/anaconda3/envs/starwhale/lib/python3.7/site-packages",
+        ]
+        self.fs.create_dir(self.workdir)
+        self.fs.create_file(os.path.join(self.workdir, "__init__.py"), contents="")
+        self.fs.create_file(
+            os.path.join(self.workdir, "ppl.py"), contents="class Handler: x=1"
+        )
+
+    @patch("starwhale.utils.load.importlib.import_module")
+    @patch("starwhale.utils.venv.subprocess.check_output")
+    def test_load(
+        self,
+        m_output: MagicMock,
+        m_import: MagicMock,
+    ) -> None:
+        m_import.return_value = MockPPL
+        m_output.side_effect = [
+            (",".join(self.inject_paths) + "\n").encode(),
+            b"3.7",
+            (",".join(self.inject_paths) + "\n").encode(),
+        ]
+
+        venv_dir = os.path.join(self.workdir, "venv")
+        py_bin = os.path.join(venv_dir, "bin", "python3")
+        os.environ[ENV_VENV] = venv_dir
+        ensure_dir(venv_dir)
+        ensure_dir(os.path.join(venv_dir, "bin"))
+        ensure_file(py_bin, " ")
+
+        _cls = import_cls(Path(self.workdir), "ppl:Handler")
+        assert _cls.__module__ == "tests.utils.test_load"
+        assert _cls.x == 1
+        for _p in self.inject_paths + [self.workdir]:
+            assert _p in sys.path


### PR DESCRIPTION
## Description
- Situation: swcli was installed in global or some indepent venvs, but runtime use another venv/conda.
- feature show: swcli can run ppl/cmp successfully.
![image](https://user-images.githubusercontent.com/590748/173308922-7d4e7a29-a28f-4366-a2bb-ed68542fbffb.png)
- related: https://github.com/star-whale/starwhale/issues/525

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
