### PR TITLE
enhance(datastore): tune datastore storage dir by swcli config

### DIFF
--- a/client/starwhale/utils/config.py
+++ b/client/starwhale/utils/config.py
@@ -109,20 +109,8 @@ class SWCliConfigMixed:
         return Path(self._config["storage"]["root"])
 
     @property
-    def workdir(self) -> Path:
-        return self.rootdir / "workdir"
-
-    @property
-    def pkgdir(self) -> Path:
-        return self.rootdir / "pkg"
-
-    @property
-    def dataset_dir(self) -> Path:
-        return self.rootdir / "dataset"
-
-    @property
-    def eval_run_dir(self) -> Path:
-        return self.rootdir / "run" / "eval"
+    def datastore_dir(self) -> Path:
+        return self.rootdir / ".datastore"
 
     @property
     def sw_remote_addr(self) -> str:

--- a/client/tests/sdk/test_base.py
+++ b/client/tests/sdk/test_base.py
@@ -1,14 +1,25 @@
 import os
-import shutil
 import tempfile
 import unittest
+
+from starwhale.utils import config as sw_config
+from starwhale.consts import ENV_SW_CLI_CONFIG, ENV_SW_LOCAL_STORAGE
+from starwhale.utils.fs import empty_dir, ensure_dir
 
 
 class BaseTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        self.root = os.path.join(tempfile.gettempdir(), "datastore_test")
-        os.makedirs(self.root, exist_ok=True)
-        os.environ["SW_ROOT_PATH"] = self.root
+        self._test_local_storage = tempfile.mkdtemp(prefix="sw-test-mock-")
+        os.environ[ENV_SW_CLI_CONFIG] = os.path.join(
+            self._test_local_storage, "config.yaml"
+        )
+        os.environ[ENV_SW_LOCAL_STORAGE] = self._test_local_storage
+        sw_config._config = {}
+
+        self.root = str(sw_config.SWCliConfigMixed().datastore_dir)
+        ensure_dir(self.root)
 
     def tearDown(self) -> None:
-        shutil.rmtree(self.root)
+        empty_dir(self._test_local_storage)
+        os.environ.pop(ENV_SW_CLI_CONFIG, "")
+        os.environ.pop(ENV_SW_LOCAL_STORAGE, "")

--- a/client/tests/sdk/test_data_store.py
+++ b/client/tests/sdk/test_data_store.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 from typing import Dict, List
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 import pyarrow as pa  # type: ignore
@@ -940,13 +941,16 @@ class TestLocalDataStore(BaseTestCase):
 
 class TestTableWriter(BaseTestCase):
     def setUp(self) -> None:
+        self.mock_atexit = patch("starwhale.api._impl.data_store.atexit", MagicMock())
+        self.mock_atexit.start()
+
         super().setUp()
-        os.environ["SW_ROOT_PATH"] = self.root
         self.writer = data_store.TableWriter("p/test", "k")
 
     def tearDown(self) -> None:
         self.writer.close()
         super().tearDown()
+        self.mock_atexit.stop()
 
     def test_insert_and_delete(self) -> None:
         with self.assertRaises(RuntimeError, msg="no key"):

--- a/client/tests/sdk/test_wrapper.py
+++ b/client/tests/sdk/test_wrapper.py
@@ -5,7 +5,7 @@ from starwhale.api._impl import wrapper, data_store
 from .test_base import BaseTestCase
 
 
-class TestEvaluaiton(BaseTestCase):
+class TestEvaluation(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         os.environ["SW_PROJECT"] = "test"


### PR DESCRIPTION
## Description
- replace `SW_ROOT_PATH` env with `SWCliConfigMixed` class for fetching datastore dir
- patch `atexit` in test

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
