### PR TITLE
fix(client): can not show job info when use cloud instance

### DIFF
--- a/client/starwhale/base/uri.py
+++ b/client/starwhale/base/uri.py
@@ -149,10 +149,6 @@ class URI(object):
             else:
                 _name, _version = raw, ""
 
-            ok, reason = validate_obj_name(_name)
-            if not ok:
-                raise Exception(reason)
-
             return ObjField(typ=self.expected_type, name=_name, version=_version), ""
 
         _sp = raw.split("/")


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc

![image](https://user-images.githubusercontent.com/3217223/176163543-74d757b3-a15f-4092-a4f5-a0050235ba17.png)
