### PR TITLE
fix(client): ignore invalid dir in project list

### DIFF
--- a/client/starwhale/core/project/model.py
+++ b/client/starwhale/core/project/model.py
@@ -143,7 +143,8 @@ class StandaloneProject(Project):
         rt = []
         for pdir in sw.rootdir.iterdir():
             # TODO: add more project details
-            if pdir.name == RECOVER_DIRNAME:
+            valid, _ = validate_obj_name(pdir.name)
+            if not valid:
                 continue
 
             rt.append(


### PR DESCRIPTION
## Description
`.tmp` will be recognized as a project without validation
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
