### PR TITLE
chore(docker): remove default pip config

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -17,9 +17,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 #python: python3.7/3.8/3.9, virtualenv, conda
-RUN mkdir /root/.pip
-COPY external/pip.conf /root/.pip/pip.conf
-
 RUN add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update \
     && apt-get install -y python3.7 python3.8 python3.9 python3-pip python3-venv python3.8-venv python3.7-venv python3.9-venv \

--- a/docker/external/pip.conf
+++ b/docker/external/pip.conf
@@ -1,9 +1,0 @@
-[global]
-index-url=https://pypi.doubanio.com/simple/
-extra-index-url=https://pypi.tuna.tsinghua.edu.cn/simple/
-                http://pypi.mirrors.ustc.edu.cn/simple/
-                https://pypi.org/simple
-[install]
-trusted-host=pypi.mirrors.ustc.edu.cn
-             pypi.tuna.tsinghua.edu.cn
-             pypi.doubanio.com


### PR DESCRIPTION
## Description
- Remove the default pip config for China's mainland. Users can config pip config by the `runtime.yaml` or `SW_PYPI_*` env.
- related: https://github.com/star-whale/starwhale/pull/796

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
