### PR TITLE
fix(controller): use manifest field as the runtime image

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/JobBoConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/JobBoConverter.java
@@ -108,8 +108,8 @@ public class JobBoConverter {
                 .storagePath(runtimeVersionEntity.getStoragePath())
                 .deviceAmount(jobEntity.getDeviceAmount())
                 .deviceClass(Device.Clazz.from(jobEntity.getDeviceType()))
-                .image(null == runtimeVersionEntity.getVersionMeta() ? defaultRuntimeImage
-                    : runtimeVersionEntity.getVersionMeta())
+                .image(null == runtimeVersionEntity.getManifest() ? defaultRuntimeImage
+                    : runtimeVersionEntity.getManifest())
                 .build())
             .status(jobEntity.getJobStatus())
             .type(jobEntity.getType())


### PR DESCRIPTION
## Description
Use manifest field as the runtime image.
## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
