### PR TITLE
fix(datastore): add ignoreNonExistingTable option for scan table

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
@@ -151,6 +151,7 @@ public class DataStoreController implements DataStoreApi {
                     .limit(request.getLimit())
                     .keepNone(request.isKeepNone())
                     .rawResult(request.isRawResult())
+                    .ignoreNonExistingTable(request.isIgnoreNonExistingTable())
                     .build());
             return ResponseEntity.ok(Code.success.asResponse(RecordListVo.builder()
                     .columnTypes(recordList.getColumnTypeMap())

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/ScanTableRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/ScanTableRequest.java
@@ -30,4 +30,5 @@ public class ScanTableRequest {
     private int limit = -1;
     private boolean keepNone;
     private boolean rawResult;
+    private boolean ignoreNonExistingTable;
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/DataStoreControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/DataStoreControllerTest.java
@@ -631,6 +631,27 @@ public class DataStoreControllerTest {
         }
 
         @Test
+        public void testTableNotExists() {
+            this.req.setTableName("table not exists");
+            assertThrows(SwValidationException.class,
+                    () -> DataStoreControllerTest.this.controller.queryTable(this.req),
+                    "");
+        }
+
+        @Test
+        public void testTableNotExistsIgnore() {
+            this.req.setTableName("table not exists");
+            this.req.setIgnoreNonExistingTable(true);
+
+            var resp = DataStoreControllerTest.this.controller.queryTable(this.req);
+            assertThat("test", resp.getStatusCode().is2xxSuccessful(), is(true));
+            assertThat("test",
+                    Objects.requireNonNull(resp.getBody()).getData().getColumnTypes().isEmpty());
+            assertThat("test",
+                    Objects.requireNonNull(resp.getBody()).getData().getRecords().isEmpty());
+        }
+
+        @Test
         public void testNullColumnName() {
             this.req.getColumns().get(0).setColumnName(null);
             assertThrows(SwValidationException.class,
@@ -1156,6 +1177,15 @@ public class DataStoreControllerTest {
             assertThrows(SwValidationException.class,
                     () -> DataStoreControllerTest.this.controller.scanTable(this.req),
                     "");
+        }
+
+        @Test
+        public void testTableNotExistsIgnore() {
+            this.req.getTables().get(0).setTableName("invalid");
+            this.req.setIgnoreNonExistingTable(true);
+
+            var resp = DataStoreControllerTest.this.controller.scanTable(this.req);
+            assertThat("test", resp.getStatusCode().is2xxSuccessful(), is(true));
         }
 
         @Test


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
