### PR TITLE
bug(dataset): fix dataset label size calculate

### DIFF
--- a/client/starwhale/api/_impl/dataset/builder.py
+++ b/client/starwhale/api/_impl/dataset/builder.py
@@ -378,7 +378,7 @@ class UserRawBuildExecutor(BaseBuildExecutor):
             )
 
             total_data_size += data_size
-            total_label_size += len(label)
+            total_label_size += sys.getsizeof(label)
             increased_rows += 1
 
         self._copy_files(map_path_sign)

--- a/example/mnist/dataset.yaml
+++ b/example/mnist/dataset.yaml
@@ -3,8 +3,8 @@ name: mnist
 data_dir: data
 data_filter: "t10k-image*"
 label_filter: "t10k-label*"
-process: mnist.process:DataSetProcessExecutor
-#process: mnist.process:RawDataSetProcessExecutor
+#process: mnist.process:DataSetProcessExecutor
+process: mnist.process:RawDataSetProcessExecutor
 #process: mnist.process:LinkRawDataSetProcessExecutor
 
 desc: MNIST data and label test dataset


### PR DESCRIPTION
## Description
- fix label size for dataset builder
- update mnist example default process

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [x] Python-SDK
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
