### PR TITLE
wip: refactor(controller): clean k8s task scheduler code

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/JobRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/JobRequest.java
@@ -44,7 +44,7 @@ public class JobRequest implements Serializable {
 
     @NotNull
     @JsonProperty("deviceAmount")
-    private Integer deviceAmount;
+    private Float deviceAmount;
 
     @JsonProperty("comment")
     private String comment;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobService.java
@@ -201,7 +201,7 @@ public class JobService {
     }
     public Long createJob(String projectUrl,
         String modelVersionUrl, String datasetVersionUrls, String runtimeVersionUrl,
-        String deviceType, int deviceCount, String comment, String resourcePool) {
+        String deviceType, Float deviceCount, String comment, String resourcePool) {
         User user = userService.currentUserDetail();
         String jobUuid = IdUtil.simpleUUID();
         Long projectId = projectManager.getProjectId(projectUrl);
@@ -219,7 +219,7 @@ public class JobService {
             .projectId(projectId)
             .swmpVersionId(modelVersionId)
             .deviceType(deviceValue)
-            .deviceAmount(deviceCount)
+            .deviceAmount(Float.valueOf(deviceCount*1000).intValue())
             .comment(comment)
             .resultOutputPath(storagePathCoordinator.generateResultMetricsPath(jobUuid))
             .jobStatus(JobStatus.CREATED)

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForSchedule.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForSchedule.java
@@ -63,11 +63,11 @@ public class TaskWatcherForSchedule implements TaskStatusChangeWatcher {
     public void onTaskStatusChange(Task task, TaskStatus oldStatus) {
         if (task.getStatus() == TaskStatus.READY) {
             log.debug("task status changed to ready id: {} oldStatus: {}, scheduled", task.getId(), oldStatus);
-            taskScheduler.adopt(List.of(task), task.getStep().getJob().getJobRuntime().getDeviceClass());
+            taskScheduler.schedule(List.of(task), task.getStep().getJob().getJobRuntime().getDeviceClass());
         } else if (task.getStatus() == TaskStatus.PAUSED || taskStatusMachine.isFinal(task.getStatus())) {
             log.debug("task status changed to {} with id: {} newStatus: {}, stop scheduled", task.getStatus(), task.getId(), task.getStatus());
             if (deletionDelayMilliseconds <= 0) {
-                taskScheduler.remove(List.of(task.getId()));
+                taskScheduler.stopSchedule(List.of(task.getId()));
             } else {
                 addToDeleteQueue(task);
             }
@@ -90,7 +90,7 @@ public class TaskWatcherForSchedule implements TaskStatusChangeWatcher {
             taskIds.add(task.getTaskId());
             task = taskToDeletes.poll();
         }
-        taskScheduler.remove(taskIds);
+        taskScheduler.stopSchedule(taskIds);
     }
 
     static class TaskToDelete implements Delayed {

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/SWTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/SWTaskScheduler.java
@@ -32,11 +32,11 @@ public interface SWTaskScheduler {
      * @param tasks tasks to be scheduled
      * @param deviceClass the device type should be scheduled on
      */
-    void adopt(Collection<Task> tasks, Device.Clazz deviceClass);
+    void schedule(Collection<Task> tasks, Device.Clazz deviceClass);
 
     /**
      * @param taskIds tasks to be stop scheduled
      */
-    void remove(Collection<Long> taskIds);
+    void stopSchedule(Collection<Long> taskIds);
 
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
@@ -129,7 +129,7 @@ public class JobLoaderTest {
         Assertions.assertNotNull(loadedJob.getCurrentStep().getNextStep());
 
         verify(jobHolder, times(1)).adopt(mockJob);
-        verify(swTaskScheduler, times(0)).adopt(anyCollection(), any(Clazz.class));
+        verify(swTaskScheduler, times(0)).schedule(anyCollection(), any(Clazz.class));
         verify(watchableTaskFactory, times(2)).wrapTasks(anyCollection());
         loadedJob.getSteps().parallelStream().map(Step::getTasks).flatMap(Collection::stream)
             .forEach(t -> {
@@ -203,7 +203,7 @@ public class JobLoaderTest {
 
         verify(jobUpdateHelper).updateJob(mockJob);
         verify(jobHolder, times(1)).adopt(mockJob);
-        verify(swTaskScheduler, times(1)).adopt(anyCollection(), any(Clazz.class));
+        verify(swTaskScheduler, times(1)).schedule(anyCollection(), any(Clazz.class));
         Set<Task> tasks = loadedJob.getSteps().parallelStream().map(Step::getTasks)
             .flatMap(Collection::stream).collect(
                 Collectors.toSet());
@@ -279,7 +279,7 @@ public class JobLoaderTest {
 
         verify(jobUpdateHelper).updateJob(mockJob);
         verify(jobHolder, times(0)).adopt(mockJob);
-        verify(swTaskScheduler, times(0)).adopt(anyCollection(), any(Clazz.class));
+        verify(swTaskScheduler, times(0)).schedule(anyCollection(), any(Clazz.class));
         Set<Task> tasks = loadedJob.getSteps().parallelStream().map(Step::getTasks)
             .flatMap(Collection::stream).collect(
                 Collectors.toSet());

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskWatcherForScheduleTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskWatcherForScheduleTest.java
@@ -24,7 +24,6 @@ import ai.starwhale.mlops.domain.job.bo.JobRuntime;
 import ai.starwhale.mlops.domain.job.bo.Job;
 import ai.starwhale.mlops.domain.job.step.bo.Step;
 import ai.starwhale.mlops.domain.node.Device.Clazz;
-import ai.starwhale.mlops.domain.system.agent.bo.Agent;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
 import ai.starwhale.mlops.domain.task.status.TaskStatusMachine;
@@ -55,8 +54,8 @@ public class TaskWatcherForScheduleTest {
                 Clazz.CPU).build()).build()).build())
             .build();
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.CREATED);
-        verify(taskScheduler).adopt(List.of(task), Clazz.CPU);
-        verify(taskScheduler, times(0)).remove(List.of(task.getId()));
+        verify(taskScheduler).schedule(List.of(task), Clazz.CPU);
+        verify(taskScheduler, times(0)).stopSchedule(List.of(task.getId()));
     }
 
     @Test
@@ -75,8 +74,8 @@ public class TaskWatcherForScheduleTest {
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.READY);
         task.updateStatus(TaskStatus.CANCELED);
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.READY);
-        verify(taskScheduler, times(0)).adopt(List.of(task), Clazz.CPU);
-        verify(taskScheduler,times(2)).remove(List.of(task.getId()));
+        verify(taskScheduler, times(0)).schedule(List.of(task), Clazz.CPU);
+        verify(taskScheduler,times(2)).stopSchedule(List.of(task.getId()));
     }
 
     @Test
@@ -95,7 +94,7 @@ public class TaskWatcherForScheduleTest {
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.SUCCESS);
 
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.FAIL);
-        verify(taskScheduler, times(0)).adopt(List.of(task), Clazz.CPU);
-        verify(taskScheduler,times(0)).remove(List.of(task.getId()));
+        verify(taskScheduler, times(0)).schedule(List.of(task), Clazz.CPU);
+        verify(taskScheduler,times(0)).stopSchedule(List.of(task.getId()));
     }
 }


### PR DESCRIPTION
## Description
- convert device unit in api to one instead of milli
- refactor k8s scheduler code
## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
