### PR TITLE
chore(controller): use static constants instead of enum in order to support future complex types

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchema.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchema.java
@@ -42,9 +42,9 @@ public class ColumnSchema {
         }
         this.name = schema.getName();
         try {
-            this.type = ColumnType.valueOf(schema.getType());
+            this.type = ColumnType.getColumnTypeByName(schema.getType());
         } catch (IllegalArgumentException e) {
-            throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE).tip(
+            throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE,
                     "invalid column type " + schema.getType());
         }
         this.index = index;

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnType.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnType.java
@@ -26,19 +26,20 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 
 @Getter
-public enum ColumnType {
+public class ColumnType {
+
     // if the column type is UNKNOWN, all values in the column are null. It is used for those columns whose type is
     // unknown. A UNKNOWN column will be changed to other types when a value other than null is written into the column.
-    UNKNOWN("unknown", 1),
-    BOOL("bool", 1),
-    INT8("int", 8),
-    INT16("int", 16),
-    INT32("int", 32),
-    INT64("int", 64),
-    FLOAT32("float", 32),
-    FLOAT64("float", 64),
-    STRING("string", 8),
-    BYTES("bytes", 8);
+    public static final ColumnType UNKNOWN = new ColumnType("unknown", 1);
+    public static final ColumnType BOOL = new ColumnType("bool", 1);
+    public static final ColumnType INT8 = new ColumnType("int", 8);
+    public static final ColumnType INT16 = new ColumnType("int", 16);
+    public static final ColumnType INT32 = new ColumnType("int", 32);
+    public static final ColumnType INT64 = new ColumnType("int", 64);
+    public static final ColumnType FLOAT32 = new ColumnType("float", 32);
+    public static final ColumnType FLOAT64 = new ColumnType("float", 64);
+    public static final ColumnType STRING = new ColumnType("string", 8);
+    public static final ColumnType BYTES = new ColumnType("bytes", 8);
 
     private static final Map<Class<?>, ColumnType> typeMap = Map.of(
             Boolean.class, BOOL,
@@ -50,11 +51,23 @@ public enum ColumnType {
             Double.class, FLOAT64,
             String.class, STRING);
 
-    private final String name;
-    private int nbits;
+    private static final Map<String, ColumnType> typeMapByName = Map.of(
+            UNKNOWN.toString(), UNKNOWN,
+            BOOL.toString(), BOOL,
+            INT8.toString(), INT8,
+            INT16.toString(), INT16,
+            INT32.toString(), INT32,
+            INT64.toString(), INT64,
+            FLOAT32.toString(), FLOAT32,
+            FLOAT64.toString(), FLOAT64,
+            STRING.toString(), STRING,
+            BYTES.toString(), BYTES);
 
-    ColumnType(String name, int nbits) {
-        this.name = name;
+    private final String category;
+    private final int nbits;
+
+    ColumnType(String category, int nbits) {
+        this.category = category;
         this.nbits = nbits;
     }
 
@@ -72,48 +85,60 @@ public enum ColumnType {
         return ret;
     }
 
+    public static ColumnType getColumnTypeByName(String typeName) {
+        var ret = typeMapByName.get(typeName.toUpperCase());
+        if (ret == null) {
+            throw new IllegalArgumentException("invalid column type " + typeName);
+        }
+        return ret;
+    }
+
+    @Override
+    public String toString() {
+        if (this.category.equals(ColumnType.INT32.category) || this.category.equals(ColumnType.FLOAT32.category)) {
+            return this.category.toUpperCase() + this.nbits;
+        } else {
+            return this.category.toUpperCase();
+        }
+    }
+
     @SneakyThrows
     public String encode(Object value, boolean rawResult) {
         if (value == null) {
             return null;
         }
         if (rawResult) {
-            switch (this) {
-                case BOOL:
-                case INT8:
-                case INT16:
-                case INT32:
-                case INT64:
-                case FLOAT32:
-                case FLOAT64:
-                case STRING:
-                    return value.toString();
-                case BYTES:
-                    return StandardCharsets.UTF_8.decode((ByteBuffer) value).toString();
-                default:
-                    throw new IllegalArgumentException("invalid type " + this);
+            if (this == ColumnType.BOOL
+                    || this == ColumnType.INT8
+                    || this == ColumnType.INT16
+                    || this == ColumnType.INT32
+                    || this == ColumnType.INT64
+                    || this == ColumnType.FLOAT32
+                    || this == ColumnType.FLOAT64
+                    || this == ColumnType.STRING) {
+                return value.toString();
+            } else if (this == ColumnType.BYTES) {
+                return StandardCharsets.UTF_8.decode((ByteBuffer) value).toString();
             }
         } else {
-            switch (this) {
-                case BOOL:
-                    return (Boolean) value ? "1" : "0";
-                case INT8:
-                case INT16:
-                case INT32:
-                case INT64:
-                    return Long.toHexString(((Number) value).longValue());
-                case FLOAT32:
-                    return Integer.toHexString(Float.floatToIntBits((Float) value));
-                case FLOAT64:
-                    return Long.toHexString(Double.doubleToLongBits((Double) value));
-                case STRING:
-                    return (String) value;
-                case BYTES:
-                    return Base64.getEncoder().encodeToString(((ByteBuffer) value).array());
-                default:
-                    throw new IllegalArgumentException("invalid type " + this);
+            if (this == ColumnType.BOOL) {
+                return (Boolean) value ? "1" : "0";
+            } else if (this == ColumnType.INT8
+                    || this == ColumnType.INT16
+                    || this == ColumnType.INT32
+                    || this == ColumnType.INT64) {
+                return Long.toHexString(((Number) value).longValue());
+            } else if (this == ColumnType.FLOAT32) {
+                return Integer.toHexString(Float.floatToIntBits((Float) value));
+            } else if (this == ColumnType.FLOAT64) {
+                return Long.toHexString(Double.doubleToLongBits((Double) value));
+            } else if (this == ColumnType.STRING) {
+                return (String) value;
+            } else if (this == ColumnType.BYTES) {
+                return Base64.getEncoder().encodeToString(((ByteBuffer) value).array());
             }
         }
+        throw new IllegalArgumentException("invalid type " + this);
     }
 
     public Object decode(String value) {
@@ -121,35 +146,33 @@ public enum ColumnType {
             return null;
         }
         try {
-            switch (this) {
-                case UNKNOWN:
-                    throw new IllegalArgumentException("invalid unknown value " + value);
-                case BOOL:
-                    if (value.equals("1")) {
-                        return true;
-                    } else if (value.equals("0")) {
-                        return false;
-                    }
-                    throw new IllegalArgumentException("invalid bool value " + value);
-                case INT8:
-                    return Byte.parseByte(value, 16);
-                case INT16:
-                    return Short.parseShort(value, 16);
-                case INT32:
-                    return Integer.parseInt(value, 16);
-                case INT64:
-                    return Long.parseLong(value, 16);
-                case FLOAT32:
-                    return Float.intBitsToFloat(Integer.parseInt(value, 16));
-                case FLOAT64:
-                    return Double.longBitsToDouble(Long.parseLong(value, 16));
-                case STRING:
-                    return value;
-                case BYTES:
-                    return ByteBuffer.wrap(Base64.getDecoder().decode(value));
-                default:
-                    throw new IllegalArgumentException("invalid type " + this);
+            if (this == ColumnType.UNKNOWN) {
+                throw new IllegalArgumentException("invalid unknown value " + value);
+            } else if (this == ColumnType.BOOL) {
+                if (value.equals("1")) {
+                    return true;
+                } else if (value.equals("0")) {
+                    return false;
+                }
+                throw new IllegalArgumentException("invalid bool value " + value);
+            } else if (this == ColumnType.INT8) {
+                return Byte.parseByte(value, 16);
+            } else if (this == ColumnType.INT16) {
+                return Short.parseShort(value, 16);
+            } else if (this == ColumnType.INT32) {
+                return Integer.parseInt(value, 16);
+            } else if (this == ColumnType.INT64) {
+                return Long.parseLong(value, 16);
+            } else if (this == ColumnType.FLOAT32) {
+                return Float.intBitsToFloat(Integer.parseInt(value, 16));
+            } else if (this == ColumnType.FLOAT64) {
+                return Double.longBitsToDouble(Long.parseLong(value, 16));
+            } else if (this == ColumnType.STRING) {
+                return value;
+            } else if (this == ColumnType.BYTES) {
+                return ByteBuffer.wrap(Base64.getDecoder().decode(value));
             }
+            throw new IllegalArgumentException("invalid type " + this);
         } catch (Exception e) {
             throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE).tip(
                     MessageFormat.format("can not decode value {0} for type {1}: {2}", value, this, e.getMessage()));

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/index/datastore/IndexWriter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/index/datastore/IndexWriter.java
@@ -90,7 +90,7 @@ public class IndexWriter {
 
     private TableSchemaDesc toSchema(Map<String, ColumnType> tableSchemaMap) {
         List<ColumnSchemaDesc> columnSchemaDescs = tableSchemaMap.entrySet().stream()
-                .map(entry -> new ColumnSchemaDesc(entry.getKey(), entry.getValue().name())).collect(
+                .map(entry -> new ColumnSchemaDesc(entry.getKey(), entry.getValue().getCategory())).collect(
                         Collectors.toList());
         return new TableSchemaDesc("id", columnSchemaDescs);
     }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/datastore/TestIndexWriter.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/datastore/TestIndexWriter.java
@@ -63,22 +63,22 @@ public class TestIndexWriter {
         List<ColumnSchemaDesc> columnSchemaList = tableSchemaDesc.getColumnSchemaList();
         columnSchemaList.forEach(columnSchemaDesc -> {
             if ("id".equals(columnSchemaDesc.getName())) {
-                Assertions.assertEquals(ColumnType.INT64.name(), columnSchemaDesc.getType());
+                Assertions.assertEquals(ColumnType.INT64.getCategory(), columnSchemaDesc.getType());
             }
             if ("data_offset".equals(columnSchemaDesc.getName())) {
-                Assertions.assertEquals(ColumnType.INT64.name(), columnSchemaDesc.getType());
+                Assertions.assertEquals(ColumnType.INT64.getCategory(), columnSchemaDesc.getType());
             }
             if ("data_size".equals(columnSchemaDesc.getName())) {
-                Assertions.assertEquals(ColumnType.INT64.name(), columnSchemaDesc.getType());
+                Assertions.assertEquals(ColumnType.INT64.getCategory(), columnSchemaDesc.getType());
             }
             if ("data_format".equals(columnSchemaDesc.getName())) {
-                Assertions.assertEquals(ColumnType.STRING.name(), columnSchemaDesc.getType());
+                Assertions.assertEquals(ColumnType.STRING.getCategory(), columnSchemaDesc.getType());
             }
             if ("object_store_type".equals(columnSchemaDesc.getName())) {
-                Assertions.assertEquals(ColumnType.STRING.name(), columnSchemaDesc.getType());
+                Assertions.assertEquals(ColumnType.STRING.getCategory(), columnSchemaDesc.getType());
             }
             if ("score".equals(columnSchemaDesc.getName())) {
-                Assertions.assertEquals(ColumnType.FLOAT64.name(), columnSchemaDesc.getType());
+                Assertions.assertEquals(ColumnType.FLOAT64.getCategory(), columnSchemaDesc.getType());
             }
         });
         Assertions.assertEquals("table-x", request.getTableName());


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [X] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
