### PR TITLE
chore(runtime): use conda-forage as the default conda channels

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -43,13 +43,6 @@ EOF
     else
         echo -e "\t ** use image builtin pip.conf"
     fi
-
-    if [ "${SW_RESET_CONDA_CONFIG}" = "1" ]; then
-        echo -e "\t ** REMOVE CONDA custom config, use default"
-        mv ~/.condarc ~/.condarc_sw_backup || true
-    else
-        echo -e "\t ** use image builtin condarc"
-    fi
 }
 
 set_pip_cache() {

--- a/client/starwhale/core/job/executor.py
+++ b/client/starwhale/core/job/executor.py
@@ -339,7 +339,6 @@ class EvalExecutor:
             "SW_PYPI_INDEX_URL",
             "SW_PYPI_EXTRA_INDEX_URL",
             "SW_PYPI_TRUSTED_HOST",
-            "SW_RESET_CONDA_CONFIG",
         ):
             if _ee not in _env:
                 continue

--- a/docker/charts/templates/_helpers.tpl
+++ b/docker/charts/templates/_helpers.tpl
@@ -74,13 +74,6 @@ Create the name of the service account to use
 Config mirror environment
 */}}
 {{- define "chart.mirror.env" -}}
-- name: SW_RESET_CONDA_CONFIG
-{{- if .Values.mirror.conda.enabled }}
-  value: "0"
-{{- else }}
-  value: "1"
-{{- end }}
-
 {{- if .Values.mirror.pypi.enabled }}
 - name: SW_PYPI_INDEX_URL
   value: "{{ .Values.mirror.pypi.indexUrl }}"

--- a/docker/charts/values.yaml
+++ b/docker/charts/values.yaml
@@ -57,11 +57,11 @@ nexus3:
 
 # todo self define hostname
 nexus-repository-manager:
-  nexus: 
+  nexus:
     nexusPort: 8081
-    # hostAliases: 
+    # hostAliases:
     #   - nexus.pre.intra.starwhale.ai
-    env: 
+    env:
       - name: NEXUS_SECURITY_RANDOMPASSWORD
         value: "false"
     resources:
@@ -184,8 +184,6 @@ ingress:
   path: /
 
 mirror:
-  conda:
-    enabled: true
   pypi:
     enabled: true
     indexUrl: "http://10.131.0.1:3141/root/pypi-douban/+simple/"

--- a/docker/external/condarc
+++ b/docker/external/condarc
@@ -1,17 +1,5 @@
 channels:
-  - defaults
+  - conda-forge
 show_channel_urls: true
 ssl_verify: false
 default_threads: 8
-default_channels:
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/r
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/msys2
-custom_channels:
-  conda-forge: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
-  msys2: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
-  bioconda: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
-  menpo: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
-  pytorch: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
-  pytorch-lts: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
-  simpleitk: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud


### PR DESCRIPTION
## Description
- https://github.com/star-whale/starwhale/issues/742
- ref: https://conda-forge.org/
  > Anaconda Inc. updated their [terms of service](https://www.anaconda.com/terms-of-service) for anaconda.org channels. Based on the new terms of service you may require a commercial license if you rely on Anaconda’s packaging and distribution. See [Anaconda Commercial Edition FAQ](https://www.anaconda.com/blog/anaconda-commercial-edition-faq) for more information. Your use of any Anaconda channels is governed by their terms of service.

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
