### PR TITLE
fix(datastore): close inputstream after using s3.get

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/objectstore/impl/S3ObjectStore.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/objectstore/impl/S3ObjectStore.java
@@ -54,11 +54,13 @@ public class S3ObjectStore implements ObjectStore {
 
     @Override
     public SwBuffer get(String name) throws IOException {
-        @SuppressWarnings("unchecked")
-        var result = (ResponseInputStream<GetObjectResponse>) this.storageAccessService.get(name);
-        var ret = this.bufferManager.allocate(result.response().contentLength().intValue());
-        assert result.read(ret.asByteBuffer().array()) == ret.capacity();
-        return ret;
+        try (var is = this.storageAccessService.get(name)) {
+            @SuppressWarnings("unchecked")
+            var result = (ResponseInputStream<GetObjectResponse>) is;
+            var ret = this.bufferManager.allocate(result.response().contentLength().intValue());
+            assert result.read(ret.asByteBuffer().array()) == ret.capacity();
+            return ret;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

Close `InputStream` after using s3.get

