### PR TITLE
fix(datastore): keep retrying to write WAL even if terminated

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/WalManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/WalManager.java
@@ -325,7 +325,6 @@ public class WalManager extends Thread {
                             Retry.of("put", RetryConfig.custom()
                                     .maxAttempts(10000)
                                     .intervalFunction(IntervalFunction.ofExponentialRandomBackoff(100, 2.0, 0.5, 10000))
-                                    .retryOnException(e -> !terminated)
                                     .build()),
                             () -> this.objectStore.put(this.logFilePrefix + this.logFileIndex,
                                     this.compressedBuffer.slice(0, compressedBufferSize)))


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [X] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
