### PR TITLE
 feat(runtime): support runtime-uri argument for job create command

### DIFF
--- a/client/starwhale/api/_impl/model.py
+++ b/client/starwhale/api/_impl/model.py
@@ -16,7 +16,7 @@ import dill
 import loguru
 import jsonlines
 
-from starwhale.utils import now_str, pretty_bytes, in_production
+from starwhale.utils import now_str, in_production
 from starwhale.consts import CURRENT_FNAME, DEFAULT_INPUT_JSON_FNAME
 from starwhale.utils.fs import ensure_dir, ensure_file
 from starwhale.utils.log import StreamWrapper
@@ -273,11 +273,6 @@ class PipelineHandler(metaclass=ABCMeta):
     @_record_status  # type: ignore
     def _starwhale_internal_run_ppl(self) -> None:
         for data, label in self._data_loader:
-            self._sw_logger.info(
-                f"[{data.idx}]data-label loaded, data size:{pretty_bytes(data.data_size)}, "
-                f"label size:{pretty_bytes(label.data_size)} ,batch:{data.batch_size}"
-            )
-
             if data.idx != label.idx:
                 msg = (
                     f"data index[{data.idx}] is not equal label index [{label.idx}], "
@@ -311,7 +306,6 @@ class PipelineHandler(metaclass=ABCMeta):
                     raise
             else:
                 exception = None
-                self._sw_logger.info(f"[{data.idx}] data handle -> success")
 
             self._do_record(data, label, exception, *pred)
 

--- a/client/starwhale/core/job/executor.py
+++ b/client/starwhale/core/job/executor.py
@@ -71,7 +71,7 @@ class EvalExecutor:
         self.gencmd = gencmd
         self.use_docker = use_docker
 
-        self._version = ""
+        self._version = gen_uniq_version(self.name)
         self._manifest: t.Dict[str, t.Any] = {"status": _STATUS.START}
         self._workdir = Path()
         self._model_dir = Path()
@@ -133,8 +133,6 @@ class EvalExecutor:
     def _gen_version(self) -> None:
         # TODO: abstract base class or mixin class for swmp/swds/
         logger.info("[step:version]create eval job version...")
-        if not self._version:
-            self._version = gen_uniq_version(self.name)
         self._manifest["version"] = self._version
         self._manifest["created_at"] = now_str()  # type: ignore
         logger.info(f"[step:version]eval job version is {self._version}")

--- a/client/starwhale/core/runtime/process.py
+++ b/client/starwhale/core/runtime/process.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import typing as t
+import tempfile
+from pathlib import Path
+from functools import partial
+
+import dill
+
+from starwhale.consts import PythonRunEnv
+from starwhale.base.uri import URI
+from starwhale.base.type import URIType, InstanceType
+from starwhale.utils.venv import guess_python_env_mode
+from starwhale.utils.error import NotFoundError, NoSupportError
+from starwhale.utils.process import check_call
+
+from .model import StandaloneRuntime
+
+
+class Process:
+
+    EnvInActivatedProcess = "SW_RUNTIME_ACTIVATED_PROCESS"
+
+    def __init__(
+        self,
+        prefix_path: Path,
+        target: t.Callable,
+        args: t.Tuple = (),
+        kwargs: t.Dict[str, t.Any] = {},
+    ) -> None:
+        self._prefix_path = prefix_path
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs
+        self._mode = guess_python_env_mode(prefix_path)
+
+    def __str__(self) -> str:
+        return f"process: {self._target} in prefix path {self._prefix_path}"
+
+    def __repr__(self) -> str:
+        return f"process: {self._target} with args:{self._args}, kwargs:{self._kwargs} in runtime {self._prefix_path}"
+
+    def run(self) -> None:
+        _, pkl_path = tempfile.mkstemp(
+            prefix="starwhale-runtime-process-", suffix="pkl"
+        )
+        partial_target = partial(self._target, *self._args, **self._kwargs)
+        dill.dump(partial_target, pkl_path)
+
+        cmd = [
+            self._get_activate_cmd(),
+            f"python3 -c 'import dill; dill.load(\"{pkl_path}\")()'",
+        ]
+        check_call(
+            ["bash", "-c", " && ".join(cmd)], env={self.EnvInActivatedProcess: "1"}
+        )
+
+    def _get_activate_cmd(self) -> str:
+        # TODO: support windows platform
+        if self._mode == PythonRunEnv.VENV:
+            _ap = self._prefix_path / "bin/activate"
+            return f"source {_ap.absolute()}"
+        elif self._mode == PythonRunEnv.CONDA:
+            return f"source activate {self._prefix_path.absolute()}"
+        else:
+            raise NoSupportError(f"get activate command for mode: {self._mode}")
+
+    @classmethod
+    def from_runtime_uri(
+        cls,
+        uri: t.Union[str, URI],
+        target: t.Callable,
+        args: t.Tuple = (),
+        kwargs: t.Dict[str, t.Any] = {},
+    ) -> Process:
+        _uri: URI
+        if isinstance(uri, str):
+            _uri = URI(uri, expected_type=URIType.RUNTIME)
+        else:
+            _uri = uri
+        # TODO: support cloud runtime uri
+        # TODO: auto extract and restore runtime uri
+        if _uri.instance_type != InstanceType.STANDALONE:
+            raise NoSupportError("run process with cloud instance uri")
+
+        runtime = StandaloneRuntime(_uri)
+        venv_prefix = runtime.store.export_dir / PythonRunEnv.VENV
+        conda_prefix = runtime.store.export_dir / PythonRunEnv.CONDA
+
+        prefix = Path()
+        if venv_prefix.exists():
+            prefix = venv_prefix
+        elif conda_prefix.exists():
+            prefix = conda_prefix
+        else:
+            raise NotFoundError(f"{runtime.store.export_dir} cannot find valid env dir")
+
+        return cls(
+            prefix_path=prefix,
+            target=target,
+            args=args,
+            kwargs=kwargs,
+        )

--- a/client/starwhale/utils/process.py
+++ b/client/starwhale/utils/process.py
@@ -21,9 +21,9 @@ def log_check_call(*args: t.Any, **kwargs: t.Any) -> int:
     while True:
         fds, _, _ = select([p.stdout], [], [], 30)  # timeout 30s
         for fd in fds:
-            line = fd.readline()
-            log(line.rstrip())
-            output.append(line)
+            for line in fd.readlines():
+                log(line.rstrip())
+                output.append(line)
         else:
             if p.poll() is not None:
                 break

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -627,6 +627,15 @@ def check_valid_conda_prefix(prefix: t.Union[str, Path]) -> bool:
     return (Path(prefix) / "conda-meta").exists()
 
 
+def guess_python_env_mode(prefix: t.Union[str, Path]) -> str:
+    if check_valid_venv_prefix(prefix):
+        return PythonRunEnv.VENV
+    elif check_valid_conda_prefix(prefix):
+        return PythonRunEnv.CONDA
+    else:
+        raise NoSupportError(f"guess python env from paht: {prefix}")
+
+
 def get_base_prefix(py_env: str) -> str:
     if py_env == PythonRunEnv.VENV:
         _path = os.environ.get(ENV_VENV, "")

--- a/client/tests/core/test_runtime_process.py
+++ b/client/tests/core/test_runtime_process.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from starwhale.utils.fs import empty_dir, ensure_dir, ensure_file
+from starwhale.core.runtime.process import Process
+
+
+class _SimpleTask:
+    def __init__(self, name: str, dest_dir: Path) -> None:
+        self.name = name
+        self.dest_dir = dest_dir
+
+    def run(self, id: int, verbose: bool = False) -> None:
+        msg = f"start to run simpleTask:{self.name}, id:{id}..."
+        print(msg)
+        ensure_dir(self.dest_dir)
+        ensure_file(self.dest_dir / self.name, content=f"{id}")
+        assert os.environ.get(Process.EnvInActivatedProcess) == "1"
+
+        if verbose:
+            ensure_file(
+                self.dest_dir / f"{self.name}.verbose", content=f"verbose info: {msg}"
+            )
+
+
+class RuntimeProcessTestCase(TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="starwhale-ut-"))
+        ensure_dir(self.root)
+
+    def tearDown(self) -> None:
+        empty_dir(self.root)
+
+    def test_venv_prefix_patch(self) -> None:
+        prefix_path = self.root / "venv"
+        ensure_dir(prefix_path)
+        ensure_file(prefix_path / "pyvenv.cfg", content="venv")
+        pybin = f"{prefix_path}/bin/python3"
+
+        patcher = patch("starwhale.core.runtime.process.check_call")
+        m_call = patcher.start()
+
+        st = _SimpleTask(name="venv", dest_dir=self.root / "task")
+        p = Process(prefix_path=prefix_path, target=st.run, args=(1,))
+        p.run()
+
+        assert m_call.call_args[0][0][0:2] == [
+            "bash",
+            "-c",
+        ]
+        assert m_call.call_args[0][0][2].startswith(
+            f"source {prefix_path}/bin/activate && {prefix_path}/bin/python3 -c"
+        )
+        patcher.stop()
+
+        ensure_dir(prefix_path / "bin")
+        ensure_file(prefix_path / "bin" / "activate", content="export SW_ACTIVATE=1")
+
+        os.symlink(sys.executable, str(pybin))
+
+        st = _SimpleTask(name="venv", dest_dir=self.root / "task")
+        p = Process(prefix_path=prefix_path, target=st.run, args=(1,))
+        p.run()
+
+        assert (self.root / "task" / "venv").exists()
+        assert not (self.root / "task" / "venv.verbose").exists()
+        assert (self.root / "task" / "venv").read_text() == "1"
+
+        st = _SimpleTask(name="venv", dest_dir=self.root / "task")
+        p = Process(
+            prefix_path=prefix_path, target=st.run, args=(1,), kwargs={"verbose": True}
+        )
+        p.run()
+        assert (self.root / "task" / "venv.verbose").exists()


### PR DESCRIPTION
## Description
- add Runtime Process Class: auto activate runtime in another new process
- support runtime-uri argument for job create command in the non-docker environment
- related: https://github.com/star-whale/starwhale/issues/752

## Feature Show
![runtime-activate](https://user-images.githubusercontent.com/590748/182159614-d00ea15f-dc67-4180-9624-f1f7236c8974.gif)


## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
