### PR TITLE
feat: support  run eval job in standalone instance without docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Starwhale is a mlops platform. It provides **Instance**, **Project**, **Runtime*
 - 🍖 **STEP6**: running evaluation job
 
    ```bash
-    swcli -vvv job create --model mnist/version/latest --runtime pytorch-mnist/version/latest --dataset mnist/version/latest --docker-verbose
+    swcli -vvv job create --model mnist/version/latest --dataset mnist/version/latest
     swcli job list
     swcli job info ${version}
    ```

--- a/client/starwhale/core/dataset/cli.py
+++ b/client/starwhale/core/dataset/cli.py
@@ -76,9 +76,7 @@ def _history(dataset: str, fullname: bool = False) -> None:
     DatasetTermView(dataset).history(fullname)
 
 
-@dataset_cmd.command(
-    "render-fuse", help="[Only Standalone]Render fuse input.json for local swds"
-)
+@dataset_cmd.command("render-fuse")
 @click.argument("target")
 @click.option(
     "-f",

--- a/client/starwhale/core/job/cli.py
+++ b/client/starwhale/core/job/cli.py
@@ -36,7 +36,7 @@ def _list(
 
 @job_cmd.command("create", help="Create job")
 @click.argument("project", default="")
-@click.option("--model", required=True, help="model uri")
+@click.option("--model", required=True, help="model uri or model.yaml dir path")
 @click.option(
     "--dataset",
     required=True,
@@ -52,10 +52,12 @@ def _list(
     type=str,
     help="[ONLY Cloud]resource, fmt is resource [name]:[cnt], such as cpu:1, gpu:2",
 )
-@click.option("--gencmd", is_flag=True, help="[ONLY Standalone]gen docker run command")
 @click.option(
-    "--docker-verbose", is_flag=True, help="[ONLY Standalone]docker run verbose output"
+    "--use-docker",
+    is_flag=True,
+    help="[ONLY Standalone]use docker to run evaluation job",
 )
+@click.option("--gencmd", is_flag=True, help="[ONLY Standalone]gen docker run command")
 @click.option(
     "--phase",
     type=click.Choice([EvalTaskType.ALL, EvalTaskType.CMP, EvalTaskType.PPL]),
@@ -70,8 +72,8 @@ def _create(
     name: str,
     desc: str,
     resource: str,
+    use_docker: bool,
     gencmd: bool,
-    docker_verbose: bool,
     phase: str,
 ) -> None:
     JobTermView.create(
@@ -83,8 +85,8 @@ def _create(
         desc=desc,
         resource=resource,
         gencmd=gencmd,
-        docker_verbose=docker_verbose,
         phase=phase,
+        use_docker=use_docker,
     )
 
 

--- a/client/starwhale/core/job/model.py
+++ b/client/starwhale/core/job/model.py
@@ -124,7 +124,7 @@ class StandaloneJob(Job):
         **kw: t.Any,
     ) -> t.Tuple[bool, str]:
         # TODO: support another job type
-        EvalExecutor(
+        _version = EvalExecutor(
             model_uri=model_uri,
             dataset_uris=dataset_uris,
             project_uri=project_uri,
@@ -132,9 +132,9 @@ class StandaloneJob(Job):
             name=name,
             desc=desc,
             gencmd=kw.get("gencmd", False),
-            docker_verbose=kw.get("docker_verbose", False),
+            use_docker=kw.get("use_docker", False),
         ).run(kw.get("phase", EvalTaskType.ALL))
-        return True, "run standalone eval job successfully"
+        return True, _version
 
     def info(
         self, page: int = DEFAULT_PAGE_IDX, size: int = DEFAULT_PAGE_SIZE

--- a/client/starwhale/core/job/view.py
+++ b/client/starwhale/core/job/view.py
@@ -182,7 +182,7 @@ class JobTermView(BaseTermView):
         desc: str = "",
         resource: str = "",
         gencmd: bool = False,
-        docker_verbose: bool = False,
+        use_docker: bool = False,
         phase: str = EvalTaskType.ALL,
     ) -> None:
         _project_uri = URI(project_uri, expected_type=URIType.PROJECT)
@@ -196,16 +196,22 @@ class JobTermView(BaseTermView):
             phase=phase,
             resource=resource,
             gencmd=gencmd,
-            docker_verbose=docker_verbose,
+            use_docker=use_docker,
         )
 
         # TODO: show report in standalone mode directly
 
         if ok:
-            console.print(f":clap: success to create job(project id: {project_uri})")
+            console.print(
+                f":clap: success to create job(project id: [red]{_project_uri.full_uri}[/])"
+            )
             if _project_uri.instance_type == InstanceType.CLOUD:
                 console.print(
-                    f":writing_hand: run cmd [green]swcli job info {_project_uri.full_uri}/job/{reason} [/] to fetch job details"
+                    f":bird: run cmd [green]swcli job info {_project_uri.full_uri}/job/{reason} [/] to fetch job details"
+                )
+            else:
+                console.print(
+                    f":bird: run cmd [green]swcli job info {reason[:SHORT_VERSION_CNT]} [/] to fetch job details"
                 )
         else:
             console.print(f":collision: failed to create job, notice: [red]{reason}[/]")

--- a/client/starwhale/core/job/view.py
+++ b/client/starwhale/core/job/view.py
@@ -206,13 +206,13 @@ class JobTermView(BaseTermView):
                 f":clap: success to create job(project id: [red]{_project_uri.full_uri}[/])"
             )
             if _project_uri.instance_type == InstanceType.CLOUD:
-                console.print(
-                    f":bird: run cmd [green]swcli job info {_project_uri.full_uri}/job/{reason} [/] to fetch job details"
-                )
+                _job_uri = f"{_project_uri.full_uri}/job/{reason}"
             else:
-                console.print(
-                    f":bird: run cmd [green]swcli job info {reason[:SHORT_VERSION_CNT]} [/] to fetch job details"
-                )
+                _job_uri = f"{reason[:SHORT_VERSION_CNT]}"
+
+            console.print(
+                f":bird: run cmd to fetch job info: [bold green]swcli job info {_job_uri}[/]"
+            )
         else:
             console.print(f":collision: failed to create job, notice: [red]{reason}[/]")
 

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -1,4 +1,5 @@
 import os
+import typing as t
 
 import click
 
@@ -11,6 +12,7 @@ from starwhale.consts import (
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType, EvalTaskType
 from starwhale.consts.env import SWEnv
+from starwhale.core.job.view import JobTermView
 from starwhale.core.dataset.store import DatasetStorage
 
 from .view import ModelTermView
@@ -225,4 +227,34 @@ def _cmp(
             "result_dir": result_dir,
             "input_config": input_config,
         },
+    )
+
+
+@model_cmd.command("eval")
+@click.argument("model")
+@click.option(
+    "--dataset",
+    required=True,
+    multiple=True,
+    help="dataset uri, one or more",
+)
+@click.option("--name", help="job name")
+@click.option("--desc", help="job description")
+@click.option("--project", default="", help="project URI")
+def _eval(model: str, dataset: t.List[str], name: str, desc: str, project: str) -> None:
+    """
+    [ONLY Standalone]Create as new job for model evaluation
+
+    MODEL: model uri or model workdir path
+    """
+    JobTermView.create(
+        project_uri=project,
+        model_uri=model,
+        dataset_uris=dataset,
+        runtime_uri="",
+        name=name,
+        desc=desc,
+        use_docker=False,
+        gencmd=False,
+        phase=EvalTaskType.ALL,
     )

--- a/client/starwhale/utils/error.py
+++ b/client/starwhale/utils/error.py
@@ -48,3 +48,7 @@ class EnvironmentError(Exception):
 
 class PythonEnvironmentError(Exception):
     pass
+
+
+class FieldTypeOrValueError(Exception):
+    pass

--- a/client/starwhale/utils/progress.py
+++ b/client/starwhale/utils/progress.py
@@ -1,3 +1,4 @@
+import os
 import typing as t
 
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
@@ -10,23 +11,32 @@ def run_with_progress_bar(
     operations: t.Sequence[t.Tuple[t.Any, ...]],
     **kw: t.Any,
 ):
-    with Progress(
-        SpinnerColumn(),
-        *Progress.get_default_columns(),
-        TimeElapsedColumn(),
-        console=console,
-        refresh_per_second=1,
-    ) as progress:
-        task = progress.add_task(f"[red]{title}", total=sum([o[1] for o in operations]))
-
-        for idx, op in enumerate(operations):
-            progress.update(task, description=f"[red]{op[2]}...")
+    if os.environ.get("DISABLE_PROGRESS_BAR"):
+        for op in operations:
             if len(op) == 4:
                 op[0](**op[3])
             else:
                 op[0]()
-            progress.update(
-                task,
-                advance=op[1],
-                description=f"[green]{idx+1} out of {len(operations)} steps finished",
+    else:
+        with Progress(
+            SpinnerColumn(),
+            *Progress.get_default_columns(),
+            TimeElapsedColumn(),
+            console=console,
+            refresh_per_second=1,
+        ) as progress:
+            task = progress.add_task(
+                f"[red]{title}", total=sum([o[1] for o in operations])
             )
+
+            for idx, op in enumerate(operations):
+                progress.update(task, description=f"[red]{op[2]}...")
+                if len(op) == 4:
+                    op[0](**op[3])
+                else:
+                    op[0]()
+                progress.update(
+                    task,
+                    advance=op[1],
+                    description=f"[green]{idx+1} out of {len(operations)} steps finished",
+                )

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -165,7 +165,7 @@ def pip_freeze(
 ) -> None:
     # TODO: add cmd timeout and error log
     _py_bin = get_user_runtime_python_bin(py_env)
-    console.print(f":snake: [blink red bold]{_py_bin} pip [/] :snake:")
+    logger.info(f"{_py_bin}: pip freeze")
     cmd = [_py_bin, "-m", "pip", "freeze", "--require-virtualenv"]
     if not include_editable:
         cmd += ["--exclude-editable"]
@@ -226,7 +226,7 @@ def guess_current_py_env() -> str:
 def get_user_python_sys_paths(py_env: str) -> t.List[str]:
     logger.debug(f"get env({py_env}) sys path")
     _py_bin = get_user_runtime_python_bin(py_env)
-    console.print(f":snake: [blink red bold]{_py_bin} sys.path [/] :snake:")
+    logger.info(f"{_py_bin}: sys.path")
     output = subprocess.check_output(
         [
             _py_bin,
@@ -503,7 +503,7 @@ def create_python_env(
 
 def get_user_python_version(py_env: str) -> str:
     _py_bin = get_user_runtime_python_bin(py_env)
-    console.print(f":snake: [blink red bold]{_py_bin} version [/] :snake:")
+    logger.info(f"{_py_bin}: python version")
     output = subprocess.check_output(
         [
             _py_bin,
@@ -662,9 +662,7 @@ def _do_restore_venv(
 
 def validate_runtime_package_dep(py_env: str) -> None:
     _py_bin = get_user_runtime_python_bin(py_env)
-    console.print(
-        f":snake: use [blink red bold]{_py_bin} to check {SW_PYPI_PKG_NAME} install [/] :snake:"
-    )
+    logger.info(f"{_py_bin}: check {SW_PYPI_PKG_NAME} install")
     cmd = [
         _py_bin,
         "-c",

--- a/client/tests/core/test_executor.py
+++ b/client/tests/core/test_executor.py
@@ -86,6 +86,7 @@ class StandaloneEvalExecutor(TestCase):
             dataset_uris=["mnist/version/me4dczleg"],
             project_uri=URI(""),
             runtime_uri="mnist/version/ga4doztfg4yw",
+            use_docker=True,
         )
 
         ee.run()
@@ -130,10 +131,10 @@ class StandaloneEvalExecutor(TestCase):
         assert pull_cmd == "docker pull ghcr.io/star-whale/starwhale:latest"
         assert ppl_cmd == " ".join(
             [
-                f"docker run --net=host --rm --name {build_version}-ppl",
+                f"docker run --net=host --rm --name {build_version}-ppl -e DEBUG=1",
                 f"-v {project_dir}/job/{build_version[:VERSION_PREFIX_CNT]}/{build_version}/ppl:/opt/starwhale",
                 f"-v {project_dir}/workdir/model/mnist/gn/gnstmntggi4t111111111111/src:/opt/starwhale/swmp/src",
-                f"-v {project_dir}/workdir/model/mnist/gn/gnstmntggi4t111111111111/model.yaml:/opt/starwhale/swmp/model.yaml",
+                f"-v {project_dir}/workdir/model/mnist/gn/gnstmntggi4t111111111111/src/model.yaml:/opt/starwhale/swmp/model.yaml",
                 f"-v {project_dir}/workdir/runtime/mnist/ga/ga4doztfg4yw11111111111111/dep:/opt/starwhale/swmp/dep",
                 f"-v {project_dir}/workdir/runtime/mnist/ga/ga4doztfg4yw11111111111111/_manifest.yaml:/opt/starwhale/swmp/_manifest.yaml",
                 f"-v {project_dir}/dataset:/opt/starwhale/dataset",
@@ -143,10 +144,10 @@ class StandaloneEvalExecutor(TestCase):
         )
         assert cmp_cmd == " ".join(
             [
-                f"docker run --net=host --rm --name {build_version}-cmp",
+                f"docker run --net=host --rm --name {build_version}-cmp -e DEBUG=1",
                 f"-v {project_dir}/job/{build_version[:VERSION_PREFIX_CNT]}/{build_version}/cmp:/opt/starwhale",
                 f"-v {project_dir}/workdir/model/mnist/gn/gnstmntggi4t111111111111/src:/opt/starwhale/swmp/src",
-                f"-v {project_dir}/workdir/model/mnist/gn/gnstmntggi4t111111111111/model.yaml:/opt/starwhale/swmp/model.yaml",
+                f"-v {project_dir}/workdir/model/mnist/gn/gnstmntggi4t111111111111/src/model.yaml:/opt/starwhale/swmp/model.yaml",
                 f"-v {project_dir}/workdir/runtime/mnist/ga/ga4doztfg4yw11111111111111/dep:/opt/starwhale/swmp/dep",
                 f"-v {project_dir}/workdir/runtime/mnist/ga/ga4doztfg4yw11111111111111/_manifest.yaml:/opt/starwhale/swmp/_manifest.yaml",
                 f"-v {project_dir}/job/{build_version[:VERSION_PREFIX_CNT]}/{build_version}/ppl/result:/opt/starwhale/ppl_result",
@@ -160,6 +161,4 @@ class StandaloneEvalExecutor(TestCase):
         assert _manifest_path.exists()
         assert _manifest["phase"] == "all"
         assert _manifest["version"] == build_version
-        assert (
-            _manifest["model"] == "local/project/self/model/mnist/version/gnstmntggi4t"
-        )
+        assert _manifest["model"] == "mnist/version/gnstmntggi4t"

--- a/docs/docs/quickstart/standalone.md
+++ b/docs/docs/quickstart/standalone.md
@@ -20,7 +20,6 @@ Starwhale standalone requires Python 3.7 or above. Today starwhale only supports
 
 At the installation point, we recommended you follow the [doc](../standalone/installation.md).
 
-
 ## Downloading the Example
 
 Download the starwhale example code by cloning Starwhale via:
@@ -107,12 +106,12 @@ We will use ML/DL HelloWorld code `MNIST` to start your starwhale journey. The f
 
 ## Running Evaluation Job
 
-Run evaluation job need docker in standalone mode today.
+Run evaluation job in current activated python runtime.
 
 - Create Evaluation Job
 
  ```bash
- swcli -vvv job create --model mnist/version/latest --runtime pytorch-mnist/version/latest --dataset mnist/version/latest --docker-verbose
+ swcli -vvv job create --model mnist/version/latest --dataset mnist/version/latest
  ```
 
 - Info Evaluation Result
@@ -120,6 +119,12 @@ Run evaluation job need docker in standalone mode today.
  ```bash
  swcli job list
  swcli job info ${version}
+ ```
+
+- [Optional Step]Additional, you can also create a job in docker environment.
+
+ ```bash
+ swcli -vvv job create --model mnist/version/latest --runtime pytorch-mnist/version/latest --dataset mnist/version/latest --use-docker
  ```
 
   :::tip Create job too slow


### PR DESCRIPTION
## Description
- related issue: https://github.com/star-whale/starwhale/issues/587
- remove `--docker-verbose` args
- add `--use-docker` to specify whether to use docker
- add `swcli model eval` command

![eval-without-docker](https://user-images.githubusercontent.com/590748/174437914-a54ec1d1-54c6-40e6-8bbb-19ee25788cc8.gif)

![image](https://user-images.githubusercontent.com/590748/174475495-e3d302b7-4840-442f-b37e-81305457787e.png)

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
