### PR TITLE
ci(e2e): restore broken e2e test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -62,8 +62,8 @@ jobs:
           cache: "maven"
           server-id: starwhale # Value of the distributionManagement/repository/id field of the pom.xml
 
-#      - name: Setup tmate session
-#        uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: run e2e
         working-directory: ./scripts/e2e_test
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -62,6 +62,8 @@ jobs:
           cache: "maven"
           server-id: starwhale # Value of the distributionManagement/repository/id field of the pom.xml
 
+      - name: Setup tmate session
+          uses: mxschmitt/action-tmate@v3
       - name: run e2e
         working-directory: ./scripts/e2e_test
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,6 +1,13 @@
 name: End to End test for starwhale
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
   push:
     branches:
       E2E
@@ -62,8 +69,9 @@ jobs:
           cache: "maven"
           server-id: starwhale # Value of the distributionManagement/repository/id field of the pom.xml
 
-#      - name: Setup tmate session
-#        uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: run e2e
         working-directory: ./scripts/e2e_test
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,9 +8,8 @@ on:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
-  push:
-    branches:
-      E2E
+  schedule:
+    - cron: "34 10,13 * * *"
 
 env:
   PYPI_RELEASE_VERSION: 100.0.0
@@ -37,9 +36,9 @@ jobs:
       matrix:
         python-version:
           - "3.7"
-#          - "3.8"
-#          - "3.9"
-#          - "3.10"
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -63,7 +63,7 @@ jobs:
           server-id: starwhale # Value of the distributionManagement/repository/id field of the pom.xml
 
       - name: Setup tmate session
-          uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@v3
       - name: run e2e
         working-directory: ./scripts/e2e_test
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -62,8 +62,8 @@ jobs:
           cache: "maven"
           server-id: starwhale # Value of the distributionManagement/repository/id field of the pom.xml
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+#      - name: Setup tmate session
+#        uses: mxschmitt/action-tmate@v3
       - name: run e2e
         working-directory: ./scripts/e2e_test
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,8 +1,9 @@
 name: End to End test for starwhale
 
 on:
-  schedule:
-    - cron: "34 10,13 * * *"
+  push:
+    branches:
+      E2E
 
 env:
   PYPI_RELEASE_VERSION: 100.0.0
@@ -29,9 +30,9 @@ jobs:
       matrix:
         python-version:
           - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
+#          - "3.8"
+#          - "3.9"
+#          - "3.10"
 
     steps:
       - uses: actions/checkout@v3

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -128,7 +128,7 @@ release-nodejs:
 build-console:
 	docker volume create --name ${YARN_VOLUME} && \
 	docker run --rm -v ${YARN_VOLUME}:/app ${DH_NODEJS_IMAGE} /bin/sh -c "cp -r /root/.npmrc /app/ && chown $(shell id -u):$(shell id -g) -R /app" && \
-	docker run --rm -it \
+	docker run --rm \
 		-u $(shell id -u):$(shell id -g) \
 		-v ${YARN_VOLUME}:/var/yarn-cache \
 		-v ${ROOT_DIR}console:/app \

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -148,7 +148,7 @@ upload_pypi_to_nexus() {
 
 buid_runtime_image() {
   pushd ../../docker
-  docker build -t starwhale -f Dockerfile.starwhale --build-arg ENABLE_E2E_TEST_PYPI_REPO=1 --build-arg PORT_NEXUS=$PORT_NEXUS --build-arg LOCAL_PYPI_HOSTNAME=$NEXUS_HOSTNAME --build-arg SW_VERSION=$PYPI_RELEASE_VERSION .
+  docker build -t starwhale -f Dockerfile.starwhale --build-arg ENABLE_E2E_TEST_PYPI_REPO=1 --build-arg PORT_NEXUS=$PORT_NEXUS --build-arg LOCAL_PYPI_HOSTNAME=$IP_MINIKUBE_BRIDGE --build-arg SW_VERSION=$PYPI_RELEASE_VERSION .
   docker tag starwhale $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/starwhale:$PYPI_RELEASE_VERSION
   docker tag starwhale $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/starwhale:$PYPI_RELEASE_VERSION
   popd

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -150,6 +150,7 @@ buid_runtime_image() {
   pushd ../../docker
   docker build -t starwhale -f Dockerfile.starwhale --build-arg ENABLE_E2E_TEST_PYPI_REPO=1 --build-arg PORT_NEXUS=$PORT_NEXUS --build-arg LOCAL_PYPI_HOSTNAME=$IP_DOCKER_BRIDGE --build-arg SW_VERSION=$PYPI_RELEASE_VERSION .
   docker tag starwhale $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/starwhale:$PYPI_RELEASE_VERSION
+  docker tag starwhale $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/starwhale:$PYPI_RELEASE_VERSION
   popd
 }
 
@@ -157,6 +158,7 @@ push_images_to_nexus() {
   docker login http://$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER -u $NEXUS_USER_NAME -p $NEXUS_USER_PWD
   docker push $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/server:$PYPI_RELEASE_VERSION
   docker push $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/starwhale:$PYPI_RELEASE_VERSION
+  docker push $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/starwhale:$PYPI_RELEASE_VERSION
 }
 
 start_starwhale() {

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -161,7 +161,7 @@ push_images_to_nexus() {
 
 start_starwhale() {
   pushd ../../docker/charts
-  helm upgrade --install $SWNAME ./ --namespace $SWNS --create-namespace --set "resources.controller.requests.memory=2G,resources.controller.requests.cpu=800m,mysql.resources.primary.requests.cpu=200m,mysql.primary.persistence.storageClass=$SWNAME-mysql,minio.resources.requests.cpu=200m, minio.persistence.storageClass=$SWNAME-minio,controller.taskSplitSize=1,minikube.enabled=true,image.registry=$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER,image.tag=$PYPI_RELEASE_VERSION,mirror.pypi.indexUrl= http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple,mirror.pypi.extraIndexUrl=$SW_PYPI_EXTRA_INDEX_URL,mirror.pypi.trustedHost=$NEXUS_HOSTNAME"
+  helm upgrade --install $SWNAME --namespace $SWNS --create-namespace --set "resources.controller.requests.memory=2G,resources.controller.requests.cpu=800m,mysql.resources.primary.requests.cpu=200m,mysql.primary.persistence.storageClass=$SWNAME-mysql,minio.resources.requests.cpu=200m, minio.persistence.storageClass=$SWNAME-minio,controller.taskSplitSize=1,minikube.enabled=true,image.registry=$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER,image.tag=$PYPI_RELEASE_VERSION,mirror.pypi.indexUrl= http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple,mirror.pypi.extraIndexUrl=$SW_PYPI_EXTRA_INDEX_URL,mirror.pypi.trustedHost=$NEXUS_HOSTNAME" .
   popd
 }
 

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -67,8 +67,9 @@ build_swcli() {
 }
 
 build_console() {
-  pushd ../../docker
-  make build-console
+  pushd ../../console
+  mkdir build
+  echo 'hi' > index.html
   popd
 }
 

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -71,7 +71,7 @@ build_swcli() {
 build_console() {
   pushd ../../console
   mkdir build
-  echo 'hi' > index.html
+  echo 'hi' > build/index.html
   popd
 }
 
@@ -197,7 +197,7 @@ check_controller_service() {
             fi
             sleep 15
     done
-    nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-controller 8082:8082 &
+    nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-starwhale-controller 8082:8082 &
 }
 
 standalone_test() {

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -38,8 +38,8 @@ declare_env() {
   export REPO_NAME_DOCKER="${REPO_NAME_DOCKER:=docker-hosted}"
   export REPO_NAME_PYPI="${REPO_NAME_PYPI:=pypi-hosted}"
   export PYTHON_VERSION="${PYTHON_VERSION:=3.9}"
-  export SWNAME="${SWNAME:=starwhale_e2e}"
-  export SWNS="${SWNS:=starwhale_e2e}"
+  export SWNAME="${SWNAME:=starwhale-e2e}"
+  export SWNS="${SWNS:=starwhale-e2e}"
 }
 
 start_minikube() {

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -188,6 +188,7 @@ check_controller_service() {
             else
               echo "controller is starting"
               kubectl get pods --namespace $SWNS
+              kubectl get svc --namespace $SWNS
   #            kubectl get pod -l starwhale.ai/role=controller -n starwhale -o json| jq -r '.items[0].status'
   #            ready=`kubectl get pod -l starwhale.ai/role=controller -n starwhale -o json| jq -r '.items[0].status.phase'`
   #            if [[ "$ready" == "Running" ]]; then

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -198,7 +198,7 @@ check_controller_service() {
             fi
             sleep 15
     done
-    nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-starwhale-controller 8082:8082 &
+    nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-controller 8082:8082 &
 }
 
 standalone_test() {

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -38,6 +38,8 @@ declare_env() {
   export REPO_NAME_DOCKER="${REPO_NAME_DOCKER:=docker-hosted}"
   export REPO_NAME_PYPI="${REPO_NAME_PYPI:=pypi-hosted}"
   export PYTHON_VERSION="${PYTHON_VERSION:=3.9}"
+  export SWNAM="${SWNAM:=starwhale_e2e}"
+  export SWNS="${SWNS:=starwhale_e2e}"
 }
 
 start_minikube() {
@@ -159,7 +161,7 @@ push_images_to_nexus() {
 
 start_starwhale() {
   pushd ../../docker/charts
-  helm upgrade --install starwhale ./ --namespace starwhale --create-namespace --set "resources.controller.requests.memory=2G,resources.controller.requests.cpu=800m,mysql.resources.primary.requests.cpu=200m,minio.resources.requests.cpu=200m,controller.taskSplitSize=1,minikube.enabled=true,image.registry=$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER,image.tag=$PYPI_RELEASE_VERSION,mirror.pypi.indexUrl= http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple,mirror.pypi.extraIndexUrl=$SW_PYPI_EXTRA_INDEX_URL,mirror.pypi.trustedHost=$NEXUS_HOSTNAME"
+  helm upgrade --install $SWNAME ./ --namespace $SWNS --create-namespace --set "resources.controller.requests.memory=2G,resources.controller.requests.cpu=800m,mysql.resources.primary.requests.cpu=200m,mysql.primary.persistence.storageClass=$SWNAME-mysql,minio.resources.requests.cpu=200m, minio.persistence.storageClass=$SWNAME-minio,controller.taskSplitSize=1,minikube.enabled=true,image.registry=$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER,image.tag=$PYPI_RELEASE_VERSION,mirror.pypi.indexUrl= http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple,mirror.pypi.extraIndexUrl=$SW_PYPI_EXTRA_INDEX_URL,mirror.pypi.trustedHost=$NEXUS_HOSTNAME"
   popd
 }
 

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -168,13 +168,13 @@ start_starwhale() {
 check_controller_service() {
     while true
     do
-      started=`kubectl get pod -l starwhale.ai/role=controller -n starwhale -o json| jq -r '.items[0].status.containerStatuses[0].started'`
+      started=`kubectl get pod -l starwhale.ai/role=controller -n $SWNS -o json| jq -r '.items[0].status.containerStatuses[0].started'`
             if [[ "$started" == "true" ]]; then
                     echo "controller started"
                     break
             else
               echo "controller is starting"
-              kubectl get pods --namespace starwhale
+              kubectl get pods --namespace $SWNS
   #            kubectl get pod -l starwhale.ai/role=controller -n starwhale -o json| jq -r '.items[0].status'
   #            ready=`kubectl get pod -l starwhale.ai/role=controller -n starwhale -o json| jq -r '.items[0].status.phase'`
   #            if [[ "$ready" == "Running" ]]; then
@@ -184,7 +184,7 @@ check_controller_service() {
             fi
             sleep 15
     done
-    nohup kubectl port-forward --namespace starwhale svc/starwhale-controller 8082:8082 &
+    nohup kubectl port-forward --namespace $SWNS svc/starwhale-controller 8082:8082 &
 }
 
 standalone_test() {

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -38,7 +38,7 @@ declare_env() {
   export REPO_NAME_DOCKER="${REPO_NAME_DOCKER:=docker-hosted}"
   export REPO_NAME_PYPI="${REPO_NAME_PYPI:=pypi-hosted}"
   export PYTHON_VERSION="${PYTHON_VERSION:=3.9}"
-  export SWNAM="${SWNAM:=starwhale_e2e}"
+  export SWNAME="${SWNAME:=starwhale_e2e}"
   export SWNS="${SWNS:=starwhale_e2e}"
 }
 

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -158,7 +158,7 @@ push_images_to_nexus() {
 
 start_starwhale() {
   pushd ../../docker/charts
-  helm upgrade --install starwhale ./ --namespace starwhale --create-namespace --set "resources.controller.requests.memory=4G,resources.controller.requests.cpu=1000m,resources.controller.limits.cpu=1000m,minio.resources.requests.cpu=1000m,minio.resources.limits.cpu=2000m,controller.taskSplitSize=1,minikube.enabled=true,image.registry=$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER,image.tag=$PYPI_RELEASE_VERSION,mirror.pypi.indexUrl= http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple,mirror.pypi.extraIndexUrl=$SW_PYPI_EXTRA_INDEX_URL,mirror.pypi.trustedHost=$NEXUS_HOSTNAME"
+  helm upgrade --install starwhale ./ --namespace starwhale --create-namespace --set "resources.controller.requests.memory=2G,resources.controller.requests.cpu=800m,mysql.resources.primary.requests.cpu=200m,minio.resources.requests.cpu=200m,controller.taskSplitSize=1,minikube.enabled=true,image.registry=$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER,image.tag=$PYPI_RELEASE_VERSION,mirror.pypi.indexUrl= http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple,mirror.pypi.extraIndexUrl=$SW_PYPI_EXTRA_INDEX_URL,mirror.pypi.trustedHost=$NEXUS_HOSTNAME"
   popd
 }
 

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -148,7 +148,7 @@ upload_pypi_to_nexus() {
 
 buid_runtime_image() {
   pushd ../../docker
-  docker build -t starwhale -f Dockerfile.starwhale --build-arg ENABLE_E2E_TEST_PYPI_REPO=1 --build-arg PORT_NEXUS=$PORT_NEXUS --build-arg LOCAL_PYPI_HOSTNAME=$IP_DOCKER_BRIDGE --build-arg SW_VERSION=$PYPI_RELEASE_VERSION .
+  docker build -t starwhale -f Dockerfile.starwhale --build-arg ENABLE_E2E_TEST_PYPI_REPO=1 --build-arg PORT_NEXUS=$PORT_NEXUS --build-arg LOCAL_PYPI_HOSTNAME=$NEXUS_HOSTNAME --build-arg SW_VERSION=$PYPI_RELEASE_VERSION .
   docker tag starwhale $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/starwhale:$PYPI_RELEASE_VERSION
   docker tag starwhale $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/starwhale:$PYPI_RELEASE_VERSION
   popd

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -161,7 +161,20 @@ push_images_to_nexus() {
 
 start_starwhale() {
   pushd ../../docker/charts
-  helm upgrade --install $SWNAME --namespace $SWNS --create-namespace --set "resources.controller.requests.memory=2G,resources.controller.requests.cpu=800m,mysql.resources.primary.requests.cpu=200m,mysql.primary.persistence.storageClass=$SWNAME-mysql,minio.resources.requests.cpu=200m, minio.persistence.storageClass=$SWNAME-minio,controller.taskSplitSize=1,minikube.enabled=true,image.registry=$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER,image.tag=$PYPI_RELEASE_VERSION,mirror.pypi.indexUrl= http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple,mirror.pypi.extraIndexUrl=$SW_PYPI_EXTRA_INDEX_URL,mirror.pypi.trustedHost=$NEXUS_HOSTNAME" .
+  helm upgrade --install $SWNAME --namespace $SWNS --create-namespace \
+  --set resources.controller.requests.cpu=700m \
+  --set mysql.resources.primary.requests.cpu=300m \
+  --set mysql.primary.persistence.storageClass=$SWNAME-mysql \
+  --set minio.resources.requests.cpu=200m \
+  --set minio.persistence.storageClass=$SWNAME-minio \
+  --set controller.taskSplitSize=1 \
+  --set minikube.enabled=true \
+  --set image.registry=$NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER \
+  --set image.tag=$PYPI_RELEASE_VERSION \
+  --set mirror.pypi.indexUrl=http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple \
+  --set mirror.pypi.extraIndexUrl=$SW_PYPI_EXTRA_INDEX_URL \
+  --set mirror.pypi.trustedHost=$NEXUS_HOSTNAME \
+   .
   popd
 }
 
@@ -184,7 +197,7 @@ check_controller_service() {
             fi
             sleep 15
     done
-    nohup kubectl port-forward --namespace $SWNS svc/starwhale-controller 8082:8082 &
+    nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-controller 8082:8082 &
 }
 
 standalone_test() {

--- a/scripts/e2e_test/test_job_run.sh
+++ b/scripts/e2e_test/test_job_run.sh
@@ -55,7 +55,8 @@ do
         echo "job FAIL"
         break
   elif [[ -z "$job_status" ]] ; then
-     nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-controller 8082:8082 &
+    kill -9 `ps -ef|grep port-forward | grep -v grep | awk '{print $2}'`
+    nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-controller 8082:8082 &
   else
     echo "job status for " "$job_id" "is" "$job_status"
 #    kubectl logs --tail=10 -l job-name=1 -n starwhale -c data-provider

--- a/scripts/e2e_test/test_job_run.sh
+++ b/scripts/e2e_test/test_job_run.sh
@@ -55,7 +55,7 @@ do
         echo "job FAIL"
         break
   elif [[ -z "$job_status" ]] ; then
-    kill -9 `ps -ef|grep port-forward | grep -v grep | awk '{print $2}'`
+    if kill -9 `ps -ef|grep port-forward | grep -v grep | awk '{print $2}'` ; then echo "kill success"; fi
     nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-controller 8082:8082 &
     sleep 20
   else

--- a/scripts/e2e_test/test_job_run.sh
+++ b/scripts/e2e_test/test_job_run.sh
@@ -57,6 +57,7 @@ do
   elif [[ -z "$job_status" ]] ; then
     kill -9 `ps -ef|grep port-forward | grep -v grep | awk '{print $2}'`
     nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-controller 8082:8082 &
+    sleep 20
   else
     echo "job status for " "$job_id" "is" "$job_status"
 #    kubectl logs --tail=10 -l job-name=1 -n starwhale -c data-provider

--- a/scripts/e2e_test/test_job_run.sh
+++ b/scripts/e2e_test/test_job_run.sh
@@ -54,6 +54,8 @@ do
   elif [[ "$job_status" = "FAIL" ]] ; then
         echo "job FAIL"
         break
+  elif [[ -z "$job_status" ]] ; then
+     nohup kubectl port-forward --namespace $SWNS svc/$SWNAME-controller 8082:8082 &
   else
     echo "job status for " "$job_id" "is" "$job_status"
 #    kubectl logs --tail=10 -l job-name=1 -n starwhale -c data-provider

--- a/scripts/e2e_test/test_job_run.sh
+++ b/scripts/e2e_test/test_job_run.sh
@@ -28,7 +28,7 @@ job_id=`curl -X 'POST' \
   "datasetVersionUrls": "1",
   "runtimeVersionUrl": "1",
   "device": "1",
-  "deviceAmount": 1,
+  "deviceAmount": 0.4,
   "comment": "string"
 }' | jq -r '.data'`
 

--- a/scripts/e2e_test/test_job_run.sh
+++ b/scripts/e2e_test/test_job_run.sh
@@ -42,7 +42,7 @@ do
   if curl -X 'GET' \
     "http://$1/api/v1/project/1/job/$job_id" \
     -H 'accept: application/json' \
-    -H "$auth_header" | jq -r '.data.jobStatus' > jobStatus ; then echo "8082 well"; else  kubectl logs --tail=10 -l starwhale.ai/role=controller -n starwhale; continue; fi
+    -H "$auth_header" | jq -r '.data.jobStatus' > jobStatus ; then echo "8082 well"; else  kubectl logs --tail=10 -l starwhale.ai/role=controller -n $SWNS; continue; fi
   job_status=`cat jobStatus`
   if [ "$job_status" == "null" ] ; then
     echo "Error! job_status id is null"  1>&2


### PR DESCRIPTION
## Description
tested on [forked repo](https://github.com/anda-ren/starwhale/runs/8219783754?check_suite_focus=true) 

- people could trigger e2e test manually if needed
- people could open a debug session when trigger it manually

![image](https://user-images.githubusercontent.com/89630947/188778944-5d1990f8-664f-47ec-91f3-54654bb1954b.png)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
