### PR TITLE
chore(controller): use offical awscli to support arm64 arch device

### DIFF
--- a/server/controller/src/main/resources/template/job.yaml
+++ b/server/controller/src/main/resources/template/job.yaml
@@ -13,7 +13,7 @@ spec:
       initContainers:
         - name: data-provider
           imagePullPolicy: IfNotPresent
-          image: anigeo/awscli:latest
+          image: amazon/aws-cli:2.7.25
           volumeMounts:
             - mountPath: /opt/starwhale
               name: data
@@ -56,7 +56,7 @@ spec:
       containers:
         - name: result-uploader
           imagePullPolicy: IfNotPresent
-          image: anigeo/awscli:latest
+          image: amazon/aws-cli:2.7.25
           volumeMounts:
             - mountPath: /opt/starwhale
               name: data


### PR DESCRIPTION
## Description
Use offical awscli to support arm64 arch device

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
