### PR TITLE
fix(sdk): resolve all ResourceWarning: unclosed file of yaml loading

### DIFF
--- a/client/starwhale/base/bundle.py
+++ b/client/starwhale/base/bundle.py
@@ -189,7 +189,8 @@ class LocalStorageBundleMixin(object):
                     _manifest["config"].update(_store.manifest)
                 elif _store.bundle_path.exists():
                     with TarFS(str(_store.bundle_path)) as tar:
-                        _om = yaml.safe_load(tar.open(DEFAULT_MANIFEST_NAME))
+                        with tar.open(DEFAULT_MANIFEST_NAME) as f:
+                            _om = yaml.safe_load(f)
                         _manifest["config"].update(_om)
                 else:
                     raise NotFoundError(

--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -1,7 +1,6 @@
 from http import HTTPStatus
 from pathlib import Path
 
-import yaml
 from rich.progress import (
     TaskID,
     Progress,
@@ -13,7 +12,7 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
-from starwhale.utils import console
+from starwhale.utils import console, load_yaml
 from starwhale.consts import HTTPMethod, VERSION_PREFIX_CNT, DEFAULT_MANIFEST_NAME
 from starwhale.base.uri import URI
 from starwhale.utils.fs import ensure_dir
@@ -218,7 +217,7 @@ class BundleCopy(CloudRequestMixed):
         if not upload_id:
             raise Exception("get invalid upload_id")
         _headers = {"X-SW-UPLOAD-ID": str(upload_id)}
-        _manifest = yaml.safe_load(_manifest_path.open())
+        _manifest = load_yaml(_manifest_path)
 
         # TODO: add retry deco
         def _upload_blob(_fp: Path, _tid: TaskID) -> None:
@@ -310,7 +309,7 @@ class BundleCopy(CloudRequestMixed):
         _manifest_path = _workdir / DEFAULT_MANIFEST_NAME
         _tid = progress.add_task(f":arrow_down: {DEFAULT_MANIFEST_NAME}")
         _download(_manifest_path, DEFAULT_MANIFEST_NAME, _tid)
-        _manifest = yaml.safe_load(_manifest_path.open())
+        _manifest = load_yaml(_manifest_path)
 
         _p_map = {}
         for _k in _manifest.get("signature", {}):

--- a/client/starwhale/base/store.py
+++ b/client/starwhale/base/store.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import yaml
 from fs.tarfs import TarFS
 
+from starwhale.utils import load_yaml
 from starwhale.consts import (
     RECOVER_DIRNAME,
     SW_TMP_DIR_NAME,
@@ -85,7 +86,7 @@ class BaseStorage(object):
         if not self.manifest_path.exists():
             return {}
         else:
-            return yaml.safe_load(self.manifest_path.open())
+            return load_yaml(self.manifest_path)
 
     def _get_recover_snapshot_workdir_for_bundle(self) -> Path:
         version = self.uri.object.version
@@ -224,7 +225,8 @@ class BaseStorage(object):
             _extracted_manifest = _extracted_dir / DEFAULT_MANIFEST_NAME
 
             if _extracted_manifest.exists():
-                return yaml.safe_load(_extracted_manifest.open())
+                return load_yaml(_extracted_manifest)
 
         with TarFS(str(fpath)) as tar:
-            return yaml.safe_load(tar.open(DEFAULT_MANIFEST_NAME))
+            with tar.open(DEFAULT_MANIFEST_NAME) as f:
+                return yaml.safe_load(f)

--- a/client/starwhale/base/tag.py
+++ b/client/starwhale/base/tag.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import yaml
 
-from starwhale.utils import now_str, validate_obj_name
+from starwhale.utils import now_str, load_yaml, validate_obj_name
 from starwhale.consts import DEFAULT_MANIFEST_NAME
 from starwhale.base.uri import URI
 from starwhale.utils.fs import ensure_dir, ensure_file
@@ -45,7 +45,7 @@ class StandaloneTag(object):
             ensure_file(self._manifest_path, yaml.safe_dump(_dft))
             return _dft
         else:
-            return yaml.safe_load(self._manifest_path.open())
+            return load_yaml(self._manifest_path)
 
     def _save_manifest(self, _manifest: t.Dict[str, t.Any]) -> None:
         _manifest["updated_at"] = now_str()  # type: ignore
@@ -121,7 +121,6 @@ class StandaloneTag(object):
     def get_manifest_by_dir(cls, dir: Path) -> t.Dict[str, t.Any]:
         _mf = dir / DEFAULT_MANIFEST_NAME
         if _mf.exists():
-            with open(_mf) as f:
-                return yaml.safe_load(f) or {}
+            return load_yaml(_mf) or {}
         else:
             return {}

--- a/client/starwhale/base/view.py
+++ b/client/starwhale/base/view.py
@@ -4,7 +4,6 @@ import json
 import typing as t
 from functools import wraps
 
-import yaml
 from rich import box
 from rich import print as rprint
 from rich.panel import Panel
@@ -12,7 +11,14 @@ from rich.table import Table
 from rich.pretty import Pretty
 from rich.console import RenderableType
 
-from starwhale.utils import Order, console, pretty_bytes, sort_obj_list, snake_to_camel
+from starwhale.utils import (
+    Order,
+    console,
+    load_yaml,
+    pretty_bytes,
+    sort_obj_list,
+    snake_to_camel,
+)
 from starwhale.consts import UserRoleType, SHORT_VERSION_CNT
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType
@@ -108,7 +114,7 @@ class BaseTermView(SWCliConfigMixed):
         console.print(f":construction: start to build {typ} bundle...")
         _project_uri = URI(project, expected_type=URIType.PROJECT)
         _path = os.path.join(workdir, yaml_name)
-        _config = yaml.safe_load(open(_path, "r"))
+        _config = load_yaml(_path)
         if "name" not in _config:
             raise FileFormatError(f"{_path}, no name field")
 

--- a/client/starwhale/core/dataset/dataset.py
+++ b/client/starwhale/core/dataset/dataset.py
@@ -4,9 +4,7 @@ import typing as t
 from copy import deepcopy
 from pathlib import Path
 
-import yaml
-
-from starwhale.utils import convert_to_bytes
+from starwhale.utils import load_yaml, convert_to_bytes
 from starwhale.consts import SWDSSubFileType, DEFAULT_STARWHALE_API_VERSION
 from starwhale.utils.error import NoSupportError
 
@@ -103,9 +101,6 @@ class DatasetConfig(object):
 
     @classmethod
     def create_by_yaml(cls, fpath: t.Union[str, Path]) -> DatasetConfig:
-        fpath = Path(fpath)
-
-        with fpath.open("r") as f:
-            c = yaml.safe_load(f)
+        c = load_yaml(fpath)
 
         return cls(**c)

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -7,12 +7,11 @@ from abc import ABCMeta
 from pathlib import Path
 from collections import defaultdict
 
-import yaml
 from fs import open_fs
 from loguru import logger
 from fs.copy import copy_fs, copy_file
 
-from starwhale.utils import console
+from starwhale.utils import console, load_yaml
 from starwhale.consts import (
     JSON_INDENT,
     DataLoaderKind,
@@ -103,7 +102,7 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
         if not _mf.exists():
             raise Exception(f"need {DEFAULT_MANIFEST_NAME} @ {workdir}")
 
-        _manifest = yaml.safe_load(_mf.open())
+        _manifest = load_yaml(_mf)
         _fuse = dict(
             backend=SWDSBackendType.FUSE,
             kind=DataLoaderKind.SWDS,
@@ -156,7 +155,7 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
         _r = []
 
         for _bf in self.store.iter_bundle_history():
-            _manifest = yaml.safe_load((_bf.path / DEFAULT_MANIFEST_NAME).open())
+            _manifest = load_yaml(_bf.path / DEFAULT_MANIFEST_NAME)
 
             _r.append(
                 dict(
@@ -198,7 +197,7 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
             bundle_type=BundleType.DATASET,
             uri_type=URIType.DATASET,
         ):
-            _manifest = yaml.safe_load((_bf.path / DEFAULT_MANIFEST_NAME).open())
+            _manifest = load_yaml(_bf.path / DEFAULT_MANIFEST_NAME)
 
             rs[_bf.name].append(
                 dict(

--- a/client/starwhale/core/job/model.py
+++ b/client/starwhale/core/job/model.py
@@ -6,9 +6,9 @@ from abc import ABCMeta, abstractmethod
 from http import HTTPStatus
 from collections import defaultdict
 
-import yaml
 import jsonlines
 
+from starwhale.utils import load_yaml
 from starwhale.consts import HTTPMethod, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
 from starwhale.base.uri import URI
 from starwhale.utils.fs import move_dir
@@ -274,7 +274,7 @@ class StandaloneJob(Job):
     ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
         _rt = []
         for _path, _is_removed in JobStorage.iter_all_jobs(project_uri):
-            _manifest = yaml.safe_load(_path.open())
+            _manifest = load_yaml(_path)
             if not _manifest:
                 continue
 

--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -7,12 +7,11 @@ from copy import deepcopy
 from pathlib import Path
 from collections import defaultdict
 
-import yaml
 from fs import open_fs
 from loguru import logger
 from fs.copy import copy_fs, copy_file
 
-from starwhale.utils import console
+from starwhale.utils import console, load_yaml
 from starwhale.consts import (
     DefaultYAMLName,
     DEFAULT_PAGE_IDX,
@@ -108,7 +107,7 @@ class ModelConfig(object):
 
     @classmethod
     def create_by_yaml(cls, path: Path) -> ModelConfig:
-        c = yaml.safe_load(path.open())
+        c = load_yaml(path)
         return cls(**c)
 
     def __str__(self) -> str:

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -10,7 +10,12 @@ from collections import defaultdict
 import yaml
 from loguru import logger
 
-from starwhale.utils import console, validate_obj_name, get_downloadable_sw_version
+from starwhale.utils import (
+    console,
+    load_yaml,
+    validate_obj_name,
+    get_downloadable_sw_version,
+)
 from starwhale.consts import (
     PythonRunEnv,
     SW_IMAGE_FMT,
@@ -85,7 +90,7 @@ class RuntimeConfig(object):
 
     @classmethod
     def create_by_yaml(cls, path: Path) -> RuntimeConfig:
-        c = yaml.safe_load(path.open())
+        c = load_yaml(path)
         return cls(**c)
 
     def as_dict(self) -> t.Dict[str, t.Any]:
@@ -407,7 +412,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         ):
             raise NoSupportError("only support swrt extract workdir")
 
-        _manifest = yaml.safe_load((workdir / DEFAULT_MANIFEST_NAME).open())
+        _manifest = load_yaml(workdir / DEFAULT_MANIFEST_NAME)
         restore_python_env(
             workdir=workdir,
             mode=_manifest["dep"]["env"],

--- a/client/starwhale/utils/__init__.py
+++ b/client/starwhale/utils/__init__.py
@@ -8,9 +8,11 @@ import string
 import typing as t
 import hashlib
 import platform
+from pathlib import Path
 from datetime import datetime
 from functools import cmp_to_key
 
+import yaml
 from rich.console import Console
 
 from starwhale import __version__
@@ -163,3 +165,9 @@ def sort_obj_list(data: t.List[t.Any], orders: t.List[Order]) -> t.Any:
         return m
 
     return sorted(data, key=cmp_to_key(compare))
+
+
+def load_yaml(path: t.Union[str, Path]):
+    """load_yaml loads yaml from path, it may raise exception such as yaml.YAMLError"""
+    with open(path) as f:
+        return yaml.safe_load(f)

--- a/client/starwhale/utils/config.py
+++ b/client/starwhale/utils/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import yaml
 
+from starwhale.utils import load_yaml
 from starwhale.consts import (
     UserRoleType,
     SW_CLI_CONFIG,
@@ -38,22 +39,21 @@ def load_swcli_config() -> t.Dict[str, t.Any]:
     if not os.path.exists(fpath):
         _config = render_default_swcli_config(fpath)
     else:
-        with open(fpath) as f:
-            _config = yaml.safe_load(f)
+        _config = load_yaml(fpath)
 
-            env = os.environ.get(ENV_SW_LOCAL_STORAGE)
-            if env:
-                _config["storage"]["root"] = env
+        env = os.environ.get(ENV_SW_LOCAL_STORAGE)
+        if env:
+            _config["storage"]["root"] = env
 
-            _version = _config.get("version")
-            if _version != LOCAL_CONFIG_VERSION:
-                console.print(
-                    f":cherries: {fpath} use unexpected version({_version}), swcli only support {LOCAL_CONFIG_VERSION} version."
-                )
-                console.print(
-                    f":carrot: {fpath} will be upgraded to {LOCAL_CONFIG_VERSION} automatically."
-                )
-                _config = render_default_swcli_config(fpath)
+        _version = _config.get("version")
+        if _version != LOCAL_CONFIG_VERSION:
+            console.print(
+                f":cherries: {fpath} use unexpected version({_version}), swcli only support {LOCAL_CONFIG_VERSION} version."
+            )
+            console.print(
+                f":carrot: {fpath} will be upgraded to {LOCAL_CONFIG_VERSION} automatically."
+            )
+            _config = render_default_swcli_config(fpath)
 
     ensure_dir(Path(_config["storage"]["root"]) / DEFAULT_PROJECT, recursion=True)
     return _config

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -3,10 +3,10 @@ import json
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-import yaml
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from starwhale.utils import config as sw_config
+from starwhale.utils import load_yaml
 from starwhale.consts import (
     DefaultYAMLName,
     SW_TMP_DIR_NAME,
@@ -74,7 +74,7 @@ class StandaloneDatasetTestCase(TestCase):
         assert (snapshot_workdir / "data").exists()
         assert (snapshot_workdir / "src").exists()
 
-        _manifest = yaml.safe_load((snapshot_workdir / DEFAULT_MANIFEST_NAME).open())
+        _manifest = load_yaml(snapshot_workdir / DEFAULT_MANIFEST_NAME)
         assert _manifest["name"] == name
 
         dataset_uri = URI(

--- a/client/tests/core/test_executor.py
+++ b/client/tests/core/test_executor.py
@@ -2,10 +2,10 @@ import os
 import json
 from unittest.mock import patch, MagicMock
 
-import yaml
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from starwhale.utils import config as sw_config
+from starwhale.utils import load_yaml
 from starwhale.consts import (
     VERSION_PREFIX_CNT,
     DEFAULT_MANIFEST_NAME,
@@ -101,7 +101,7 @@ class StandaloneEvalExecutor(TestCase):
         ppl_dir = job_dir / "ppl"
         cmp_dir = job_dir / "cmp"
         _manifest_path = job_dir / DEFAULT_MANIFEST_NAME
-        _manifest = yaml.safe_load(_manifest_path.open())
+        _manifest = load_yaml(_manifest_path)
 
         assert _manifest["version"] == build_version
         assert ppl_dir.exists()
@@ -157,7 +157,7 @@ class StandaloneEvalExecutor(TestCase):
         )
 
         _manifest_path = job_dir / DEFAULT_MANIFEST_NAME
-        _manifest = yaml.safe_load(_manifest_path.open())
+        _manifest = load_yaml(_manifest_path)
         assert _manifest_path.exists()
         assert _manifest["phase"] == "all"
         assert _manifest["version"] == build_version

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -2,11 +2,11 @@ import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-import yaml
 from requests_mock import Mocker
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from starwhale.utils import config as sw_config
+from starwhale.utils import load_yaml
 from starwhale.consts import (
     HTTPMethod,
     DefaultYAMLName,
@@ -83,7 +83,7 @@ class StandaloneModelTestCase(TestCase):
         assert snapshot_workdir.exists()
         assert (snapshot_workdir / "src").exists()
 
-        _manifest = yaml.safe_load((snapshot_workdir / DEFAULT_MANIFEST_NAME).open())
+        _manifest = load_yaml(snapshot_workdir / DEFAULT_MANIFEST_NAME)
         assert _manifest["name"] == name
         assert _manifest["version"] == build_version
 

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -7,6 +7,7 @@ import yaml
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from starwhale.utils import config as sw_config
+from starwhale.utils import load_yaml
 from starwhale.consts import (
     ENV_VENV,
     PythonRunEnv,
@@ -58,7 +59,7 @@ class StandaloneRuntimeTestCase(TestCase):
             "install",
         ]
 
-        _rt_config = yaml.safe_load(open(runtime_path, "r"))
+        _rt_config = load_yaml(runtime_path)
         assert _rt_config["name"] == name
         assert _rt_config["mode"] == "venv"
         assert _rt_config["python_version"] == "3.9"
@@ -79,7 +80,7 @@ class StandaloneRuntimeTestCase(TestCase):
             "--python",
             "3.8",
         ]
-        _rt_config = yaml.safe_load(open(runtime_path, "r"))
+        _rt_config = load_yaml(runtime_path)
         assert _rt_config["python_version"] == "3.8"
 
     @patch("starwhale.utils.venv.check_call")
@@ -95,7 +96,7 @@ class StandaloneRuntimeTestCase(TestCase):
             mode=PythonRunEnv.CONDA,
         )
         assert os.path.exists(os.path.join(workdir, runtime_path))
-        _rt_config = yaml.safe_load(open(runtime_path, "r"))
+        _rt_config = load_yaml(runtime_path)
         assert _rt_config["mode"] == "conda"
         assert m_call.call_args_list[0][0][0] == [
             "conda",
@@ -167,9 +168,7 @@ class StandaloneRuntimeTestCase(TestCase):
         assert os.path.exists(runtime_workdir)
         assert "latest" in sr.tag.list()
 
-        _manifest = yaml.safe_load(
-            open(os.path.join(runtime_workdir, DEFAULT_MANIFEST_NAME))
-        )
+        _manifest = load_yaml(os.path.join(runtime_workdir, DEFAULT_MANIFEST_NAME))
 
         assert (
             _manifest["user_raw_config"]["python_version"]


### PR DESCRIPTION
## Description

```sh
/home/foo/work/repos/starwhale/client/starwhale/core/dataset/model.py:201: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/foo/.cache/starwhale/self/dataset/mnist/gv/gvqtqzdche3wcnrtmftdgyjzon2xena.swds/_manifest.yaml' mode='r' encoding='UTF-8'>
  _manifest = yaml.safe_load((_bf.path / DEFAULT_MANIFEST_NAME).open())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/foo/work/repos/starwhale/client/starwhale/core/dataset/model.py:201: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/foo/.cache/starwhale/self/dataset/mnist/hf/hfrdmyrzhe3wgnrtmftdgyjzonudi6a.swds/_manifest.yaml' mode='r' encoding='UTF-8'>
  _manifest = yaml.safe_load((_bf.path / DEFAULT_MANIFEST_NAME).open())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/foo/work/repos/starwhale/client/starwhale/core/dataset/model.py:201: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/foo/.cache/starwhale/self/dataset/mnist/ga/ga3tqytfga2gknrtmftdgyjzgv5da3y.swds/_manifest.yaml' mode='r' encoding='UTF-8'>
  _manifest = yaml.safe_load((_bf.path / DEFAULT_MANIFEST_NAME).open())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/foo/work/repos/starwhale/client/starwhale/core/dataset/model.py:201: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/foo/.cache/starwhale/self/dataset/mnist/g4/g4ytcojtgmzdenrtmftdgyjzgv4w24y.swds/_manifest.yaml' mode='r' encoding='UTF-8'>
  _manifest = yaml.safe_load((_bf.path / DEFAULT_MANIFEST_NAME).open())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/foo/work/repos/starwhale/client/starwhale/core/dataset/model.py:201: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/foo/.cache/starwhale/self/dataset/mnist/me/meztmmlgme3dinrtmftdgyjznzrwy2a.swds/_manifest.yaml' mode='r' encoding='UTF-8'>
  _manifest = yaml.safe_load((_bf.path / DEFAULT_MANIFEST_NAME).open())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [x] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
