### PR TITLE
fix(client): cmp results use multi table in datastore

### DIFF
--- a/client/starwhale/api/_impl/metric.py
+++ b/client/starwhale/api/_impl/metric.py
@@ -10,10 +10,7 @@ from sklearn.metrics import (  # type: ignore
     confusion_matrix,
     cohen_kappa_score,
     classification_report,
-    multilabel_confusion_matrix,
 )
-
-from starwhale.utils.flatten import do_flatten_dict
 
 
 class MetricKind:
@@ -50,11 +47,9 @@ def multi_classification(
             cm = confusion_matrix(
                 y_true, y_pred, labels=all_labels, normalize=confusion_matrix_normalize
             )
-            mcm = multilabel_confusion_matrix(y_true, y_pred, labels=all_labels)
 
             _r["confusion_matrix"] = {
                 "binarylabel": cm.tolist(),
-                "multilabel": mcm.tolist(),
             }
             if show_hamming_loss:
                 _r["summary"]["hamming_loss"] = hamming_loss(y_true, y_pred)
@@ -67,7 +62,7 @@ def multi_classification(
                     _r["roc_auc"][_label] = _calculate_roc_auc(
                         y_true, y_pr, _label, _idx
                     )
-            return do_flatten_dict(_r)
+            return _r
 
         return _wrapper
 

--- a/client/starwhale/api/_impl/model.py
+++ b/client/starwhale/api/_impl/model.py
@@ -260,18 +260,14 @@ class PipelineHandler(metaclass=ABCMeta):
             self.evaluation.log_metrics({"kind": output["kind"]})
 
             for i, label in output["labels"].items():
-                self.evaluation.log_table("labels", label, id=i)
+                self.evaluation.log("labels", id=i, **label)
 
             _binary_label = output["confusion_matrix"]["binarylabel"]
             for _label, _probability in enumerate(_binary_label):
-                self.evaluation.log_table(
+                self.evaluation.log(
                     "confusion_matrix/binarylabel",
-                    {
-                        **dict(
-                            id=str(_label),
-                        ),
-                        **{str(k): v for k, v in enumerate(_probability)},
-                    },
+                    id=str(_label),
+                    **{str(k): v for k, v in enumerate(_probability)},
                 )
 
             for _label, _roc_auc in output["roc_auc"].items():
@@ -279,9 +275,12 @@ class PipelineHandler(metaclass=ABCMeta):
                 for _fpr, _tpr, _threshold in zip(
                     _roc_auc["fpr"], _roc_auc["tpr"], _roc_auc["thresholds"]
                 ):
-                    self.evaluation.log_table(
+                    self.evaluation.log(
                         f"roc_auc/{_label}",
-                        dict(id=str(_id), fpr=_fpr, tpr=_tpr, threshold=_threshold),
+                        id=str(_id),
+                        fpr=_fpr,
+                        tpr=_tpr,
+                        threshold=_threshold,
                     )
                     _id += 1
                     self.evaluation.log_metrics({f"roc_auc/{_label}": _roc_auc["auc"]})

--- a/client/starwhale/api/_impl/wrapper.py
+++ b/client/starwhale/api/_impl/wrapper.py
@@ -48,7 +48,7 @@ class Evaluation(Logger):
         if self.project is None:
             raise RuntimeError(f"{SWEnv.project} is not set")
         self._results_table_name = self._get_datastore_table_name("results")
-        self._summary_table_name = self._get_datastore_table_name("summary")
+        self._summary_table_name = f"project/{self.project}/eval/summary"
         self._init_writers([self._results_table_name, self._summary_table_name])
         self._data_store = data_store.get_data_store()
 

--- a/client/starwhale/core/eval/model.py
+++ b/client/starwhale/core/eval/model.py
@@ -174,14 +174,12 @@ class StandaloneEvaluationJob(EvaluationJob):
             f"datastore path:{str(self.sw_config.datastore_dir)}, eval_id:{self.store.id}"
         )
         _datastore = wrapper.Evaluation()
-        _labels = list(_datastore.get_results_from_table("labels"))
+        _labels = list(_datastore.get("labels"))
         return dict(
             summary=_datastore.get_metrics(),
             labels={str(i): l for i, l in enumerate(_labels)},
             confusion_matrix=dict(
-                binarylabel=list(
-                    _datastore.get_results_from_table("confusion_matrix/binarylabel")
-                )
+                binarylabel=list(_datastore.get("confusion_matrix/binarylabel"))
             ),
             kind=_datastore.get_metrics()["kind"],
         )

--- a/client/starwhale/core/eval/model.py
+++ b/client/starwhale/core/eval/model.py
@@ -174,7 +174,17 @@ class StandaloneEvaluationJob(EvaluationJob):
             f"datastore path:{str(self.sw_config.datastore_dir)}, eval_id:{self.store.id}"
         )
         _datastore = wrapper.Evaluation()
-        return _datastore.get_metrics()
+        _labels = list(_datastore.get_results_from_table("labels"))
+        return dict(
+            summary=_datastore.get_metrics(),
+            labels={str(i): l for i, l in enumerate(_labels)},
+            confusion_matrix=dict(
+                binarylabel=list(
+                    _datastore.get_results_from_table("confusion_matrix/binarylabel")
+                )
+            ),
+            kind=_datastore.get_metrics()["kind"],
+        )
 
     @staticmethod
     def _do_flatten_summary(summary: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:

--- a/client/starwhale/core/eval/view.py
+++ b/client/starwhale/core/eval/view.py
@@ -175,16 +175,17 @@ class JobTermView(BaseTermView):
                     _tree.add(str(_obj))
 
                 for _k, _v in _obj.items():
-                    if isinstance(_v, (list, tuple)):
-                        _k = f"{_k}: [green]{'|'.join(_v)}"
-                    elif isinstance(_v, dict):
-                        _k = _k
-                    else:
-                        _k = f"{_k}: [green]{_v:.4f}"
+                    if _k != "id":
+                        if isinstance(_v, (list, tuple)):
+                            _k = f"{_k}: [green]{'|'.join(_v)}"
+                        elif isinstance(_v, dict) or isinstance(_v, str):
+                            _k = _k
+                        else:
+                            _k = f"{_k}: [green]{_v:.4f}"
 
-                    _ntree = _tree.add(_k)
-                    if isinstance(_v, dict):
-                        _r(_ntree, _v)
+                        _ntree = _tree.add(_k)
+                        if isinstance(_v, dict):
+                            _r(_ntree, _v)
 
             tree = Tree("Summary")
             _r(tree, report["summary"])
@@ -198,7 +199,7 @@ class JobTermView(BaseTermView):
                 table.add_column(_k.capitalize())
 
             for _k, _v in labels.items():
-                table.add_row(_k, *(f"{_v[_k2]:.4f}" for _k2 in keys))
+                table.add_row(_k, *(f"{float(_v[_k2]):.4f}" for _k2 in keys))
 
             console.rule(f"[bold green]{report['kind'].upper()} Report")
             console.print(self.comparison(tree, table))
@@ -213,7 +214,10 @@ class JobTermView(BaseTermView):
             for n in sort_label_names:
                 btable.add_column(n)
             for idx, bl in enumerate(cm.get("binarylabel", [])):
-                btable.add_row(sort_label_names[idx], *[f"{_:.4f}" for _ in bl])
+                btable.add_row(
+                    sort_label_names[idx],
+                    *[f"{float(bl[i]):.4f}" for i in bl if i != "id"],
+                )
 
             mtable = Table(box=box.SIMPLE)
             mtable.add_column("Label", style="cyan")

--- a/client/starwhale/core/eval/view.py
+++ b/client/starwhale/core/eval/view.py
@@ -175,17 +175,20 @@ class JobTermView(BaseTermView):
                     _tree.add(str(_obj))
 
                 for _k, _v in _obj.items():
-                    if _k != "id":
-                        if isinstance(_v, (list, tuple)):
-                            _k = f"{_k}: [green]{'|'.join(_v)}"
-                        elif isinstance(_v, dict) or isinstance(_v, str):
-                            _k = _k
-                        else:
-                            _k = f"{_k}: [green]{_v:.4f}"
+                    if _k == "id":
+                        continue
+                    if isinstance(_v, (list, tuple)):
+                        _k = f"{_k}: [green]{'|'.join(_v)}"
+                    elif isinstance(_v, dict):
+                        _k = _k
+                    elif isinstance(_v, str):
+                        _k = f"{_k}:{_v}"
+                    else:
+                        _k = f"{_k}: [green]{_v:.4f}"
 
-                        _ntree = _tree.add(_k)
-                        if isinstance(_v, dict):
-                            _r(_ntree, _v)
+                    _ntree = _tree.add(_k)
+                    if isinstance(_v, dict):
+                        _r(_ntree, _v)
 
             tree = Tree("Summary")
             _r(tree, report["summary"])


### PR DESCRIPTION
## Description

1. cmp metrics use multi table store
![image](https://user-images.githubusercontent.com/24869618/187060110-e3f48adc-e120-45a7-af0d-b4ed88cceb92.png)
2. solve the cmd `swcli eval info {version}`  display problem
![image](https://user-images.githubusercontent.com/24869618/187060064-16ea8880-7eb6-43e5-a4c3-6b9c35e14a5d.png)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
