### PR TITLE
fix(controller): fix the problem of generating empty WAL files when DataStore uses object storage

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -325,7 +325,7 @@ public class RuntimeService {
             if(dsFile.getSize() >= Integer.MAX_VALUE){
                 is = new LargeFileInputStream(inputStream, dsFile.getSize());
             }
-            storageAccessService.put(String.format(FORMATTER_STORAGE_PATH, runtimePath, dsFile.getOriginalFilename()), is);
+            storageAccessService.put(String.format(FORMATTER_STORAGE_PATH, runtimePath, dsFile.getOriginalFilename()), is, dsFile.getSize());
         } catch (IOException e) {
             log.error("upload runtime failed {}",uploadRequest.getRuntime(),e);
             throw new StarWhaleApiException(new SWProcessException(ErrorType.STORAGE),

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/upload/SwdsUploader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/upload/SwdsUploader.java
@@ -169,7 +169,7 @@ public class SwdsUploader {
             }
             final String storagePath = String.format(FORMATTER_STORAGE_PATH, swDatasetVersionWithMeta.getSwDatasetVersionEntity().getStoragePath(),
                 StringUtils.hasText(uri)?uri:filename);
-            storageAccessService.put(storagePath,is);
+            storageAccessService.put(storagePath,is, file.getSize());
         } catch (IOException e) {
             log.error("read swds failed {}", filename,e);
             throw new StarWhaleApiException(new SWProcessException(ErrorType.NETWORK),

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SWModelPackageService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SWModelPackageService.java
@@ -355,7 +355,7 @@ public class SWModelPackageService {
             // only extract the eval job file content
             jobContent = new String(
                 Objects.requireNonNull(TarFileUtil.getContentFromTarFile(dsFile.getInputStream(), "src", "eval_jobs.yaml")));
-            storageAccessService.put(String.format(FORMATTER_STORAGE_PATH,swmpPath,dsFile.getOriginalFilename()),is);
+            storageAccessService.put(String.format(FORMATTER_STORAGE_PATH,swmpPath,dsFile.getOriginalFilename()),is, dsFile.getSize());
         } catch (IOException e) {
             log.error("upload swmp failed {}",uploadRequest.getSwmp(),e);
             throw new StarWhaleApiException(new SWProcessException(ErrorType.STORAGE),

--- a/server/controller/src/main/java/ai/starwhale/mlops/objectstore/impl/S3ObjectStore.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/objectstore/impl/S3ObjectStore.java
@@ -49,7 +49,7 @@ public class S3ObjectStore implements ObjectStore {
 
     @Override
     public void put(String name, SwBuffer buf) throws IOException {
-        this.storageAccessService.put(name, new SwBufferInputStream(buf));
+        this.storageAccessService.put(name, new SwBufferInputStream(buf), buf.capacity());
     }
 
     @Override

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/SwdsUploaderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/SwdsUploaderTest.java
@@ -104,7 +104,7 @@ public class SwdsUploaderTest {
         swdsUploader.end(dsVersionId);
 
         verify(storageAccessService).put(anyString(),any(byte[].class));
-        verify(storageAccessService).put(anyString(),any(InputStream.class));
+        verify(storageAccessService).put(anyString(),any(InputStream.class), anyLong());
         verify(swdsVersionMapper).updateStatus(null, STATUS_AVAILABLE);
         verify(swdsVersionMapper).addNewVersion(any(SWDatasetVersionEntity.class));
         String dsName = "testds3";

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/StorageAccessService.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/StorageAccessService.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 public interface StorageAccessService {
 
     StorageObjectInfo head(String path) throws IOException;
-    void put(String path,InputStream inputStream) throws IOException;
+    void put(String path, InputStream inputStream, long size) throws IOException;
     void put(String path,byte[] body) throws IOException;
     InputStream get(String path) throws IOException;
     InputStream get(String path,Long offset,Long size) throws IOException;

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/s3/StorageAccessServiceS3.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/s3/StorageAccessServiceS3.java
@@ -94,16 +94,10 @@ public class StorageAccessServiceS3 implements StorageAccessService {
      * about 2G, you should wrapp the inputStream with a  LargeFileInputStream
      */
     @Override
-    public void put(String path, InputStream inputStream) throws IOException {
-        long fileSize;
-        if (inputStream instanceof LargeFileInputStream) {
-            fileSize = ((LargeFileInputStream) inputStream).size();
-        } else {
-            fileSize = inputStream.available();
-        }
+    public void put(String path, InputStream inputStream, long size) throws IOException {
         s3client.putObject(
             PutObjectRequest.builder().bucket(s3Config.getBucket()).key(path).build(),
-            RequestBody.fromInputStream(inputStream, fileSize));
+            RequestBody.fromInputStream(inputStream, size));
     }
 
     @Override


### PR DESCRIPTION
## Description
Fix the problem of generating empty WAL files when DataStore uses object storage
The empty WAL file causes a starting problem acting like

```
Caused by: ai.starwhale.mlops.exception.SWProcessException: ERROR occurs while dealing with DATASTORE
    at ai.starwhale.mlops.datastore.WalManager$1.getNext(WalManager.java:157) ~[classes!/:0.1.0-SNAPSHOT]
    at ai.starwhale.mlops.datastore.WalManager$1.next(WalManager.java:129) ~[classes!/:0.1.0-SNAPSHOT]
    at ai.starwhale.mlops.datastore.WalManager$1.next(WalManager.java:113) ~[classes!/:0.1.0-SNAPSHOT]
```

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
