### PR TITLE
feat(controller): support injecting host path config for pip cache

### DIFF
--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -20,6 +20,7 @@ sw:
   infra:
     k8s:
       name-space: ${SW_K8S_NAME_SPACE:default}
+      host-path-for-cache: ${SW_K8S_HOST_PATH_FOR_CACHE:/mnt/data}
   storage:
     path-prefix: ${SW_STORAGE_PREFIX:StarWhale}
     s3-config:


### PR DESCRIPTION
## Description
Support inject `SW_K8S_HOST_PATH_FOR_CACHE` env for configuring job's pip cache host path dir

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
