### PR TITLE
bug(runtime): fix runtime activate shell bin path

### DIFF
--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shutil
 import typing as t
 import tarfile
 import platform
@@ -560,6 +561,9 @@ def activate_python_env(mode: str, identity: str, interactive: bool) -> None:
             _name, _bin = shellingham.detect_shell()
         except shellingham.ShellDetectionFailure:
             _name, _bin = "", ""
+
+        if not _bin.startswith("/") or _name == _bin:
+            _bin = shutil.which(_name) or _bin
 
         if _name == "zsh":
             # https://zsh.sourceforge.io/Intro/intro_3.html


### PR DESCRIPTION
## Description
in SHLVL 2, the `_bin` is the wrong path.
![image](https://user-images.githubusercontent.com/590748/183397218-b00471ed-2e22-4bd7-8c36-ddff45d48003.png)
![image](https://user-images.githubusercontent.com/590748/183397062-c29d35ab-1480-462f-a474-52d47131b7cf.png)
 

## Modules
- [x] Client

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
