### PR TITLE
bug(docker): fix trusted host in default pip config

### DIFF
--- a/docker/external/pip.conf
+++ b/docker/external/pip.conf
@@ -4,7 +4,6 @@ extra-index-url=https://pypi.tuna.tsinghua.edu.cn/simple/
                 http://pypi.mirrors.ustc.edu.cn/simple/
                 https://pypi.org/simple
 [install]
-trusted-host=mirrors.aliyun.com
+trusted-host=pypi.mirrors.ustc.edu.cn
              pypi.tuna.tsinghua.edu.cn
              pypi.doubanio.com
-             pypi.org


### PR DESCRIPTION
## Description

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
