### PR TITLE
bug(sdk): fix s3 data loader type

### DIFF
--- a/client/starwhale/api/_impl/loader.py
+++ b/client/starwhale/api/_impl/loader.py
@@ -40,7 +40,7 @@ class DataLoader(object):
         swds: t.List[t.Dict[str, t.Any]] = [],
         logger: t.Union[loguru.Logger, None] = None,
         kind: str = DataLoaderKind.SWDS,
-        deserializer: t.Callable = None,
+        deserializer: t.Optional[t.Callable] = None,
     ):
         self.storage = storage
         self.swds = swds
@@ -94,6 +94,7 @@ class JSONLineDataLoader(DataLoader):
             line = line.strip()
             if not line:
                 continue
+
             if self.deserializer:
                 yield self.deserializer(line)
                 continue

--- a/client/starwhale/api/_impl/model.py
+++ b/client/starwhale/api/_impl/model.py
@@ -232,8 +232,8 @@ class PipelineHandler(object):
     def label_data_deserialize(self, data: bytes) -> bytes:
         return dill.loads(base64.b64decode(data))[0]
 
-    def deserialize(self, data: bytes) -> t.Any:
-        ret = json.loads(data.decode("utf-8"))
+    def deserialize(self, data: t.Union[str, bytes]) -> t.Any:
+        ret = json.loads(data)
         ret[self._ppl_data_field] = self.ppl_data_deserialize(ret[self._ppl_data_field])
         ret[self._label_field] = self.label_data_deserialize(ret[self._label_field])
         return ret

--- a/client/tests/utils/test_process.py
+++ b/client/tests/utils/test_process.py
@@ -21,4 +21,4 @@ class TestCheckCall(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             log_check_call(["err"])
 
-        assert len(save_logs) == 2
+        assert len(save_logs) >= 2


### PR DESCRIPTION
## Description
- json.loads can handle `str`, `bytes` automatically.
- related pr: https://github.com/star-whale/starwhale/pull/631
![image](https://user-images.githubusercontent.com/590748/175944405-ed39692b-611e-4a1e-b789-7fde1d1dd667.png)

## Fixed Result Show
- ![image](https://user-images.githubusercontent.com/590748/175971606-8cda08c8-84d4-45e6-9cf2-c5c873bd409c.png)


## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
