### PR TITLE
fix issue 633 :response to FE with readable error when uerying dag of job at status of created

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dag/DAGQuerier.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dag/DAGQuerier.java
@@ -82,6 +82,9 @@ public class DAGQuerier {
     }
 
     private Graph buildGraphFromCache(Job job) {
+        if(job.getStatus() == JobStatus.CREATED){
+            throw new SWValidationException(ValidSubject.JOB).tip("Job is still creating");
+        }
         Graph graph = new Graph();
         AtomicLong idx = new AtomicLong(0);
         JobNodeContent initialJobNodeContent = new JobNodeContent(job);

--- a/server/controller/src/test/java/ai/starwhale/test/domain/dag/DAGQuerierTest.java
+++ b/server/controller/src/test/java/ai/starwhale/test/domain/dag/DAGQuerierTest.java
@@ -29,6 +29,7 @@ import ai.starwhale.mlops.domain.job.mapper.JobMapper;
 import ai.starwhale.mlops.domain.job.po.JobEntity;
 import ai.starwhale.mlops.domain.job.status.JobStatus;
 import ai.starwhale.mlops.domain.job.step.StepHelper;
+import ai.starwhale.mlops.exception.SWValidationException;
 import ai.starwhale.test.JobMockHolder;
 import java.util.Collections;
 import java.util.List;
@@ -46,11 +47,15 @@ public class DAGQuerierTest {
         JobManager jobManager = mock(JobManager.class);
         when(jobManager.getJobId("1")).thenReturn(1L);
         when(jobManager.getJobId("2")).thenReturn(2L);
+        when(jobManager.getJobId("3")).thenReturn(3L);
         HotJobHolder hotJobHolder = mock(HotJobHolder.class);
         when(hotJobHolder.ofIds(List.of(1L))).thenReturn(Collections.emptySet());
         JobMockHolder jobMockHolder = new JobMockHolder();
         Job mockedJob = jobMockHolder.mockJob();
+        Job createdJob = jobMockHolder.mockJob();
+        createdJob.setStatus(JobStatus.CREATED);
         when(hotJobHolder.ofIds(List.of(2L))).thenReturn(List.of(mockedJob));
+        when(hotJobHolder.ofIds(List.of(3L))).thenReturn(List.of(createdJob));
 
         JobMapper jobMapper = mock(JobMapper.class);
         JobEntity jobEntity = JobEntity.builder().id(1L).jobStatus(JobStatus.RUNNING).build();
@@ -66,6 +71,8 @@ public class DAGQuerierTest {
 
         Graph graph2 = dagQuerier.dagOfJob("2",true);
         Assertions.assertEquals(3,graph2.getGroupingNodes().keySet().size());
+
+        Assertions.assertThrowsExactly(SWValidationException.class,()->dagQuerier.dagOfJob("3",true));
 
 
     }


### PR DESCRIPTION
## Description
- response to FE with readable error when uerying dag of job at status of created
## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
