### PR TITLE
enhance(datastore): tune TableWriter run thread exception handler

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -27,6 +27,7 @@ install_requires = [
     "packaging>=21.3",
     "pyarrow>=8.0.0",
     "Jinja2>=3.1.2",
+    "tenacity>=8.0.1",
 ]
 
 

--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -16,6 +16,9 @@ import pyarrow as pa  # type: ignore
 import requests
 import pyarrow.parquet as pq  # type: ignore
 from loguru import logger
+from tenacity import retry
+from tenacity.stop import stop_after_attempt
+from tenacity.retry import retry_if_exception_type
 from typing_extensions import Protocol
 
 from starwhale.utils.fs import ensure_dir
@@ -871,6 +874,11 @@ class RemoteDataStore:
         if self.token is None:
             raise RuntimeError("SW_TOKEN is not found in environment")
 
+    @retry(
+        reraise=True,
+        stop=stop_after_attempt(3),
+        retry=retry_if_exception_type(requests.exceptions.HTTPError),
+    )
     def update_table(
         self,
         table_name: str,
@@ -901,7 +909,6 @@ class RemoteDataStore:
         if self.token is None:
             raise MissingFieldError("no authorization token")
 
-        assert self.token is not None
         resp = requests.post(
             urllib.parse.urljoin(self.instance_uri, "/api/v1/datastore/updateTable"),
             data=json.dumps(data, separators=(",", ":")),
@@ -1017,15 +1024,29 @@ def _flatten(record: Dict[str, Any]) -> Dict[str, Any]:
     return record
 
 
+class TableWriterException(Exception):
+    pass
+
+
 class TableWriter(threading.Thread):
-    def __init__(self, table_name: str, key_column: str = "id") -> None:
-        super().__init__()
+    def __init__(
+        self,
+        table_name: str,
+        key_column: str = "id",
+        data_store: Optional[DataStore] = None,
+        run_exceptions_limits: int = 100,
+    ) -> None:
+        super().__init__(name=f"TableWriter-{table_name}")
         self.table_name = table_name
         self.schema = TableSchema(key_column, [])
-        self.records: List[Dict[str, Any]] = []
-        self.stopped = False
-        self.data_store = get_data_store()
-        self.cond = threading.Condition()
+        self.data_store = data_store or get_data_store()
+
+        self._cond = threading.Condition()
+        self._stopped = False
+        self._records: List[Dict[str, Any]] = []
+        self._queue_run_exceptions: List[Exception] = []
+        self._run_exceptions_limits = max(run_exceptions_limits, 0)
+
         self.setDaemon(True)
         self.start()
 
@@ -1039,11 +1060,18 @@ class TableWriter(threading.Thread):
         self.close()
 
     def close(self) -> None:
-        with self.cond:
-            if not self.stopped:
-                self.stopped = True
-                self.cond.notify()
+        with self._cond:
+            if not self._stopped:
+                self._stopped = True
+                self._cond.notify()
         self.join()
+        self._raise_run_exceptions(0)
+
+    def _raise_run_exceptions(self, limits: int) -> None:
+        if len(self._queue_run_exceptions) > limits:
+            _es = self._queue_run_exceptions
+            self._queue_run_exceptions = []
+            raise TableWriterException(f"{self} run raise {len(_es)} exceptions: {_es}")
 
     def insert(self, record: Dict[str, Any]) -> None:
         record = _flatten(record)
@@ -1063,23 +1091,32 @@ class TableWriter(threading.Thread):
         self._insert({self.schema.key_column: key, "-": True})
 
     def _insert(self, record: Dict[str, Any]) -> None:
+        self._raise_run_exceptions(self._run_exceptions_limits)
+
         key = record.get(self.schema.key_column, None)
         if key is None:
             raise RuntimeError(
                 f"the key {self.schema.key_column} should not be none, record:{record}"
             )
-        with self.cond:
+        with self._cond:
             self.schema = _update_schema(self.schema, record)
-            self.records.append(record)
-            self.cond.notify()
+            self._records.append(record)
+            self._cond.notify()
 
     def run(self) -> None:
         while True:
-            with self.cond:
-                while not self.stopped and len(self.records) == 0:
-                    self.cond.wait()
-                if len(self.records) == 0:
+            with self._cond:
+                while not self._stopped and len(self._records) == 0:
+                    self._cond.wait()
+                if len(self._records) == 0:
                     break
-                records = self.records
-                self.records = []
-            self.data_store.update_table(self.table_name, self.schema, records)
+                records = self._records
+                self._records = []
+
+            try:
+                self.data_store.update_table(self.table_name, self.schema, records)
+            except Exception as e:
+                logger.warning(f"{self} run-update-table raise exception: {e}")
+                self._queue_run_exceptions.append(e)
+                if len(self._queue_run_exceptions) > self._run_exceptions_limits:
+                    break


### PR DESCRIPTION
## Description
- When the TableWriter runs thread raises an Exception, the main thread can handle it.
- add retry for update_table for remote store

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
