### PR TITLE
feat(client): auto active env in bash/fish/zsh when executing runtime active cmd

### DIFF
--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -87,8 +87,20 @@ def _quickstart_from_uri(
     default=False,
     show_default=True,
 )
+@click.option(
+    "-i",
+    "--interactive",
+    is_flag=True,
+    default=False,
+    help="Try entering the interactive shell at the end",
+)
 def _quickstart(
-    workdir: str, force: bool, python_env: str, name: str, create_env: bool
+    workdir: str,
+    force: bool,
+    python_env: str,
+    name: str,
+    create_env: bool,
+    interactive: bool,
 ) -> None:
     """[Only Standalone]Quickstart Starwhale Runtime
 
@@ -99,7 +111,7 @@ def _quickstart(
     p_workdir = Path(workdir).absolute()
     name = name or p_workdir.name
     RuntimeTermView.quickstart_from_ishell(
-        p_workdir, name, python_env, create_env, force
+        p_workdir, name, python_env, create_env, force, interactive
     )
 
 

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -803,6 +803,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         mode: str,
         create_env: bool = False,
         force: bool = False,
+        interactive: bool = False,
     ) -> None:
         workdir = Path(workdir).absolute()
         console.print(f":printer: render runtime.yaml @ {workdir}")
@@ -833,7 +834,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             elif mode == PythonRunEnv.CONDA:
                 conda_install_req(env_name=_id, req=sw_pkg, enable_pre=True)
 
-            activate_python_env(mode=mode, identity=_id)
+            activate_python_env(mode=mode, identity=_id, interactive=interactive)
 
     @classmethod
     def activate(cls, path: str = "", uri: str = "") -> None:
@@ -854,7 +855,9 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         else:
             raise Exception("No uri or path to activate")
 
-        activate_python_env(mode=mode, identity=str(prefix_path.resolve()))
+        activate_python_env(
+            mode=mode, identity=str(prefix_path.resolve()), interactive=True
+        )
 
     @classmethod
     def lock(

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -156,11 +156,14 @@ class RuntimeTermView(BaseTermView):
         mode: str,
         create_env: bool = False,
         force: bool = False,
+        interactive: bool = False,
     ) -> None:
         console.print(
             f":construction: quickstart Starwhale Runtime[{name}] environment..."
         )
-        StandaloneRuntime.quickstart_from_ishell(workdir, name, mode, create_env, force)
+        StandaloneRuntime.quickstart_from_ishell(
+            workdir, name, mode, create_env, force, interactive
+        )
         console.print(":clap: Starwhale Runtime environment is ready to use :tada:")
 
     @classmethod


### PR DESCRIPTION
## Description
Fixes #851 

https://user-images.githubusercontent.com/3217223/183001459-0bddaddb-8ddc-4b73-8525-d499bcd70aa9.mp4

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
