### PR TITLE
feat(model): support `--runtime` argument for model build and auto restore runtime

### DIFF
--- a/client/starwhale/core/dataset/cli.py
+++ b/client/starwhale/core/dataset/cli.py
@@ -32,7 +32,6 @@ def dataset_cmd(ctx: click.Context) -> None:
 @click.option("--append", is_flag=True, help="Only append new data")
 @click.option("--append-from", default=LATEST_TAG, help="Append from dataset version")
 @click.option("--runtime", default="", help="runtime uri")
-@click.option("--runtime-restore", is_flag=True, help="Force to restore runtime")
 @click.pass_obj
 def _build(
     view: DatasetTermView,
@@ -42,14 +41,11 @@ def _build(
     append: bool,
     append_from: str,
     runtime: str,
-    runtime_restore: bool,
 ) -> None:
     # TODO: add cmd options for dataset build, another choice for dataset.yaml
     # TODO: add dry-run
     # TODO: add compress args
-    view.build(
-        workdir, project, dataset_yaml, append, append_from, runtime, runtime_restore
-    )
+    view.build(workdir, project, dataset_yaml, append, append_from, runtime)
 
 
 @dataset_cmd.command("diff", help="Dataset version diff")

--- a/client/starwhale/core/dataset/view.py
+++ b/client/starwhale/core/dataset/view.py
@@ -155,7 +155,6 @@ class DatasetTermView(BaseTermView):
         append: bool = False,
         append_from: str = LATEST_TAG,
         runtime_uri: str = "",
-        runtime_restore: bool = False,
     ) -> None:
         dataset_uri = cls.prepare_build_bundle(
             workdir, project, yaml_name, URIType.DATASET
@@ -167,7 +166,6 @@ class DatasetTermView(BaseTermView):
                 target=ds.build,
                 args=(Path(workdir), yaml_name),
                 kwargs={"append": append, "append_from": append_from},
-                runtime_restore=runtime_restore,
             ).run()
         else:
             ds.build(Path(workdir), yaml_name, append=append, append_from=append_from)

--- a/client/starwhale/core/eval/cli.py
+++ b/client/starwhale/core/eval/cli.py
@@ -49,7 +49,6 @@ def _list(
     help="dataset uri, one or more",
 )
 @click.option("--runtime", default="", help="runtime uri")
-@click.option("--runtime-restore", is_flag=True, help="Force to restore runtime")
 @click.option("--name", default="default", help="job name")
 @click.option("--desc", help="job description")
 @click.option(
@@ -72,7 +71,6 @@ def _run(
     model: str,
     dataset: str,
     runtime: str,
-    runtime_restore: bool,
     name: str,
     desc: str,
     resource: str,
@@ -94,7 +92,6 @@ def _run(
         use_docker=use_docker,
         step=step,
         task_index=task_index,
-        runtime_restore=runtime_restore,
     )
 
 

--- a/client/starwhale/core/eval/model.py
+++ b/client/starwhale/core/eval/model.py
@@ -160,7 +160,6 @@ class StandaloneEvaluationJob(EvaluationJob):
                 uri=runtime_uri,
                 target=ee.run,
                 args=(),
-                runtime_restore=kw.get("runtime_restore", False),
             ).run()
         else:
             ee.run()

--- a/client/starwhale/core/eval/view.py
+++ b/client/starwhale/core/eval/view.py
@@ -254,7 +254,6 @@ class JobTermView(BaseTermView):
         use_docker: bool = False,
         step: str = "",
         task_index: int = 0,
-        runtime_restore: bool = False,
     ) -> None:
         _project_uri = URI(project_uri, expected_type=URIType.PROJECT)
         ok, reason = EvaluationJob.run(
@@ -268,7 +267,6 @@ class JobTermView(BaseTermView):
             resource=resource,
             gencmd=gencmd,
             use_docker=use_docker,
-            runtime_restore=runtime_restore,
             step=step,
             task_index=task_index,
         )

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -22,8 +22,9 @@ def model_cmd(ctx: click.Context) -> None:
     default=DefaultYAMLName.MODEL,
     help="mode yaml filename, default use ${workdir}/model.yaml file",
 )
-def _build(workdir: str, project: str, model_yaml: str) -> None:
-    ModelTermView.build(workdir, project, model_yaml)
+@click.option("--runtime", default="", help="runtime uri")
+def _build(workdir: str, project: str, model_yaml: str, runtime: str) -> None:
+    ModelTermView.build(workdir, project, model_yaml, runtime)
 
 
 @model_cmd.command("tag", help="Model Tag Management, add or remove")
@@ -134,7 +135,6 @@ def _extract(model: str, force: bool, target_dir: str) -> None:
 @click.option("--step", default="", help="Evaluation run step")
 @click.option("--task-index", default=0, help="Index of tasks in the current step")
 @click.option("--runtime", default="", help="runtime uri")
-@click.option("--runtime-restore", is_flag=True, help="Force to restore runtime")
 @click.option("--dataset", envvar=SWEnv.dataset_uri, help="dataset uri")
 def _eval(
     project: str,
@@ -145,7 +145,6 @@ def _eval(
     step: str,
     task_index: int,
     runtime: str,
-    runtime_restore: bool,
 ) -> None:
     """
     [ONLY Standalone]Run evaluation processing with root dir of {target}.
@@ -158,7 +157,6 @@ def _eval(
         version=version,
         yaml_name=model_yaml,
         runtime_uri=runtime,
-        runtime_restore=runtime_restore,
         step=step,
         task_index=task_index,
         dataset_uris=[dataset],


### PR DESCRIPTION
## Description
- add `--runtime` for the model build, the reason is gen_steps will import user [code](https://github.com/star-whale/starwhale/blob/main/client/starwhale/api/_impl/job.py#L154).
- tune `--runtime-restore` argument, when detecting the venv or conda dir is invalid, the command will restore runtime automatically.
- related: https://github.com/star-whale/starwhale/issues/1063

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
