### PR TITLE
fix(controller): do not cache unfinished evaluation

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/evaluation/EvaluationService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/evaluation/EvaluationService.java
@@ -33,6 +33,7 @@ import ai.starwhale.mlops.domain.job.converter.JobConvertor;
 import ai.starwhale.mlops.domain.job.mapper.JobMapper;
 import ai.starwhale.mlops.domain.job.po.JobEntity;
 import ai.starwhale.mlops.domain.job.status.JobStatus;
+import ai.starwhale.mlops.domain.job.status.JobStatusMachine;
 import ai.starwhale.mlops.domain.project.ProjectManager;
 import ai.starwhale.mlops.domain.user.UserService;
 import ai.starwhale.mlops.resulting.ResultQuerier;
@@ -78,6 +79,9 @@ public class EvaluationService {
 
     @Resource
     private ResultQuerier resultQuerier;
+
+    @Resource
+    private JobStatusMachine jobStatusMachine;
 
     private static final Map<Long, SummaryVO> summaryCache = new ConcurrentHashMap<>();
 
@@ -159,7 +163,11 @@ public class EvaluationService {
                 .value(value)
                 .build());
         }*/
-        summaryCache.put(entity.getId(), summaryVO);
+
+        // only cache the jobs which have the final status
+        if (jobStatusMachine.isFinal(entity.getJobStatus())) {
+            summaryCache.put(entity.getId(), summaryVO);
+        }
         return summaryVO;
     }
 


### PR DESCRIPTION
## Description

Access the evaluation list when the job is unfinished, the status will be cached, and never update until controller restart.

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
