### PR TITLE
Fix: agent log with line separator

### DIFF
--- a/server/agent/src/main/java/ai/starwhale/mlops/agent/task/inferencetask/persistence/FileSystemTaskPersistence.java
+++ b/server/agent/src/main/java/ai/starwhale/mlops/agent/task/inferencetask/persistence/FileSystemTaskPersistence.java
@@ -341,7 +341,7 @@ public class FileSystemTaskPersistence implements TaskPersistence {
             }
             Path logFilePath = Path.of(fileSystemPath.oneActiveTaskAgentLogFile(task.getId()));
 
-            Files.writeString(logFilePath, toAppend, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+            Files.writeString(logFilePath, toAppend + System.lineSeparator(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         } catch (Exception e) {
             log.error("record log for task:{} error, info:{}", task.getId(), e.getMessage());
         }

--- a/server/agent/src/test/java/ai/starwhale/mlops/agent/test/TaskActionTest.java
+++ b/server/agent/src/test/java/ai/starwhale/mlops/agent/test/TaskActionTest.java
@@ -62,7 +62,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
-//@Ignore
+@Ignore
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         classes = StarWhaleAgentTestApplication.class)
@@ -73,7 +73,7 @@ import static org.mockito.ArgumentMatchers.any;
                 "sw.agent.node.sourcePool.init.enabled=false",
                 // when test,please set these properties with debug configuration
                 //"sw.storage.s3-config.endpoint=http://${ip}:9000",
-                "sw.agent.basePath=/home/starwhale"
+                "sw.agent.basePath=/var/starwhale"
         },
         locations = "classpath:application-integrationtest.yaml"
 )

--- a/server/agent/src/test/java/ai/starwhale/mlops/agent/test/TaskActionTest.java
+++ b/server/agent/src/test/java/ai/starwhale/mlops/agent/test/TaskActionTest.java
@@ -62,7 +62,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
-@Ignore
+//@Ignore
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         classes = StarWhaleAgentTestApplication.class)
@@ -73,7 +73,7 @@ import static org.mockito.ArgumentMatchers.any;
                 "sw.agent.node.sourcePool.init.enabled=false",
                 // when test,please set these properties with debug configuration
                 //"sw.storage.s3-config.endpoint=http://${ip}:9000",
-                "sw.agent.basePath=/var/starwhale"
+                "sw.agent.basePath=/home/starwhale"
         },
         locations = "classpath:application-integrationtest.yaml"
 )


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [x] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
