### PR TITLE
refactor(controller): rename manifest field of runtime to image

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/runtime/RuntimeVersionVO.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/runtime/RuntimeVersionVO.java
@@ -41,8 +41,8 @@ public class RuntimeVersionVO implements Serializable {
     @JsonProperty("meta")
     private Object meta;
 
-    @JsonProperty("manifest")
-    private String manifest;
+    @JsonProperty("image")
+    private String image;
 
     @JsonProperty("createdTime")
     private Long createdTime;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/JobBoConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/JobBoConverter.java
@@ -28,7 +28,6 @@ import ai.starwhale.mlops.domain.runtime.mapper.RuntimeMapper;
 import ai.starwhale.mlops.domain.runtime.mapper.RuntimeVersionMapper;
 import ai.starwhale.mlops.domain.swds.bo.SWDataSet;
 import ai.starwhale.mlops.domain.swds.converter.SWDSBOConverter;
-import ai.starwhale.mlops.domain.swds.po.SWDatasetVersionEntity;
 import ai.starwhale.mlops.domain.swmp.SWModelPackage;
 import ai.starwhale.mlops.domain.swmp.po.SWModelPackageEntity;
 import ai.starwhale.mlops.domain.swmp.mapper.SWModelPackageMapper;
@@ -108,8 +107,8 @@ public class JobBoConverter {
                 .storagePath(runtimeVersionEntity.getStoragePath())
                 .deviceAmount(jobEntity.getDeviceAmount())
                 .deviceClass(Device.Clazz.from(jobEntity.getDeviceType()))
-                .image(null == runtimeVersionEntity.getManifest() ? defaultRuntimeImage
-                    : runtimeVersionEntity.getManifest())
+                .image(null == runtimeVersionEntity.getImage() ? defaultRuntimeImage
+                    : runtimeVersionEntity.getImage())
                 .build())
             .status(jobEntity.getJobStatus())
             .type(jobEntity.getType())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -339,10 +339,11 @@ public class RuntimeService {
         }
         /* create new entity */
         if(!entityExists) {
-            RuntimeManifest runtimeManifestObj = null;
+            RuntimeManifest runtimeManifestObj;
+            String runtimeManifest ;
             try(final InputStream inputStream = dsFile.getInputStream()){
                 // only extract the eval job file content
-                String runtimeManifest = new String(
+                runtimeManifest = new String(
                     Objects.requireNonNull(
                         TarFileUtil.getContentFromTarFile(inputStream, "", "_manifest.yaml")));
                 runtimeManifestObj = yamlMapper.readValue(runtimeManifest,
@@ -357,8 +358,8 @@ public class RuntimeService {
                 .storagePath(runtimePath)
                 .runtimeId(entity.getId())
                 .versionName(uploadRequest.version())
-                .versionMeta(uploadRequest.getRuntime())
-                .manifest(null == runtimeManifestObj? null : runtimeManifestObj.getBaseImage())
+                .versionMeta(runtimeManifest)
+                .image(null == runtimeManifestObj? null : runtimeManifestObj.getBaseImage())
                 .build());
         }
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConvertor.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConvertor.java
@@ -47,7 +47,7 @@ public class RuntimeVersionConvertor implements Convertor<RuntimeVersionEntity, 
             .owner(userConvertor.convert(entity.getOwner()))
             .tag(entity.getVersionTag())
             .meta(entity.getVersionMeta())
-            .manifest(entity.getManifest())
+            .image(entity.getImage())
             .createdTime(localDateTimeConvertor.convert(entity.getCreatedTime()))
             .build();
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/po/RuntimeVersionEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/po/RuntimeVersionEntity.java
@@ -48,7 +48,7 @@ public class RuntimeVersionEntity extends BaseEntity implements BundleVersionEnt
 
     private String storagePath;
 
-    private String manifest;
+    private String image;
 
     @Override
     public String getName() {

--- a/server/controller/src/main/resources/db/migration/V00016__alter_manifest_2_image.sql
+++ b/server/controller/src/main/resources/db/migration/V00016__alter_manifest_2_image.sql
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ALTER TABLE runtime_version RENAME COLUMN manifest TO image;

--- a/server/controller/src/main/resources/mapper/RuntimeVersionMapper.xml
+++ b/server/controller/src/main/resources/mapper/RuntimeVersionMapper.xml
@@ -25,7 +25,7 @@
                rv.version_tag as rv_version_tag,
                rv.version_meta as rv_version_meta,
                rv.storage_path as rv_storage_path,
-               rv.manifest as rv_manifest,
+               rv.image as rv_image,
                rv.created_time as rv_created_time,
                rv.modified_time as rv_modified_time,
                u.id as user_id,
@@ -78,21 +78,21 @@
     </select>
 
     <insert id="revertTo">
-        replace into runtime_version (runtime_id, owner_id, version_name, version_tag, version_meta, storage_path, manifest)
-        select runtime_id, owner_id, version_name, version_tag, version_meta, storage_path, manifest
+        replace into runtime_version (runtime_id, owner_id, version_name, version_tag, version_meta, storage_path, image)
+        select runtime_id, owner_id, version_name, version_tag, version_meta, storage_path, image
         from runtime_version
         where id = #{rtVersionId}
     </insert>
 
     <insert id="addNewVersion" parameterType="ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity" useGeneratedKeys="true" keyProperty="id">
-        insert into runtime_version (runtime_id, owner_id, version_name, version_tag, version_meta, storage_path, manifest)
+        insert into runtime_version (runtime_id, owner_id, version_name, version_tag, version_meta, storage_path, image)
         values(#{version.runtimeId},
                #{version.ownerId},
                #{version.versionName},
                #{version.versionTag},
                #{version.versionMeta},
                #{version.storagePath},
-               #{version.manifest})
+               #{version.image})
     </insert>
 
     <update id="update" parameterType="ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity">
@@ -110,7 +110,7 @@
         <result property="versionTag" column="rv_version_tag" />
         <result property="versionMeta" column="rv_version_meta" />
         <result property="storagePath" column="rv_storage_path" />
-        <result property="manifest" column="rv_manifest" />
+        <result property="image" column="rv_image" />
         <result property="createdTime" column="rv_created_time"/>
         <result property="modifiedTime" column="rv_modified_time"/>
         <result property="ownerId" column="owner_id" />


### PR DESCRIPTION
## Description
rename `manifest` field of `runtime` to `image` to make the semantic clear

![image](https://user-images.githubusercontent.com/89630947/188047403-9e786f79-d82e-422a-ae54-01551c3528f6.png)
![image](https://user-images.githubusercontent.com/89630947/188047633-722bc902-0038-4b69-9ff9-70121fabb5a9.png)

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
