### PR TITLE
feat(runtime): add `swcli runtime lock` command

### DIFF
--- a/client/starwhale/base/type.py
+++ b/client/starwhale/base/type.py
@@ -64,12 +64,6 @@ class RuntimeLockFileType:
     CONDA = "conda-sw-lock.yaml"
 
 
-class RuntimeEnvURIType:
-    SHELL = "shell"
-    PATH = "path"
-    NAME = "name"
-
-
 def get_bundle_type_by_uri(uri_type: str) -> str:
     if uri_type == URIType.DATASET:
         return BundleType.DATASET

--- a/client/starwhale/base/type.py
+++ b/client/starwhale/base/type.py
@@ -59,6 +59,17 @@ class RuntimeArtifactType:
     FILES = "files"
 
 
+class RuntimeLockFileType:
+    VENV = "requirements-sw-lock.txt"
+    CONDA = "conda-sw-lock.yaml"
+
+
+class RuntimeEnvURIType:
+    SHELL = "shell"
+    PATH = "path"
+    NAME = "name"
+
+
 def get_bundle_type_by_uri(uri_type: str) -> str:
     if uri_type == URIType.DATASET:
         return BundleType.DATASET

--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -236,4 +236,4 @@ def _lock(
 
     TARGET_DIR: the runtime.yaml and local file dir, default is "."
     """
-    RuntimeTermView.lock(target_dir, disable_auto_inject, env, stdout, include_editable)
+    RuntimeTermView.lock(target_dir, env, disable_auto_inject, stdout, include_editable)

--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -9,6 +9,7 @@ from starwhale.consts import (
     DEFAULT_PAGE_SIZE,
     DEFAULT_PYTHON_VERSION,
 )
+from starwhale.base.type import RuntimeEnvURIType
 
 from .view import get_term_view, RuntimeTermView
 
@@ -202,3 +203,37 @@ def _tag(runtime: str, tags: t.List[str], remove: bool, quiet: bool) -> None:
 @click.argument("workdir")
 def _activate(workdir: str, runtime_yaml: str) -> None:
     RuntimeTermView.activate(workdir, runtime_yaml)
+
+
+@runtime_cmd.command("lock")
+@click.argument("target_dir", default=".")
+@click.option(
+    "--disable-auto-inject",
+    is_flag=True,
+    help="Disable auto update runtime.yaml dependencies field with lock file name, only render the lock file",
+)
+@click.option(
+    "-e",
+    "--env",
+    default=RuntimeEnvURIType.SHELL,
+    help="Detect the python environment name, support:shell, venv name(pyenv), conda name, venv path, conda prefix path, default is current shell",
+)
+@click.option("--stdout", is_flag=True, help="Output lock file content to the stdout")
+@click.option(
+    "--include-editable",
+    is_flag=True,
+    help="Include editable packages, only for venv mode",
+)
+def _lock(
+    target_dir: str,
+    disable_auto_inject: bool,
+    env: str,
+    stdout: bool,
+    include_editable: bool,
+) -> None:
+    """
+    [Only Standalone]Lock Python venv or conda environment
+
+    TARGET_DIR: the runtime.yaml and local file dir, default is "."
+    """
+    RuntimeTermView.lock(target_dir, disable_auto_inject, env, stdout, include_editable)

--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -9,7 +9,6 @@ from starwhale.consts import (
     DEFAULT_PAGE_SIZE,
     DEFAULT_PYTHON_VERSION,
 )
-from starwhale.base.type import RuntimeEnvURIType
 
 from .view import get_term_view, RuntimeTermView
 
@@ -212,12 +211,8 @@ def _activate(workdir: str, runtime_yaml: str) -> None:
     is_flag=True,
     help="Disable auto update runtime.yaml dependencies field with lock file name, only render the lock file",
 )
-@click.option(
-    "-e",
-    "--env",
-    default=RuntimeEnvURIType.SHELL,
-    help="Detect the python environment name, support:shell, venv name(pyenv), conda name, venv path, conda prefix path, default is current shell",
-)
+@click.option("-n", "--name", default="", help="conda name")
+@click.option("-p", "--prefix", default="", help="conda or virtualenv prefix path")
 @click.option("--stdout", is_flag=True, help="Output lock file content to the stdout")
 @click.option(
     "--include-editable",
@@ -227,7 +222,8 @@ def _activate(workdir: str, runtime_yaml: str) -> None:
 def _lock(
     target_dir: str,
     disable_auto_inject: bool,
-    env: str,
+    name: str,
+    prefix: str,
     stdout: bool,
     include_editable: bool,
 ) -> None:
@@ -236,4 +232,6 @@ def _lock(
 
     TARGET_DIR: the runtime.yaml and local file dir, default is "."
     """
-    RuntimeTermView.lock(target_dir, env, disable_auto_inject, stdout, include_editable)
+    RuntimeTermView.lock(
+        target_dir, name, prefix, disable_auto_inject, stdout, include_editable
+    )

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -769,12 +769,12 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             mode = load_yaml(runtime_fpath).get("mode", PythonRunEnv.VENV)
 
         if env == RuntimeEnvURIType.SHELL:
-            _current_py_env = guess_current_py_env()
-            if mode and _current_py_env != mode:
+            _guess_mode = guess_current_py_env()
+            if mode and _guess_mode != mode:
                 raise PythonEnvironmentError(
-                    f"runtime.yaml mode:{mode}, shell python env:{_current_py_env}"
+                    f"runtime.yaml mode:{mode}, shell python env:{_guess_mode}"
                 )
-            mode = mode or _current_py_env
+            mode = mode or _guess_mode
             env_prefix = get_base_prefix(mode)
         elif os.path.isdir(env):
             if os.path.exists(os.path.join(env, "pyvenv.cfg")):

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -56,12 +56,12 @@ class RuntimeTermView(BaseTermView):
     def lock(
         cls,
         target_dir: str,
-        disable_auto_inject: bool,
         env: str,
-        stdout: bool,
-        include_editable: bool,
+        disable_auto_inject: bool = False,
+        stdout: bool = False,
+        include_editable: bool = False,
     ) -> None:
-        Runtime.lock(target_dir, disable_auto_inject, env, stdout, include_editable)
+        Runtime.lock(target_dir, env, disable_auto_inject, stdout, include_editable)
 
     @classmethod
     def build(

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -53,6 +53,17 @@ class RuntimeTermView(BaseTermView):
         Runtime.activate(workdir, yaml_name)
 
     @classmethod
+    def lock(
+        cls,
+        target_dir: str,
+        disable_auto_inject: bool,
+        env: str,
+        stdout: bool,
+        include_editable: bool,
+    ) -> None:
+        Runtime.lock(target_dir, disable_auto_inject, env, stdout, include_editable)
+
+    @classmethod
     def build(
         cls,
         workdir: str,

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -56,12 +56,20 @@ class RuntimeTermView(BaseTermView):
     def lock(
         cls,
         target_dir: str,
-        env: str,
+        env_name: str = "",
+        prefix_path: str = "",
         disable_auto_inject: bool = False,
         stdout: bool = False,
         include_editable: bool = False,
     ) -> None:
-        Runtime.lock(target_dir, env, disable_auto_inject, stdout, include_editable)
+        Runtime.lock(
+            target_dir,
+            env_name,
+            prefix_path,
+            disable_auto_inject,
+            stdout,
+            include_editable,
+        )
 
     @classmethod
     def build(

--- a/client/starwhale/utils/__init__.py
+++ b/client/starwhale/utils/__init__.py
@@ -172,7 +172,7 @@ def sort_obj_list(data: t.Sequence, orders: t.List[Order]) -> t.Any:
     return sorted(data, key=cmp_to_key(compare))
 
 
-def load_yaml(path: t.Union[str, Path]):
+def load_yaml(path: t.Union[str, Path]) -> t.Any:
     """load_yaml loads yaml from path, it may raise exception such as yaml.YAMLError"""
     with open(path) as f:
         return yaml.safe_load(f)

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -570,6 +570,14 @@ def get_user_runtime_python_bin(py_env: str) -> str:
     return _py_bin
 
 
+def check_valid_venv_prefix(prefix: t.Union[str, Path]) -> bool:
+    return (Path(prefix) / "pyvenv.cfg").exists()
+
+
+def check_valid_conda_prefix(prefix: t.Union[str, Path]) -> bool:
+    return (Path(prefix) / "conda-meta").exists()
+
+
 def get_base_prefix(py_env: str) -> str:
     if py_env == PythonRunEnv.VENV:
         _path = os.environ.get(ENV_VENV, "")


### PR DESCRIPTION
## Description
- issues: https://github.com/star-whale/starwhale/issues/741  https://github.com/star-whale/starwhale/issues/764
- support freeze environment: `shell`, `conda env name`, `conda prefix`, `venv dir` 

## Feature Show
- current shell + venv
![image](https://user-images.githubusercontent.com/590748/180433374-150f90e5-3f24-47ac-94a0-72cf91cafe4d.png)

- current shell + conda
![image](https://user-images.githubusercontent.com/590748/180432881-d0df20cf-ac63-400a-b057-79e779bb362d.png)

- name + conda
![image](https://user-images.githubusercontent.com/590748/180433035-3c86c07a-1e32-4dac-a577-c067f3adb636.png)

- prefix + conda
![image](https://user-images.githubusercontent.com/590748/180433127-e3b839fb-6c27-462e-a62d-1010d08d297e.png)

- prefix + venv
![image](https://user-images.githubusercontent.com/590748/180433470-a8a64ea2-c068-4dd4-a6ef-8be736090cb1.png)


## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
