### PR TITLE
fix(client): force to close popen stdout for log_check_call 

### DIFF
--- a/client/starwhale/utils/process.py
+++ b/client/starwhale/utils/process.py
@@ -30,6 +30,11 @@ def log_check_call(*args: t.Any, **kwargs: t.Any) -> int:
 
     p.wait()
 
+    try:
+        p.stdout.close()  # type: ignore
+    except Exception as ex:
+        log(f"failed to close stdout:{ex}")
+
     if p.returncode != 0:
         cmd = kwargs.get("args") or args[0]
         e = CalledProcessError(p.returncode, cmd)


### PR DESCRIPTION
## Description
- warning message:
![image](https://user-images.githubusercontent.com/590748/180127117-9cc098fe-b72b-4d7d-aa98-fec4e82a3994.png)
- fixed output:
![image](https://user-images.githubusercontent.com/590748/180127208-5e68e4e2-18be-4329-b5ca-27f34af7af79.png)


## Modules
- [x] Client


## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
