### PR TITLE
chore(datastore): allow non existing table when query or scan

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
@@ -102,6 +102,7 @@ public class DataStoreController implements DataStoreApi {
                     .limit(request.getLimit())
                     .keepNone(request.isKeepNone())
                     .rawResult(request.isRawResult())
+                    .ignoreNonExistingTable(request.isIgnoreNonExistingTable())
                     .build());
             return ResponseEntity.ok(Code.success.asResponse(RecordListVO.builder()
                     .columnTypes(recordList.getColumnTypeMap())

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/QueryTableRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/QueryTableRequest.java
@@ -31,4 +31,5 @@ public class QueryTableRequest {
     private int limit = -1;
     private boolean keepNone;
     private boolean rawResult;
+    private boolean ignoreNonExistingTable;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreQueryRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreQueryRequest.java
@@ -39,4 +39,5 @@ public class DataStoreQueryRequest {
     private int limit = -1;
     private boolean keepNone;
     private boolean rawResult;
+    private boolean ignoreNonExistingTable;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreScanRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreScanRequest.java
@@ -48,4 +48,5 @@ public class DataStoreScanRequest {
     private int limit = -1;
     private boolean keepNone;
     private boolean rawResult;
+    private boolean ignoreNonExistingTable;
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
@@ -226,6 +226,14 @@ public class DataStoreTest {
                         Map.of(),
                         Map.of("url", "http://test.com/1.jpg", "y:link/mime_type", "image/jpeg"),
                         Map.of("url", "http://test.com/2.png", "y:link/mime_type", "image/png"))));
+        // query non exist table
+        final String tableNonExist = "tableNonExist";
+        assertThrows(SWValidationException.class, () -> this.dataStore.query(DataStoreQueryRequest.builder()
+                .tableName(tableNonExist).build()));
+        recordList = this.dataStore.query(DataStoreQueryRequest.builder()
+                .tableName(tableNonExist).ignoreNonExistingTable(true).build());
+        assertThat("result of non exist table", recordList.getColumnTypeMap().isEmpty());
+        assertThat("result of non exist table", recordList.getRecords().isEmpty());
     }
 
     @Test
@@ -529,6 +537,22 @@ public class DataStoreTest {
                                 .columns(Map.of("k", "a"))
                                 .build()))
                 .build()));
+
+        // scan non exist table
+        final String tableNonExist = "tableNonExist";
+        var builder = DataStoreScanRequest.builder()
+                .tables(List.of(DataStoreScanRequest.TableInfo.builder().tableName("t1").build(),
+                    DataStoreScanRequest.TableInfo.builder().tableName(tableNonExist).build()))
+                .limit(1);
+        assertThrows(SWValidationException.class, () -> this.dataStore.scan(builder.build()));
+
+        recordList = this.dataStore.scan(builder.ignoreNonExistingTable(true).build());
+        assertThat("result of non exist table",
+                recordList.getColumnTypeMap(),
+                is(Map.of("k", ColumnType.STRING, "a", ColumnType.INT32)));
+        assertThat("result of non exist table",
+                recordList.getRecords(),
+                is(List.of(Map.of("k", "0", "a", "5"))));
     }
 
     @Test


### PR DESCRIPTION
## Description
Allow non existing table when query or scan

cc @tianweidut @waynelwz 

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
