### PR TITLE
feat(runtime): add runtime quickstart command, goodbye to create command

### DIFF
--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -26,24 +26,46 @@ def runtime_cmd(ctx: click.Context) -> None:
 @runtime_cmd.command("quickstart")
 @click.argument("workdir", type=click.Path(exists=True, file_okay=False))
 @click.option("-f", "--force", is_flag=True, help="Force to quickstart")
-def _quickstart(workdir: str, force: bool) -> None:
+@click.option(
+    "-p",
+    "--python-env",
+    prompt="Choose your python env",
+    type=click.Choice([PythonRunEnv.VENV, PythonRunEnv.CONDA]),
+    default=PythonRunEnv.VENV,
+    show_choices=True,
+    show_default=True,
+)
+@click.option(
+    "-n",
+    "--name",
+    default="",
+    prompt="Please enter Starwhale Runtime name",
+)
+@click.option(
+    "-c",
+    "--create-env",
+    prompt="Do you want to create isolated python environment",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+def _quickstart(
+    workdir: str, force: bool, python_env: str, name: str, create_env: bool
+) -> None:
     """[Only Standalone]Quickstart Starwhale Runtime
 
     Args:
         workdir (Path): runtime workdir
     """
     p_workdir = Path(workdir).absolute()
-    name = click.prompt("Please enter Starwhale Runtime name", default=p_workdir.name)
-    mode = click.prompt("Use venv or conda?", default=PythonRunEnv.VENV)
-    create_env = click.confirm(
-        f"Do you want to create {mode} isolated python environment?", default=False
-    )
-
     if not p_workdir.exists():
         raise NotFoundError(workdir)
 
+    name = name or p_workdir.name
     # TODO: support quickstart runtime from the existed runtime uri (local or remote)
-    RuntimeTermView.quickstart_from_ishell(p_workdir, name, mode, create_env, force)
+    RuntimeTermView.quickstart_from_ishell(
+        p_workdir, name, python_env, create_env, force
+    )
 
 
 @runtime_cmd.command(

--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -1,4 +1,5 @@
 import typing as t
+from pathlib import Path
 
 import click
 
@@ -7,9 +8,9 @@ from starwhale.consts import (
     DefaultYAMLName,
     DEFAULT_PAGE_IDX,
     DEFAULT_PAGE_SIZE,
-    DEFAULT_PYTHON_VERSION,
 )
 from starwhale.base.type import RuntimeLockFileType
+from starwhale.utils.error import NotFoundError
 
 from .view import get_term_view, RuntimeTermView
 
@@ -22,29 +23,27 @@ def runtime_cmd(ctx: click.Context) -> None:
     ctx.obj = get_term_view(ctx.obj)
 
 
-@runtime_cmd.command(
-    "create",
-    help="[ONLY Standalone]Create a python runtime, which help user create a easy-to-use and unambiguous environment with venv or conda",
-)
-@click.argument("workdir")
-@click.option("-n", "--name", required=True, help="Runtime name")
-@click.option(
-    "-m",
-    "--mode",
-    type=click.Choice([PythonRunEnv.CONDA, PythonRunEnv.VENV]),
-    default=PythonRunEnv.VENV,
-    help="Runtime mode",
-)
-@click.option("--python", default=DEFAULT_PYTHON_VERSION, help="Python Version")
-@click.option("-f", "--force", is_flag=True, help="Force to create runtime")
-def _create(workdir: str, name: str, mode: str, python: str, force: bool) -> None:
-    RuntimeTermView.create(
-        workdir=workdir,
-        name=name,
-        mode=mode,
-        python_version=python,
-        force=force,
+@runtime_cmd.command("quickstart")
+@click.argument("workdir", type=click.Path(exists=True, file_okay=False))
+@click.option("-f", "--force", is_flag=True, help="Force to quickstart")
+def _quickstart(workdir: str, force: bool) -> None:
+    """[Only Standalone]Quickstart Starwhale Runtime
+
+    Args:
+        workdir (Path): runtime workdir
+    """
+    p_workdir = Path(workdir).absolute()
+    name = click.prompt("Please enter Starwhale Runtime name", default=p_workdir.name)
+    mode = click.prompt("Use venv or conda?", default=PythonRunEnv.VENV)
+    create_env = click.confirm(
+        f"Do you want to create {mode} isolated python environment?", default=False
     )
+
+    if not p_workdir.exists():
+        raise NotFoundError(workdir)
+
+    # TODO: support quickstart runtime from the existed runtime uri (local or remote)
+    RuntimeTermView.quickstart_from_ishell(p_workdir, name, mode, create_env, force)
 
 
 @runtime_cmd.command(

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -3,19 +3,13 @@ import typing as t
 from pathlib import Path
 
 from starwhale.utils import console, pretty_bytes, in_production
-from starwhale.consts import (
-    PythonRunEnv,
-    DefaultYAMLName,
-    DEFAULT_PAGE_IDX,
-    DEFAULT_PAGE_SIZE,
-    DEFAULT_PYTHON_VERSION,
-)
+from starwhale.consts import DefaultYAMLName, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType, InstanceType
 from starwhale.base.view import BaseTermView
 from starwhale.core.runtime.store import RuntimeStorage
 
-from .model import Runtime
+from .model import Runtime, StandaloneRuntime
 
 
 class RuntimeTermView(BaseTermView):
@@ -131,23 +125,19 @@ class RuntimeTermView(BaseTermView):
         return _data, _pager
 
     @classmethod
-    def create(
+    def quickstart_from_ishell(
         cls,
-        workdir: str,
+        workdir: t.Union[Path, str],
         name: str,
-        python_version: str = DEFAULT_PYTHON_VERSION,
-        mode: str = PythonRunEnv.VENV,
+        mode: str,
+        create_env: bool = False,
         force: bool = False,
     ) -> None:
-        console.print(f":construction: start to create runtime[{name}] environment...")
-        Runtime.create(
-            workdir,
-            name,
-            python_version=python_version,
-            mode=mode,
-            force=force,
+        console.print(
+            f":construction: quickstart Starwhale Runtime[{name}] environment..."
         )
-        console.print(":clap: python runtime environment is ready to use :tada:")
+        StandaloneRuntime.quickstart_from_ishell(workdir, name, mode, create_env, force)
+        console.print(":clap: Starwhale Runtime environment is ready to use :tada:")
 
     @classmethod
     def restore(cls, target: str) -> None:

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -304,7 +304,7 @@ def check_python_interpreter_consistency(mode: str) -> t.Tuple[bool, str, str]:
     )
     _ok = ep_base_prefix == sys.base_prefix
     if not _ok:
-        cur_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        cur_version = get_python_version()
         user_version = get_user_python_version(mode)
         if not user_version.startswith(cur_version):
             logger.error(
@@ -561,7 +561,7 @@ def create_python_env(
 ) -> str:
 
     if mode == PythonRunEnv.VENV:
-        venvdir = workdir / "venv"
+        venvdir = workdir / ".venv"
         if venvdir.exists() and not force:
             raise ExistedError(str(venvdir))
 
@@ -574,6 +574,10 @@ def create_python_env(
         return name
     else:
         raise NoSupportError(mode)
+
+
+def get_python_version() -> str:
+    return f"{sys.version_info.major}.{sys.version_info.minor}"
 
 
 def get_python_version_by_bin(py_bin: str) -> str:

--- a/scripts/run_demo.sh
+++ b/scripts/run_demo.sh
@@ -33,8 +33,8 @@ if ! in_github_action; then
   cp -rf ./client "$WORK_DIR"
   cp -rf ./example "$WORK_DIR"
   cp -rf ./README.md "$WORK_DIR"
-  rm -rf "$WORK_DIR/venv"
-  rm -rf "$WORK_DIR/example/mnist/venv"
+  rm -rf "$WORK_DIR/.venv"
+  rm -rf "$WORK_DIR/example/mnist/.venv"
   rm -f "$WORK_DIR/example/mnist/runtime.yaml"
 
   # use a separate data & config dir
@@ -47,16 +47,16 @@ fi
 echo "start test in $WORK_DIR"
 cd "$WORK_DIR" || exit
 # shellcheck source=/dev/null
-python3 -m venv venv && . venv/bin/activate && pip install --upgrade pip
+python3 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip
 cd "$WORK_DIR/client" || exit
 
 echo "install swcli"
 make install-sw
 
 cd "$WORK_DIR/example/mnist" || exit
-swcli runtime create -n pytorch-mnist -m venv --python $PYTHON_VERSION .
+swcli runtime quickstart . --python-env=venv --create-env --name pytorch-mnist
 # shellcheck source=/dev/null
-. venv/bin/activate
+. .venv/bin/activate
 
 python3 -m pip install -r requirements.txt
 


### PR DESCRIPTION
## Description
- add `runtime quickstart` command that renders the runtime.yaml with the interactive shell
  - ![image](https://user-images.githubusercontent.com/590748/181572561-1d560efb-e9e1-4dbd-9e2a-bb5ca68fcf88.png)
- remove create command
- related: https://github.com/star-whale/starwhale/issues/751

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
