### PR TITLE
fix(ci): remove starwhale arch matrix build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,6 @@ jobs:
     strategy:
       matrix:
         cuda_version: ["", "11.3", "11.3-cudnn8", "11.4", "11.4-cudnn8", "11.5", "11.5-cudnn8", "11.6", "11.6-cudnn8", "11.7"]
-        arch: ["linux/arm64", "linux/amd64"]
 
     steps:
       - uses: actions/checkout@v3
@@ -103,9 +102,9 @@ jobs:
           PYPI_RELEASE_VERSION: ${{ steps.tag.outputs.tag }}
         run: |
           if [ "${{matrix.cuda_version}}" = "" ]; then
-            make build-release-starwhale arch=${{matrix.arch}}
+            make build-release-starwhale
           else
-            make build-release-starwhale-cuda arch=${{matrix.arch}} version=${{matrix.cuda_version}}
+            make build-release-starwhale-cuda version=${{matrix.cuda_version}}
           fi
 
   server-image-release:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -50,7 +50,7 @@ define push-image
 endef
 
 define build-starwhale
-	docker buildx build --platform $(3) \
+	docker buildx build --platform linux/arm64,linux/amd64 \
 		--build-arg BASE_IMAGE=$(1) \
 		--build-arg SW_VERSION=$(PYPI_RELEASE_VERSION) \
 		--build-arg HTTP_PROXY=$(HTTP_PROXY) --build-arg HTTPS_PROXY=$(HTTPS_PROXY) \
@@ -66,7 +66,7 @@ define build-starwhale
 endef
 
 define build-starwhale-cuda
-	$(call build-starwhale,${GHCR_IO_REPO}/cuda:$(1)-base${FIXED_VERSION_BASE_IMAGE},-cuda$(1),$(2))
+	$(call build-starwhale,${GHCR_IO_REPO}/cuda:$(1)-base${FIXED_VERSION_BASE_IMAGE},-cuda$(1))
 endef
 
 
@@ -89,10 +89,10 @@ build-release-base:
 		--push -f Dockerfile.base .
 
 build-release-starwhale:
-	$(call build-starwhale,${GHCR_IO_REPO}/base:${FIXED_VERSION_BASE_IMAGE},,$(arch))
+	$(call build-starwhale,${GHCR_IO_REPO}/base:${FIXED_VERSION_BASE_IMAGE},)
 
 build-release-starwhale-cuda:
-	$(call build-starwhale-cuda,$(version),$(arch))
+	$(call build-starwhale-cuda,$(version))
 
 build-cuda:
 	cd cuda; python3 render.py --all --push --base-image $(GHCR_BASE_IMAGE)


### PR DESCRIPTION
## Description
Docker buildx does not support parallel upload of the different arch images.
![image](https://user-images.githubusercontent.com/590748/183357070-7c4283d9-cb09-4a75-ac0d-a176509d8716.png)
only one arch image.

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
