### PR TITLE
feat(controller): populate runtime image to task

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/common/RegExps.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/RegExps.java
@@ -6,9 +6,9 @@ public class RegExps {
 
     public static final String USER_NAME_REGEX = "^[a-zA-Z][a-zA-Z\\d_-]{3,32}$";
 
-    public static final String PROJECT_NAME_REGEX = "^[a-zA-Z][a-zA-Z\\d_-]{3,80}$";
+    public static final String PROJECT_NAME_REGEX = "^[a-zA-Z][a-zA-Z\\d_-]{2,80}$";
 
-    public static final String BUNDLE_NAME_REGEX = "^[a-zA-Z][a-zA-Z\\d_-]{3,80}$";
+    public static final String BUNDLE_NAME_REGEX = "^[a-zA-Z][a-zA-Z\\d_-]{2,80}$";
 
 
     public static void main(String[] args) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/JobBoConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/JobBoConverter.java
@@ -108,7 +108,8 @@ public class JobBoConverter {
                 .storagePath(runtimeVersionEntity.getStoragePath())
                 .deviceAmount(jobEntity.getDeviceAmount())
                 .deviceClass(Device.Clazz.from(jobEntity.getDeviceType()))
-                .image(defaultRuntimeImage)
+                .image(null == runtimeVersionEntity.getVersionMeta() ? defaultRuntimeImage
+                    : runtimeVersionEntity.getVersionMeta())
                 .build())
             .status(jobEntity.getJobStatus())
             .type(jobEntity.getType())


### PR DESCRIPTION
## Description
- populate runtime image to task
people could overwirte `runtime_version.manifest` in mysql to do debug

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
