### PR TITLE
feat(controller): support version alias for model/dataset/runtime

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/runtime/RuntimeInfoVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/runtime/RuntimeInfoVo.java
@@ -20,7 +20,6 @@ import ai.starwhale.mlops.api.protocol.StorageFileVo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.Builder;
@@ -42,6 +41,9 @@ public class RuntimeInfoVo implements Serializable {
     @JsonProperty("versionName")
     private String versionName;
 
+    @JsonProperty("versionAlias")
+    private String versionAlias;
+
     @JsonProperty("versionTag")
     private String versionTag;
 
@@ -59,6 +61,6 @@ public class RuntimeInfoVo implements Serializable {
     private List<StorageFileVo> files;
 
     public static RuntimeInfoVo empty() {
-        return new RuntimeInfoVo("", "", "", "", "", "", 0L, new ArrayList<>());
+        return new RuntimeInfoVo("", "", "", "", "", "", "", 0L, List.of());
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/runtime/RuntimeVersionVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/runtime/RuntimeVersionVo.java
@@ -39,6 +39,9 @@ public class RuntimeVersionVo implements Serializable {
     @JsonProperty("tag")
     private String tag;
 
+    @JsonProperty("alias")
+    private String alias;
+
     @JsonProperty("meta")
     private Object meta;
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swds/DatasetVersionVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swds/DatasetVersionVo.java
@@ -39,6 +39,9 @@ public class DatasetVersionVo implements Serializable {
     @JsonProperty("tag")
     private String tag;
 
+    @JsonProperty("alias")
+    private String alias;
+
     @JsonProperty("meta")
     private Object meta;
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swds/SwDatasetInfoVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swds/SwDatasetInfoVo.java
@@ -43,6 +43,9 @@ public class SwDatasetInfoVo implements Serializable {
     @JsonProperty("versionName")
     private String versionName;
 
+    @JsonProperty("versionAlias")
+    private String versionAlias;
+
     /**
      * the table name for index in DataStore
      */

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swmp/SwModelPackageInfoVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swmp/SwModelPackageInfoVo.java
@@ -39,6 +39,9 @@ public class SwModelPackageInfoVo implements Serializable {
     @JsonProperty("name")
     private String name;
 
+    @JsonProperty("versionAlias")
+    private String versionAlias;
+
     @JsonProperty("versionName")
     private String versionName;
 
@@ -60,7 +63,7 @@ public class SwModelPackageInfoVo implements Serializable {
 
     public static SwModelPackageInfoVo empty() {
         return new SwModelPackageInfoVo("", "",
-                "", "", "", "",
+                "", "", "", "", "",
                 0L, new ArrayList<>());
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swmp/SwModelPackageVersionVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swmp/SwModelPackageVersionVo.java
@@ -36,6 +36,9 @@ public class SwModelPackageVersionVo implements Serializable {
     @JsonProperty("name")
     private String name;
 
+    @JsonProperty("alias")
+    private String alias;
+
     @JsonProperty("tag")
     private String tag;
 
@@ -55,7 +58,7 @@ public class SwModelPackageVersionVo implements Serializable {
     private UserVo owner;
 
     public static SwModelPackageVersionVo empty() {
-        return new SwModelPackageVersionVo("", "", "", "{}", "",
+        return new SwModelPackageVersionVo("", "", "", "", "{}", "",
                 0L, -1L, UserVo.empty());
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/common/VersionAliasConvertor.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/VersionAliasConvertor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.common;
+
+import ai.starwhale.mlops.exception.ConvertException;
+import cn.hutool.core.util.StrUtil;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VersionAliasConvertor implements Convertor<Long, String> {
+
+    @Override
+    public String convert(Long order) throws ConvertException {
+        if (order == null) {
+            return null;
+        }
+        return "v" + order;
+    }
+
+    @Override
+    public Long revert(String alias) throws ConvertException {
+        if (StrUtil.isEmpty(alias)) {
+            return null;
+        }
+        try {
+            if (!alias.startsWith("v")) {
+                throw new Exception("Alias is not start with v");
+            }
+            return Long.parseLong(alias.substring(1));
+        } catch (Exception e) {
+            throw new ConvertException("Version alias revert error: " + alias, e);
+        }
+    }
+
+    public boolean isVersionAlias(String alias) {
+        return alias != null
+                && alias.startsWith("v")
+                && StrUtil.isNumeric(alias.substring(1));
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/common/VersionAliasConvertor.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/VersionAliasConvertor.java
@@ -17,7 +17,7 @@
 package ai.starwhale.mlops.common;
 
 import ai.starwhale.mlops.exception.ConvertException;
-import cn.hutool.core.util.StrUtil;
+import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -26,20 +26,17 @@ public class VersionAliasConvertor implements Convertor<Long, String> {
     @Override
     public String convert(Long order) throws ConvertException {
         if (order == null) {
-            return null;
+            throw new ConvertException("Version alias covert error: order is null");
         }
         return "v" + order;
     }
 
     @Override
     public Long revert(String alias) throws ConvertException {
-        if (StrUtil.isEmpty(alias)) {
-            return null;
+        if (!isVersionAlias(alias)) {
+            throw new ConvertException("Version alias revert error: " + alias);
         }
         try {
-            if (!alias.startsWith("v")) {
-                throw new Exception("Alias is not start with v");
-            }
             return Long.parseLong(alias.substring(1));
         } catch (Exception e) {
             throw new ConvertException("Version alias revert error: " + alias, e);
@@ -48,7 +45,6 @@ public class VersionAliasConvertor implements Convertor<Long, String> {
 
     public boolean isVersionAlias(String alias) {
         return alias != null
-                && alias.startsWith("v")
-                && StrUtil.isNumeric(alias.substring(1));
+                && Pattern.compile("v\\d+").matcher(alias).matches();
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/bundle/BundleManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/bundle/BundleManager.java
@@ -17,6 +17,7 @@
 package ai.starwhale.mlops.domain.bundle;
 
 import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.bundle.base.BundleEntity;
 import ai.starwhale.mlops.domain.bundle.base.BundleVersionEntity;
 import ai.starwhale.mlops.domain.project.ProjectAccessor;
@@ -32,16 +33,19 @@ public class BundleManager {
     public static final String BUNDLE_NAME_REGEX = "^[a-zA-Z][a-zA-Z\\d_-]{2,80}$";
     private final ProjectAccessor projectAccessor;
     private final IdConvertor idConvertor;
+    private final VersionAliasConvertor versionAliasConvertor;
     private final BundleAccessor bundleAccessor;
     private final BundleVersionAccessor bundleVersionAccessor;
     private final ValidSubject validSubject;
 
     public BundleManager(IdConvertor idConvertor,
+            VersionAliasConvertor versionAliasConvertor,
             ProjectAccessor projectAccessor,
             BundleAccessor bundleAccessor,
             BundleVersionAccessor bundleVersionAccessor,
             ValidSubject validSubject) {
         this.idConvertor = idConvertor;
+        this.versionAliasConvertor = versionAliasConvertor;
         this.projectAccessor = projectAccessor;
         this.bundleAccessor = bundleAccessor;
         this.bundleVersionAccessor = bundleVersionAccessor;
@@ -81,6 +85,8 @@ public class BundleManager {
         BundleVersionEntity entity;
         if (idConvertor.isId(versionUrl)) {
             entity = bundleVersionAccessor.findVersionById(idConvertor.revert(versionUrl));
+        } else if (versionAliasConvertor.isVersionAlias(versionUrl)) {
+            entity = bundleVersionAccessor.findVersionByAliasAndBundleId(versionUrl, bundleId);
         } else {
             entity = bundleVersionAccessor.findVersionByNameAndBundleId(versionUrl, bundleId);
         }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/bundle/BundleVersionAccessor.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/bundle/BundleVersionAccessor.java
@@ -22,5 +22,7 @@ public interface BundleVersionAccessor {
 
     BundleVersionEntity findVersionById(Long bundleVersionId);
 
+    BundleVersionEntity findVersionByAliasAndBundleId(String alias, Long bundleId);
+
     BundleVersionEntity findVersionByNameAndBundleId(String name, Long bundleId);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeManager.java
@@ -17,6 +17,7 @@
 package ai.starwhale.mlops.domain.runtime;
 
 import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.bundle.BundleAccessor;
 import ai.starwhale.mlops.domain.bundle.BundleVersionAccessor;
 import ai.starwhale.mlops.domain.bundle.base.BundleEntity;
@@ -51,6 +52,9 @@ public class RuntimeManager implements BundleAccessor, BundleVersionAccessor, Ta
     @Resource
     private IdConvertor idConvertor;
 
+    @Resource
+    private VersionAliasConvertor versionAliasConvertor;
+
     public Long getRuntimeVersionId(String versionUrl, Long runtimeId) {
         if (idConvertor.isId(versionUrl)) {
             return idConvertor.revert(versionUrl);
@@ -76,6 +80,12 @@ public class RuntimeManager implements BundleAccessor, BundleVersionAccessor, Ta
     @Override
     public BundleVersionEntity findVersionById(Long bundleVersionId) {
         return runtimeVersionMapper.findVersionById(bundleVersionId);
+    }
+
+    @Override
+    public BundleVersionEntity findVersionByAliasAndBundleId(String alias, Long bundleId) {
+        Long versionOrder = versionAliasConvertor.revert(alias);
+        return runtimeVersionMapper.findByVersionOrderAndRuntimeId(versionOrder, bundleId);
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeManager.java
@@ -35,7 +35,6 @@ import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
 import ai.starwhale.mlops.exception.api.StarwhaleApiException;
 import java.util.List;
-import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -45,15 +44,18 @@ import org.springframework.stereotype.Service;
 public class RuntimeManager implements BundleAccessor, BundleVersionAccessor, TagAccessor,
         RevertAccessor, RecoverAccessor, RemoveAccessor {
 
-    @Resource
-    private RuntimeMapper runtimeMapper;
-    @Resource
-    private RuntimeVersionMapper runtimeVersionMapper;
-    @Resource
-    private IdConvertor idConvertor;
+    private final RuntimeMapper runtimeMapper;
+    private final RuntimeVersionMapper runtimeVersionMapper;
+    private final IdConvertor idConvertor;
+    private final VersionAliasConvertor versionAliasConvertor;
 
-    @Resource
-    private VersionAliasConvertor versionAliasConvertor;
+    public RuntimeManager(RuntimeMapper runtimeMapper, RuntimeVersionMapper runtimeVersionMapper,
+            IdConvertor idConvertor, VersionAliasConvertor versionAliasConvertor) {
+        this.runtimeMapper = runtimeMapper;
+        this.runtimeVersionMapper = runtimeVersionMapper;
+        this.idConvertor = idConvertor;
+        this.versionAliasConvertor = versionAliasConvertor;
+    }
 
     public Long getRuntimeVersionId(String versionUrl, Long runtimeId) {
         if (idConvertor.isId(versionUrl)) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -26,6 +26,7 @@ import ai.starwhale.mlops.common.LocalDateTimeConvertor;
 import ai.starwhale.mlops.common.PageParams;
 import ai.starwhale.mlops.common.TagAction;
 import ai.starwhale.mlops.common.TarFileUtil;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.common.util.PageUtil;
 import ai.starwhale.mlops.domain.bundle.BundleManager;
 import ai.starwhale.mlops.domain.bundle.BundleUrl;
@@ -127,11 +128,15 @@ public class RuntimeService {
     private LocalDateTimeConvertor localDateTimeConvertor;
 
     @Resource
+    private VersionAliasConvertor versionAliasConvertor;
+
+    @Resource
     @Qualifier("yamlMapper")
     private ObjectMapper yamlMapper;
 
     private BundleManager bundleManager() {
-        return new BundleManager(idConvertor, projectManager, runtimeManager, runtimeManager, ValidSubject.RUNTIME);
+        return new BundleManager(idConvertor, versionAliasConvertor, projectManager, runtimeManager, runtimeManager,
+                ValidSubject.RUNTIME);
     }
 
     public PageInfo<RuntimeVo> listRuntime(RuntimeQuery runtimeQuery, PageParams pageParams) {
@@ -190,6 +195,7 @@ public class RuntimeService {
             return RuntimeInfoVo.builder()
                     .id(idConvertor.convert(rt.getId()))
                     .name(rt.getRuntimeName())
+                    .versionAlias(versionAliasConvertor.convert(versionEntity.getVersionOrder()))
                     .versionName(versionEntity.getVersionName())
                     .versionTag(versionEntity.getVersionTag())
                     .versionMeta(versionEntity.getVersionMeta())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConvertor.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConvertor.java
@@ -20,23 +20,27 @@ import ai.starwhale.mlops.api.protocol.runtime.RuntimeVersionVo;
 import ai.starwhale.mlops.common.Convertor;
 import ai.starwhale.mlops.common.IdConvertor;
 import ai.starwhale.mlops.common.LocalDateTimeConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
 import ai.starwhale.mlops.domain.user.UserConvertor;
 import ai.starwhale.mlops.exception.ConvertException;
-import javax.annotation.Resource;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RuntimeVersionConvertor implements Convertor<RuntimeVersionEntity, RuntimeVersionVo> {
 
-    @Resource
-    private IdConvertor idConvertor;
+    private final IdConvertor idConvertor;
+    private final UserConvertor userConvertor;
+    private final LocalDateTimeConvertor localDateTimeConvertor;
+    private final VersionAliasConvertor versionAliasConvertor;
 
-    @Resource
-    private UserConvertor userConvertor;
-
-    @Resource
-    private LocalDateTimeConvertor localDateTimeConvertor;
+    public RuntimeVersionConvertor(IdConvertor idConvertor, UserConvertor userConvertor,
+            LocalDateTimeConvertor localDateTimeConvertor, VersionAliasConvertor versionAliasConvertor) {
+        this.idConvertor = idConvertor;
+        this.userConvertor = userConvertor;
+        this.localDateTimeConvertor = localDateTimeConvertor;
+        this.versionAliasConvertor = versionAliasConvertor;
+    }
 
     @Override
     public RuntimeVersionVo convert(RuntimeVersionEntity entity)
@@ -44,6 +48,7 @@ public class RuntimeVersionConvertor implements Convertor<RuntimeVersionEntity, 
         return RuntimeVersionVo.builder()
                 .id(idConvertor.convert(entity.getId()))
                 .name(entity.getVersionName())
+                .alias(versionAliasConvertor.convert(entity.getVersionOrder()))
                 .owner(userConvertor.convert(entity.getOwner()))
                 .tag(entity.getVersionTag())
                 .meta(entity.getVersionMeta())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/mapper/RuntimeMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/mapper/RuntimeMapper.java
@@ -18,8 +18,10 @@ package ai.starwhale.mlops.domain.runtime.mapper;
 
 import ai.starwhale.mlops.domain.runtime.po.RuntimeEntity;
 import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+@Mapper
 public interface RuntimeMapper {
 
     List<RuntimeEntity> listRuntimes(@Param("projectId") Long projectId, @Param("namePrefix") String namePrefix);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/mapper/RuntimeVersionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/mapper/RuntimeVersionMapper.java
@@ -41,4 +41,7 @@ public interface RuntimeVersionMapper {
 
     RuntimeVersionEntity findByNameAndRuntimeId(@Param("rtVersion") String rtVersion,
             @Param("runtimeId") Long runtimeId);
+
+    RuntimeVersionEntity findByVersionOrderAndRuntimeId(@Param("versionOrder") Long versionOrder,
+            @Param("runtimeId") Long runtimeId);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/mapper/RuntimeVersionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/mapper/RuntimeVersionMapper.java
@@ -18,8 +18,10 @@ package ai.starwhale.mlops.domain.runtime.mapper;
 
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
 import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+@Mapper
 public interface RuntimeVersionMapper {
 
     List<RuntimeVersionEntity> listVersions(@Param("runtimeId") Long runtimeId,

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/po/RuntimeVersionEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/po/RuntimeVersionEntity.java
@@ -34,6 +34,8 @@ public class RuntimeVersionEntity extends BaseEntity implements BundleVersionEnt
 
     private Long id;
 
+    private Long versionOrder;
+
     private Long runtimeId;
 
     private Long ownerId;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwDatasetService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwDatasetService.java
@@ -24,6 +24,7 @@ import ai.starwhale.mlops.common.IdConvertor;
 import ai.starwhale.mlops.common.LocalDateTimeConvertor;
 import ai.starwhale.mlops.common.PageParams;
 import ai.starwhale.mlops.common.TagAction;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.common.util.PageUtil;
 import ai.starwhale.mlops.domain.bundle.BundleManager;
 import ai.starwhale.mlops.domain.bundle.BundleUrl;
@@ -41,6 +42,7 @@ import ai.starwhale.mlops.domain.swds.bo.SwdsQuery;
 import ai.starwhale.mlops.domain.swds.bo.SwdsVersion;
 import ai.starwhale.mlops.domain.swds.bo.SwdsVersionQuery;
 import ai.starwhale.mlops.domain.swds.converter.SwdsVersionConvertor;
+import ai.starwhale.mlops.domain.swds.converter.SwdsVoConvertor;
 import ai.starwhale.mlops.domain.swds.mapper.SwDatasetMapper;
 import ai.starwhale.mlops.domain.swds.mapper.SwDatasetVersionMapper;
 import ai.starwhale.mlops.domain.swds.objectstore.DsFileGetter;
@@ -79,7 +81,7 @@ public class SwDatasetService {
     private SwDatasetVersionMapper swdsVersionMapper;
 
     @Resource
-    private ai.starwhale.mlops.domain.swds.converter.SwdsVoConvertor swdsVoConvertor;
+    private SwdsVoConvertor swdsVoConvertor;
 
     @Resource
     private SwdsVersionConvertor versionConvertor;
@@ -100,6 +102,9 @@ public class SwDatasetService {
     private LocalDateTimeConvertor localDateTimeConvertor;
 
     @Resource
+    private VersionAliasConvertor versionAliasConvertor;
+
+    @Resource
     private UserService userService;
 
     @Resource
@@ -109,7 +114,8 @@ public class SwDatasetService {
     private DsFileGetter dsFileGetter;
 
     private BundleManager bundleManager() {
-        return new BundleManager(idConvertor, projectManager, swdsManager, swdsManager, ValidSubject.SWDS);
+        return new BundleManager(idConvertor, versionAliasConvertor, projectManager, swdsManager, swdsManager,
+                ValidSubject.SWDS);
     }
 
     public PageInfo<DatasetVo> listSwDataset(SwdsQuery query, PageParams pageParams) {
@@ -181,6 +187,7 @@ public class SwDatasetService {
                     .id(idConvertor.convert(ds.getId()))
                     .name(ds.getDatasetName())
                     .versionName(versionEntity.getVersionName())
+                    .versionAlias(versionAliasConvertor.convert(versionEntity.getVersionOrder()))
                     .versionTag(versionEntity.getVersionTag())
                     .versionMeta(versionEntity.getVersionMeta())
                     .createdTime(localDateTimeConvertor.convert(versionEntity.getCreatedTime()))

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwdsManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwdsManager.java
@@ -17,6 +17,7 @@
 package ai.starwhale.mlops.domain.swds;
 
 import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.bundle.BundleAccessor;
 import ai.starwhale.mlops.domain.bundle.BundleVersionAccessor;
 import ai.starwhale.mlops.domain.bundle.base.BundleEntity;
@@ -53,6 +54,9 @@ public class SwdsManager implements BundleAccessor, BundleVersionAccessor, TagAc
     @Resource
     private IdConvertor idConvertor;
 
+    @Resource
+    private VersionAliasConvertor versionAliasConvertor;
+
     public Long getSwdsVersionId(String versionUrl, Long swdsId) {
         if (idConvertor.isId(versionUrl)) {
             return idConvertor.revert(versionUrl);
@@ -78,6 +82,12 @@ public class SwdsManager implements BundleAccessor, BundleVersionAccessor, TagAc
     @Override
     public BundleVersionEntity findVersionById(Long bundleVersionId) {
         return datasetVersionMapper.getVersionById(bundleVersionId);
+    }
+
+    @Override
+    public BundleVersionEntity findVersionByAliasAndBundleId(String alias, Long bundleId) {
+        Long versionOrder = versionAliasConvertor.revert(alias);
+        return datasetVersionMapper.findByDsIdAndVersionOrder(bundleId, versionOrder);
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwdsManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwdsManager.java
@@ -35,7 +35,6 @@ import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
 import ai.starwhale.mlops.exception.api.StarwhaleApiException;
 import java.util.List;
-import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -45,17 +44,18 @@ import org.springframework.stereotype.Service;
 public class SwdsManager implements BundleAccessor, BundleVersionAccessor, TagAccessor,
         RevertAccessor, RecoverAccessor, RemoveAccessor {
 
-    @Resource
-    private SwDatasetMapper datasetMapper;
+    private final SwDatasetMapper datasetMapper;
+    private final SwDatasetVersionMapper datasetVersionMapper;
+    private final IdConvertor idConvertor;
+    private final VersionAliasConvertor versionAliasConvertor;
 
-    @Resource
-    private SwDatasetVersionMapper datasetVersionMapper;
-
-    @Resource
-    private IdConvertor idConvertor;
-
-    @Resource
-    private VersionAliasConvertor versionAliasConvertor;
+    public SwdsManager(SwDatasetMapper datasetMapper, SwDatasetVersionMapper datasetVersionMapper,
+            IdConvertor idConvertor, VersionAliasConvertor versionAliasConvertor) {
+        this.datasetMapper = datasetMapper;
+        this.datasetVersionMapper = datasetVersionMapper;
+        this.idConvertor = idConvertor;
+        this.versionAliasConvertor = versionAliasConvertor;
+    }
 
     public Long getSwdsVersionId(String versionUrl, Long swdsId) {
         if (idConvertor.isId(versionUrl)) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/converter/SwdsVersionConvertor.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/converter/SwdsVersionConvertor.java
@@ -20,24 +20,27 @@ import ai.starwhale.mlops.api.protocol.swds.DatasetVersionVo;
 import ai.starwhale.mlops.common.Convertor;
 import ai.starwhale.mlops.common.IdConvertor;
 import ai.starwhale.mlops.common.LocalDateTimeConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity;
 import ai.starwhale.mlops.domain.user.UserConvertor;
 import ai.starwhale.mlops.exception.ConvertException;
-import java.util.Objects;
-import javax.annotation.Resource;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SwdsVersionConvertor implements Convertor<SwDatasetVersionEntity, DatasetVersionVo> {
 
-    @Resource
-    private IdConvertor idConvertor;
+    private final IdConvertor idConvertor;
+    private final UserConvertor userConvertor;
+    private final LocalDateTimeConvertor localDateTimeConvertor;
+    private final VersionAliasConvertor versionAliasConvertor;
 
-    @Resource
-    private UserConvertor userConvertor;
-
-    @Resource
-    private LocalDateTimeConvertor localDateTimeConvertor;
+    public SwdsVersionConvertor(IdConvertor idConvertor, UserConvertor userConvertor,
+            LocalDateTimeConvertor localDateTimeConvertor, VersionAliasConvertor versionAliasConvertor) {
+        this.idConvertor = idConvertor;
+        this.userConvertor = userConvertor;
+        this.localDateTimeConvertor = localDateTimeConvertor;
+        this.versionAliasConvertor = versionAliasConvertor;
+    }
 
     @Override
     public DatasetVersionVo convert(SwDatasetVersionEntity entity)
@@ -47,6 +50,7 @@ public class SwdsVersionConvertor implements Convertor<SwDatasetVersionEntity, D
         }
         return DatasetVersionVo.builder()
                 .id(idConvertor.convert(entity.getId()))
+                .alias(versionAliasConvertor.convert(entity.getVersionOrder()))
                 .name(entity.getVersionName())
                 .owner(userConvertor.convert(entity.getOwner()))
                 .tag(entity.getVersionTag())
@@ -58,12 +62,6 @@ public class SwdsVersionConvertor implements Convertor<SwDatasetVersionEntity, D
     @Override
     public SwDatasetVersionEntity revert(DatasetVersionVo vo)
             throws ConvertException {
-        Objects.requireNonNull(vo, "datasetVersionVo");
-        return SwDatasetVersionEntity.builder()
-                .id(idConvertor.revert(vo.getId()))
-                .versionName(vo.getName())
-                .ownerId(idConvertor.revert(vo.getOwner().getId()))
-                .versionTag(vo.getTag())
-                .build();
+        throw new UnsupportedOperationException();
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/mapper/SwDatasetVersionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/mapper/SwDatasetVersionMapper.java
@@ -44,6 +44,9 @@ public interface SwDatasetVersionMapper {
     SwDatasetVersionEntity findByDsIdAndVersionName(@Param("datasetId") Long datasetId,
             @Param("versionName") String versionName);
 
+    SwDatasetVersionEntity findByDsIdAndVersionOrder(@Param("datasetId") Long datasetId,
+            @Param("versionOrder") Long versionOrder);
+
     int revertTo(@Param("dsId") Long dsId, @Param("dsVersionId") Long dsVersionId);
 
     int addNewVersion(@Param("version") SwDatasetVersionEntity version);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/po/SwDatasetVersionEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/po/SwDatasetVersionEntity.java
@@ -36,6 +36,8 @@ public class SwDatasetVersionEntity extends BaseEntity implements BundleVersionE
 
     private Long datasetId;
 
+    private Long versionOrder;
+
     private String datasetName;
 
     private Long ownerId;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwModelPackageService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwModelPackageService.java
@@ -26,6 +26,7 @@ import ai.starwhale.mlops.common.LocalDateTimeConvertor;
 import ai.starwhale.mlops.common.PageParams;
 import ai.starwhale.mlops.common.TagAction;
 import ai.starwhale.mlops.common.TarFileUtil;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.common.util.PageUtil;
 import ai.starwhale.mlops.domain.bundle.BundleManager;
 import ai.starwhale.mlops.domain.bundle.BundleUrl;
@@ -94,6 +95,9 @@ public class SwModelPackageService {
 
     @Resource
     private LocalDateTimeConvertor localDateTimeConvertor;
+
+    @Resource
+    private VersionAliasConvertor versionAliasConvertor;
 
     @Resource
     private SwmpConvertor swmpConvertor;
@@ -220,6 +224,7 @@ public class SwModelPackageService {
             return SwModelPackageInfoVo.builder()
                     .id(idConvertor.convert(model.getId()))
                     .name(model.getSwmpName())
+                    .versionAlias(versionAliasConvertor.convert(version.getVersionOrder()))
                     .versionName(version.getVersionName())
                     .versionTag(version.getVersionTag())
                     .versionMeta(version.getVersionMeta())
@@ -449,6 +454,7 @@ public class SwModelPackageService {
     }
 
     private BundleManager bundleManager() {
-        return new BundleManager(idConvertor, projectManager, swmpManager, swmpManager, ValidSubject.SWMP);
+        return new BundleManager(idConvertor, versionAliasConvertor, projectManager, swmpManager, swmpManager,
+                ValidSubject.SWMP);
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwmpManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwmpManager.java
@@ -35,7 +35,6 @@ import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
 import ai.starwhale.mlops.exception.api.StarwhaleApiException;
 import java.util.List;
-import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -45,15 +44,18 @@ import org.springframework.stereotype.Service;
 public class SwmpManager implements BundleAccessor, BundleVersionAccessor, TagAccessor,
         RevertAccessor, RecoverAccessor, RemoveAccessor {
 
-    @Resource
-    private SwModelPackageMapper swmpMapper;
-    @Resource
-    private SwModelPackageVersionMapper versionMapper;
-    @Resource
-    private IdConvertor idConvertor;
+    private final SwModelPackageMapper swmpMapper;
+    private final SwModelPackageVersionMapper versionMapper;
+    private final IdConvertor idConvertor;
+    private final VersionAliasConvertor versionAliasConvertor;
 
-    @Resource
-    private VersionAliasConvertor versionAliasConvertor;
+    public SwmpManager(SwModelPackageMapper swmpMapper, SwModelPackageVersionMapper versionMapper,
+            IdConvertor idConvertor, VersionAliasConvertor versionAliasConvertor) {
+        this.swmpMapper = swmpMapper;
+        this.versionMapper = versionMapper;
+        this.idConvertor = idConvertor;
+        this.versionAliasConvertor = versionAliasConvertor;
+    }
 
     public Long getSwmpVersionId(String versionUrl, Long swmpId) {
         if (idConvertor.isId(versionUrl)) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwmpManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwmpManager.java
@@ -17,6 +17,7 @@
 package ai.starwhale.mlops.domain.swmp;
 
 import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.bundle.BundleAccessor;
 import ai.starwhale.mlops.domain.bundle.BundleVersionAccessor;
 import ai.starwhale.mlops.domain.bundle.base.BundleEntity;
@@ -50,6 +51,9 @@ public class SwmpManager implements BundleAccessor, BundleVersionAccessor, TagAc
     private SwModelPackageVersionMapper versionMapper;
     @Resource
     private IdConvertor idConvertor;
+
+    @Resource
+    private VersionAliasConvertor versionAliasConvertor;
 
     public Long getSwmpVersionId(String versionUrl, Long swmpId) {
         if (idConvertor.isId(versionUrl)) {
@@ -94,6 +98,12 @@ public class SwmpManager implements BundleAccessor, BundleVersionAccessor, TagAc
     @Override
     public BundleVersionEntity findVersionById(Long bundleVersionId) {
         return versionMapper.findVersionById(bundleVersionId);
+    }
+
+    @Override
+    public BundleVersionEntity findVersionByAliasAndBundleId(String alias, Long bundleId) {
+        Long versionOrder = versionAliasConvertor.revert(alias);
+        return versionMapper.findByVersionOrderAndSwmpId(versionOrder, bundleId);
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwmpVersionConvertor.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwmpVersionConvertor.java
@@ -20,24 +20,28 @@ import ai.starwhale.mlops.api.protocol.swmp.SwModelPackageVersionVo;
 import ai.starwhale.mlops.common.Convertor;
 import ai.starwhale.mlops.common.IdConvertor;
 import ai.starwhale.mlops.common.LocalDateTimeConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity;
 import ai.starwhale.mlops.domain.user.UserConvertor;
 import ai.starwhale.mlops.exception.ConvertException;
 import java.util.Objects;
-import javax.annotation.Resource;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SwmpVersionConvertor implements Convertor<SwModelPackageVersionEntity, SwModelPackageVersionVo> {
 
-    @Resource
-    private IdConvertor idConvertor;
+    private final IdConvertor idConvertor;
+    private final UserConvertor userConvertor;
+    private final LocalDateTimeConvertor localDateTimeConvertor;
+    private final VersionAliasConvertor versionAliasConvertor;
 
-    @Resource
-    private UserConvertor userConvertor;
-
-    @Resource
-    private LocalDateTimeConvertor localDateTimeConvertor;
+    public SwmpVersionConvertor(IdConvertor idConvertor, UserConvertor userConvertor,
+            LocalDateTimeConvertor localDateTimeConvertor, VersionAliasConvertor versionAliasConvertor) {
+        this.idConvertor = idConvertor;
+        this.userConvertor = userConvertor;
+        this.localDateTimeConvertor = localDateTimeConvertor;
+        this.versionAliasConvertor = versionAliasConvertor;
+    }
 
     @Override
     public SwModelPackageVersionVo convert(SwModelPackageVersionEntity entity)
@@ -45,6 +49,7 @@ public class SwmpVersionConvertor implements Convertor<SwModelPackageVersionEnti
         return SwModelPackageVersionVo.builder()
                 .id(idConvertor.convert(entity.getId()))
                 .name(entity.getVersionName())
+                .alias(versionAliasConvertor.convert(entity.getVersionOrder()))
                 .owner(userConvertor.convert(entity.getOwner()))
                 .tag(entity.getVersionTag())
                 .meta(entity.getVersionMeta())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwmpVersionConvertor.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/SwmpVersionConvertor.java
@@ -24,7 +24,6 @@ import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity;
 import ai.starwhale.mlops.domain.user.UserConvertor;
 import ai.starwhale.mlops.exception.ConvertException;
-import java.util.Objects;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -61,12 +60,6 @@ public class SwmpVersionConvertor implements Convertor<SwModelPackageVersionEnti
     @Override
     public SwModelPackageVersionEntity revert(SwModelPackageVersionVo vo)
             throws ConvertException {
-        Objects.requireNonNull(vo, "SWModelPackageVersionVo");
-        return SwModelPackageVersionEntity.builder()
-                .id(idConvertor.revert(vo.getId()))
-                .versionName(vo.getName())
-                .ownerId(idConvertor.revert(vo.getOwner().getId()))
-                .versionTag(vo.getTag())
-                .build();
+        throw new UnsupportedOperationException();
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/mapper/SwModelPackageMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/mapper/SwModelPackageMapper.java
@@ -18,8 +18,10 @@ package ai.starwhale.mlops.domain.swmp.mapper;
 
 import ai.starwhale.mlops.domain.swmp.po.SwModelPackageEntity;
 import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+@Mapper
 public interface SwModelPackageMapper {
 
     List<SwModelPackageEntity> listSwModelPackages(@Param("projectId") Long projectId,

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/mapper/SwModelPackageVersionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/mapper/SwModelPackageVersionMapper.java
@@ -40,4 +40,7 @@ public interface SwModelPackageVersionMapper {
     int updateTag(@Param("versionId") Long versionId, @Param("tag") String tag);
 
     SwModelPackageVersionEntity findByNameAndSwmpId(@Param("swmpVersion") String version, @Param("swmpId") Long id);
+
+    SwModelPackageVersionEntity findByVersionOrderAndSwmpId(@Param("versionOrder") Long versionOrder,
+            @Param("swmpId") Long id);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/mapper/SwModelPackageVersionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/mapper/SwModelPackageVersionMapper.java
@@ -18,8 +18,10 @@ package ai.starwhale.mlops.domain.swmp.mapper;
 
 import ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity;
 import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+@Mapper
 public interface SwModelPackageVersionMapper {
 
     List<SwModelPackageVersionEntity> listVersions(@Param("swmpId") Long swmpId, @Param("namePrefix") String namePrefix,

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/po/SwModelPackageVersionEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swmp/po/SwModelPackageVersionEntity.java
@@ -36,6 +36,8 @@ public class SwModelPackageVersionEntity extends BaseEntity implements BundleVer
 
     private Long swmpId;
 
+    private Long versionOrder;
+
     private String swmpName;
 
     private Long ownerId;

--- a/server/controller/src/main/java/ai/starwhale/mlops/exception/ConvertException.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/exception/ConvertException.java
@@ -20,6 +20,10 @@ import static ai.starwhale.mlops.api.protocol.Code.internalServerError;
 
 public class ConvertException extends StarwhaleException {
 
+    public ConvertException(String message) {
+        super(message);
+    }
+
     public ConvertException(String message, Throwable e) {
         super(message, e);
     }

--- a/server/controller/src/main/resources/mapper/RuntimeVersionMapper.xml
+++ b/server/controller/src/main/resources/mapper/RuntimeVersionMapper.xml
@@ -19,24 +19,40 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="ai.starwhale.mlops.domain.runtime.mapper.RuntimeVersionMapper">
   <sql id="select_runtime_version">
-    select rv.id as rv_id,
-    rv.runtime_id,
-    rv.owner_id,
-    rv.version_name as rv_version_name,
-    rv.version_tag as rv_version_tag,
-    rv.version_meta as rv_version_meta,
-    rv.storage_path as rv_storage_path,
-    rv.image as rv_image,
-    rv.created_time as rv_created_time,
-    rv.modified_time as rv_modified_time,
-    u.id as user_id,
-    u.user_name,
-    u.created_time as user_created_time,
-    u.user_enabled
+    select rv.id            as rv_id,
+           rv.runtime_id,
+           rv.owner_id,
+           rv.version_order as rv_version_order,
+           rv.version_name  as rv_version_name,
+           rv.version_tag   as rv_version_tag,
+           rv.version_meta  as rv_version_meta,
+           rv.storage_path  as rv_storage_path,
+           rv.image         as rv_image,
+           rv.created_time  as rv_created_time,
+           rv.modified_time as rv_modified_time,
+           u.id             as user_id,
+           u.user_name,
+           u.created_time   as user_created_time,
+           u.user_enabled
     from runtime_version as rv,
-    user_info as u
+         user_info as u
     where owner_id = u.id
   </sql>
+
+  <insert id="addNewVersion"
+    keyProperty="id"
+    parameterType="ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity"
+    useGeneratedKeys="true">
+    insert into runtime_version (runtime_id, owner_id, version_name, version_tag, version_meta,
+                                 storage_path, image)
+    values (#{version.runtimeId},
+            #{version.ownerId},
+            #{version.versionName},
+            #{version.versionTag},
+            #{version.versionMeta},
+            #{version.storagePath},
+            #{version.image})
+  </insert>
 
   <select id="listVersions" resultMap="runtimeVersionResultMap">
     <include refid="select_runtime_version"/>
@@ -78,39 +94,62 @@
     limit 1
   </select>
 
-  <insert id="revertTo">
+  <select id="findByVersionOrderAndRuntimeId" resultMap="runtimeVersionResultMap">
+    <if test="runtimeId != null">
+      and rv.runtime_id = #{runtimeId}
+    </if>
+    <include refid="select_runtime_version"/>
+    and rv.version_order = #{versionOrder}
+  </select>
+
+  <update id="revertTo">
     update runtime_version
-    set version_order = (select max from ((select max(version_order) as max from runtime_version))
-    as v) + 1
+    set version_order = if((select version_order
+                            from ((select version_order
+                                   from runtime_version
+                                   where id = #{rtVersionId})) as v1)
+                             = (select max
+                                from (select max(version_order) as max
+                                      from runtime_version
+                                      where runtime_id = (select runtime_id
+                                                          from runtime_version
+                                                          where id = #{rtVersionId})) as v2)
+                             and
+                           (select version_order
+                            from ((select version_order
+                                   from runtime_version
+                                   where id = #{rtVersionId})) as v3)
+                             != 0,
+                           (select version_order
+                            from (select version_order
+                                  from runtime_version
+                                  where id = #{rtVersionId}) as v4),
+                           (select max
+                            from ((select max(version_order) as max
+                                   from runtime_version
+                                   where runtime_id = (select runtime_id
+                                                       from runtime_version
+                                                       where id = #{rtVersionId}))) as v5) + 1)
     where id = #{rtVersionId}
-  </insert>
-
-  <insert id="addNewVersion"
-    parameterType="ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity"
-    useGeneratedKeys="true" keyProperty="id">
-    insert into runtime_version (runtime_id, owner_id, version_name, version_tag, version_meta,
-    storage_path, image)
-    values(#{version.runtimeId},
-    #{version.ownerId},
-    #{version.versionName},
-    #{version.versionTag},
-    #{version.versionMeta},
-    #{version.storagePath},
-    #{version.image})
-  </insert>
-
-  <update id="update" parameterType="ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity">
-    update runtime_version set version_tag = #{version.versionTag} where id = #{version.id}
   </update>
 
   <update id="updateTag" parameterType="ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity">
-    update runtime_version set version_tag = #{tag} where id = #{versionId}
+    update runtime_version
+    set version_tag = #{tag}
+    where id = #{versionId}
+  </update>
+
+  <update id="update" parameterType="ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity">
+    update runtime_version
+    set version_tag = #{version.versionTag}
+    where id = #{version.id}
   </update>
 
   <resultMap id="runtimeVersionResultMap"
     type="ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity">
     <id property="id" column="rv_id"/>
     <result property="runtimeId" column="runtime_id"/>
+    <result column="rv_version_order" property="versionOrder"/>
     <result property="versionName" column="rv_version_name"/>
     <result property="versionTag" column="rv_version_tag"/>
     <result property="versionMeta" column="rv_version_meta"/>

--- a/server/controller/src/main/resources/mapper/SwDatasetVersionMapper.xml
+++ b/server/controller/src/main/resources/mapper/SwDatasetVersionMapper.xml
@@ -9,30 +9,37 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="ai.starwhale.mlops.domain.swds.mapper.SwDatasetVersionMapper">
   <sql id="select_swds_version">
-    select dsv.id as dsv_id,
-    dataset_id,
-    dsv.owner_id,
-    dsv.size as dsv_size,
-    dsv.index_table as dsv_index_table,
-    dsv.storage_auths as dsv_storage_auths,
-    version_name as dsv_version_name,
-    version_tag as dsv_version_tag,
-    version_meta as dsv_version_meta,
-    storage_path as dsv_storage_path,
-    status as status,
-    dsv.created_time as dsv_created_time,
-    dsv.modified_time as dsv_modified_time,
-    ds.dataset_name as ds_dataset_name,
-    u.id as user_id,
-    u.user_name,
-    u.created_time as user_created_time,
-    u.user_enabled
+    select dsv.id            as dsv_id,
+           dataset_id,
+           dsv.version_order as dsv_version_order,
+           dsv.owner_id,
+           dsv.size          as dsv_size,
+           dsv.index_table   as dsv_index_table,
+           dsv.storage_auths as dsv_storage_auths,
+           version_name      as dsv_version_name,
+           version_tag       as dsv_version_tag,
+           version_meta      as dsv_version_meta,
+           storage_path      as dsv_storage_path,
+           status            as status,
+           dsv.created_time  as dsv_created_time,
+           dsv.modified_time as dsv_modified_time,
+           ds.dataset_name   as ds_dataset_name,
+           u.id              as user_id,
+           u.user_name,
+           u.created_time    as user_created_time,
+           u.user_enabled
     from dataset_version as dsv,
-    dataset_info as ds,
-    user_info as u
+         dataset_info as ds,
+         user_info as u
     where dsv.owner_id = u.id
-    and ds.id = dsv.dataset_id
+      and ds.id = dsv.dataset_id
   </sql>
+
+  <delete id="deleteById">
+    delete
+    from dataset_version
+    WHERE id = #{id};
+  </delete>
 
   <select id="listVersions" resultMap="dsVersionResultMap">
     <include refid="select_swds_version"/>
@@ -60,6 +67,17 @@
     </if>
     and version_name = #{versionName}
   </select>
+
+  <insert id="addNewVersion"
+    keyProperty="id" parameterType="ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity"
+    useGeneratedKeys="true">
+    insert into dataset_version (dataset_id, owner_id, version_name, size, index_table, version_tag,
+                                 version_meta, storage_path, files_uploaded)
+    values (#{version.datasetId}, #{version.ownerId}, #{version.versionName}, #{version.size},
+            #{version.indexTable}, #{version.versionTag}, #{version.versionMeta},
+            #{version.storagePath},
+            #{version.filesUploaded})
+  </insert>
 
   <select id="getVersionById" resultMap="dsVersionResultMap">
     <include refid="select_swds_version"/>
@@ -94,66 +112,95 @@
     limit 1
   </select>
 
-  <insert id="revertTo">
-    update dataset_version
-    set version_order = (select max from ((select max(version_order) as max from dataset_version))
-    as v) + 1
-    where id = #{dsVersionId}
-  </insert>
+  <select id="findByDsIdAndVersionOrder" resultMap="dsVersionResultMap">
+    <if test="datasetId != null">
+      and dataset_id = #{datasetId}
+    </if>
+    <include refid="select_swds_version"/>
+    and version_order = #{versionOrder}
+  </select>
 
-  <insert id="addNewVersion"
-    parameterType="ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity" useGeneratedKeys="true"
-    keyProperty="id">
-    insert into dataset_version (dataset_id, owner_id, version_name, size, index_table, version_tag,
-    version_meta, storage_path, files_uploaded)
-    values(#{version.datasetId}, #{version.ownerId}, #{version.versionName}, #{version.size},
-    #{version.indexTable}, #{version.versionTag}, #{version.versionMeta}, #{version.storagePath},
-    #{version.filesUploaded})
-  </insert>
+  <update id="revertTo">
+    update dataset_version
+    set version_order = if((select version_order
+                            from ((select version_order
+                                   from dataset_version
+                                   where id = #{dsVersionId})) as v1)
+                             = (select max
+                                from (select max(version_order) as max
+                                      from dataset_version
+                                      where dataset_id = (select dataset_id
+                                                          from dataset_version
+                                                          where id = #{dsVersionId})) as v2)
+                             and
+                           (select version_order
+                            from ((select version_order
+                                   from dataset_version
+                                   where id = #{dsVersionId})) as v3)
+                             != 0,
+                           (select version_order
+                            from (select version_order
+                                  from dataset_version
+                                  where id = #{dsVersionId}) as v4),
+                           (select max
+                            from ((select max(version_order) as max
+                                   from dataset_version
+                                   where dataset_id = (select dataset_id
+                                                       from dataset_version
+                                                       where id = #{dsVersionId}))) as v5) + 1)
+    where id = #{dsVersionId}
+  </update>
 
   <update id="update" parameterType="ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity">
-    update dataset_version set version_tag = #{version.versionTag} where id = #{version.id}
+    update dataset_version
+    set version_tag = #{version.versionTag}
+    where id = #{version.id}
   </update>
 
   <update id="updateTag" parameterType="ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity">
-    update dataset_version set version_tag = #{tag} where id = #{versionId}
+    update dataset_version
+    set version_tag = #{tag}
+    where id = #{versionId}
   </update>
 
   <update id="updateFilesUploaded"
     parameterType="ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity">
-    update dataset_version set files_uploaded = #{version.filesUploaded} where id = #{version.id}
+    update dataset_version
+    set files_uploaded = #{version.filesUploaded}
+    where id = #{version.id}
   </update>
 
   <update id="updateStatus">
-    update dataset_version set status = #{status} where id = #{id}
+    update dataset_version
+    set status = #{status}
+    where id = #{id}
   </update>
+
 
   <update id="updateStorageAuths">
-    update dataset_version set storage_auths = #{storageAuths} where id = #{id}
+    update dataset_version
+    set storage_auths = #{storageAuths}
+    where id = #{id}
   </update>
-
-  <delete id="deleteById">
-    delete from dataset_version WHERE id = #{id};
-  </delete>
-
 
   <resultMap id="dsVersionResultMap"
     type="ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity">
-    <id property="id" column="dsv_id"/>
-    <result property="datasetId" column="dataset_id"/>
-    <result property="versionName" column="dsv_version_name"/>
-    <result property="datasetName" column="ds_dataset_name"/>
-    <result property="size" column="dsv_size"/>
-    <result property="indexTable" column="dsv_index_table"/>
-    <result property="storageAuths" column="dsv_storage_auths"/>
-    <result property="versionTag" column="dsv_version_tag"/>
-    <result property="versionMeta" column="dsv_version_meta"/>
-    <result property="storagePath" column="dsv_storage_path"/>
-    <result property="createdTime" column="dsv_created_time"/>
-    <result property="modifiedTime" column="dsv_modified_time"/>
-    <result property="ownerId" column="owner_id"/>
-    <result property="status" column="status"/>
-    <result property="filesUploaded" column="files_uploaded"/>
+    <id column="dsv_id" property="id"/>
+    <result column="dataset_id" property="datasetId"/>
+    <result column="dsv_version_order" property="versionOrder"/>
+    <result column="dsv_version_name" property="versionName"/>
+    <result column="ds_dataset_name" property="datasetName"/>
+    <result column="dsv_size" property="size"/>
+    <result column="dsv_index_table" property="indexTable"/>
+    <result column="dsv_storage_auths" property="storageAuths"/>
+    <result column="dsv_version_tag" property="versionTag"/>
+    <result column="dsv_version_meta" property="versionMeta"/>
+    <result column="dsv_storage_path" property="storagePath"/>
+    <result column="dsv_created_time" property="createdTime"/>
+    <result column="dsv_modified_time" property="modifiedTime"/>
+    <result column="owner_id" property="ownerId"/>
+    <result column="status" property="status"/>
+    <result column="files_uploaded" property="filesUploaded"/>
     <association property="owner"
       resultMap="ai.starwhale.mlops.domain.user.mapper.UserMapper.userResultMap"/>
   </resultMap>

--- a/server/controller/src/main/resources/mapper/SwModelPackageVersionMapper.xml
+++ b/server/controller/src/main/resources/mapper/SwModelPackageVersionMapper.xml
@@ -9,28 +9,46 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="ai.starwhale.mlops.domain.swmp.mapper.SwModelPackageVersionMapper">
   <sql id="select_swmp_version">
-    select mv.id as mv_id,
-    mv.swmp_id,
-    mv.owner_id,
-    mv.version_name as mv_version_name,
-    mv.version_tag as mv_version_tag,
-    mv.version_meta as mv_version_meta,
-    mv.storage_path as mv_storage_path,
-    mv.manifest as mv_manifest,
-    mv.eval_jobs as mv_eval_jobs,
-    mv.created_time as mv_created_time,
-    mv.modified_time as mv_modified_time,
-    m.swmp_name as swmp_name,
-    u.id as user_id,
-    u.user_name,
-    u.created_time as user_created_time,
-    u.user_enabled
+    select mv.id            as mv_id,
+           mv.swmp_id,
+           mv.owner_id,
+           mv.version_name  as mv_version_name,
+           mv.version_order as mv_version_order,
+           mv.version_tag   as mv_version_tag,
+           mv.version_meta  as mv_version_meta,
+           mv.storage_path  as mv_storage_path,
+           mv.manifest      as mv_manifest,
+           mv.eval_jobs     as mv_eval_jobs,
+           mv.created_time  as mv_created_time,
+           mv.modified_time as mv_modified_time,
+           m.swmp_name      as swmp_name,
+           u.id             as user_id,
+           u.user_name,
+           u.created_time   as user_created_time,
+           u.user_enabled
     from swmp_version as mv,
-    swmp_info as m,
-    user_info as u
+         swmp_info as m,
+         user_info as u
     where mv.owner_id = u.id
-    and mv.swmp_id = m.id
+      and mv.swmp_id = m.id
   </sql>
+
+  <insert id="addNewVersion"
+    keyProperty="id"
+    parameterType="ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity"
+    useGeneratedKeys="true">
+    insert into swmp_version (swmp_id, owner_id, version_name, version_tag, version_meta,
+                              storage_path, manifest, eval_jobs)
+    values (#{version.swmpId},
+            #{version.ownerId},
+            #{version.versionName},
+            #{version.versionTag},
+            #{version.versionMeta},
+            #{version.storagePath},
+            #{version.manifest},
+            #{version.evalJobs})
+  </insert>
+
   <select id="listVersions" resultMap="swmpVersionResultMap">
     <include refid="select_swmp_version"/>
     and swmp_id = #{swmpId}
@@ -71,51 +89,73 @@
     limit 1
   </select>
 
-  <insert id="revertTo">
+  <select id="findByVersionOrderAndSwmpId" resultMap="swmpVersionResultMap">
+    <if test="swmpId != null">
+      and mv.swmp_id = #{swmpId}
+    </if>
+    <include refid="select_swmp_version"/>
+    and mv.version_order = #{versionOrder}
+  </select>
+
+  <update id="revertTo">
     update swmp_version
-    set version_order = (select max from ((select max(version_order) as max from swmp_version)) as
-    v) + 1
+    set version_order = if((select version_order
+                            from ((select version_order
+                                   from swmp_version
+                                   where id = #{swmpVersionId})) as v1)
+                             = (select max
+                                from (select max(version_order) as max
+                                      from swmp_version
+                                      where swmp_id = (select swmp_id
+                                                       from swmp_version
+                                                       where id = #{swmpVersionId})) as v2)
+                             and
+                           (select version_order
+                            from ((select version_order
+                                   from swmp_version
+                                   where id = #{swmpVersionId})) as v3)
+                             != 0,
+                           (select version_order
+                            from (select version_order
+                                  from swmp_version
+                                  where id = #{swmpVersionId}) as v4),
+                           (select max
+                            from ((select max(version_order) as max
+                                   from swmp_version
+                                   where swmp_id = (select swmp_id
+                                                    from swmp_version
+                                                    where id = #{swmpVersionId}))) as v5) + 1)
     where id = #{swmpVersionId}
-  </insert>
-
-  <insert id="addNewVersion"
-    parameterType="ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity"
-    useGeneratedKeys="true" keyProperty="id">
-    insert into swmp_version (swmp_id, owner_id, version_name, version_tag, version_meta,
-    storage_path, manifest, eval_jobs)
-    values(#{version.swmpId},
-    #{version.ownerId},
-    #{version.versionName},
-    #{version.versionTag},
-    #{version.versionMeta},
-    #{version.storagePath},
-    #{version.manifest},
-    #{version.evalJobs})
-  </insert>
-
-  <update id="update" parameterType="ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity">
-    update swmp_version set version_tag = #{version.versionTag} where id = #{version.id}
   </update>
 
   <update id="updateTag"
     parameterType="ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity">
-    update swmp_version set version_tag = #{tag} where id = #{versionId}
+    update swmp_version
+    set version_tag = #{tag}
+    where id = #{versionId}
+  </update>
+
+  <update id="update" parameterType="ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity">
+    update swmp_version
+    set version_tag = #{version.versionTag}
+    where id = #{version.id}
   </update>
 
   <resultMap id="swmpVersionResultMap"
     type="ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity">
-    <id property="id" column="mv_id"/>
-    <result property="swmpId" column="swmp_id"/>
-    <result property="swmpName" column="swmp_name"/>
-    <result property="versionName" column="mv_version_name"/>
-    <result property="versionTag" column="mv_version_tag"/>
-    <result property="versionMeta" column="mv_version_meta"/>
-    <result property="storagePath" column="mv_storage_path"/>
-    <result property="manifest" column="mv_manifest"/>
-    <result property="evalJobs" column="mv_eval_jobs"/>
-    <result property="createdTime" column="mv_created_time"/>
-    <result property="modifiedTime" column="mv_modified_time"/>
-    <result property="ownerId" column="owner_id"/>
+    <id column="mv_id" property="id"/>
+    <result column="swmp_id" property="swmpId"/>
+    <result column="swmp_name" property="swmpName"/>
+    <result column="mv_version_order" property="versionOrder"/>
+    <result column="mv_version_name" property="versionName"/>
+    <result column="mv_version_tag" property="versionTag"/>
+    <result column="mv_version_meta" property="versionMeta"/>
+    <result column="mv_storage_path" property="storagePath"/>
+    <result column="mv_manifest" property="manifest"/>
+    <result column="mv_eval_jobs" property="evalJobs"/>
+    <result column="mv_created_time" property="createdTime"/>
+    <result column="mv_modified_time" property="modifiedTime"/>
+    <result column="owner_id" property="ownerId"/>
     <association property="owner"
       resultMap="ai.starwhale.mlops.domain.user.mapper.UserMapper.userResultMap"/>
   </resultMap>

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/VersionAliasConvertorTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/VersionAliasConvertorTest.java
@@ -18,7 +18,6 @@ package ai.starwhale.mlops.common;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import ai.starwhale.mlops.exception.ConvertException;
@@ -36,10 +35,10 @@ public class VersionAliasConvertorTest {
 
     @Test
     public void testConvert() {
-        var res = versionAliasConvertor.convert(null);
-        assertThat(res, nullValue());
+        assertThrows(ConvertException.class,
+                () -> versionAliasConvertor.convert(null));
 
-        res = versionAliasConvertor.convert(1L);
+        var res = versionAliasConvertor.convert(1L);
         assertThat(res, is("v1"));
 
         res = versionAliasConvertor.convert(100L);
@@ -48,22 +47,40 @@ public class VersionAliasConvertorTest {
 
     @Test
     public void testRevert() {
-        var res = versionAliasConvertor.revert(null);
-        assertThat(res, nullValue());
-
-        res = versionAliasConvertor.revert("");
-        assertThat(res, nullValue());
-
-        res = versionAliasConvertor.revert("v1");
+        var res = versionAliasConvertor.revert("v1");
         assertThat(res, is(1L));
 
         res = versionAliasConvertor.revert("v100");
         assertThat(res, is(100L));
 
         assertThrows(ConvertException.class,
+                () -> versionAliasConvertor.revert(null));
+
+        assertThrows(ConvertException.class,
+                () -> versionAliasConvertor.revert(""));
+
+        assertThrows(ConvertException.class,
                 () -> versionAliasConvertor.revert("v"));
 
         assertThrows(ConvertException.class,
                 () -> versionAliasConvertor.revert("vv100"));
+    }
+
+    @Test
+    public void testIsVersionAlias() {
+        var res = versionAliasConvertor.isVersionAlias(null);
+        assertThat(res, is(false));
+
+        res = versionAliasConvertor.isVersionAlias("");
+        assertThat(res, is(false));
+
+        res = versionAliasConvertor.isVersionAlias("v");
+        assertThat(res, is(false));
+
+        res = versionAliasConvertor.isVersionAlias("va");
+        assertThat(res, is(false));
+
+        res = versionAliasConvertor.isVersionAlias("v2");
+        assertThat(res, is(true));
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/VersionAliasConvertorTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/VersionAliasConvertorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.starwhale.mlops.exception.ConvertException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class VersionAliasConvertorTest {
+
+    private VersionAliasConvertor versionAliasConvertor;
+
+    @BeforeEach
+    public void setUp() {
+        versionAliasConvertor = new VersionAliasConvertor();
+    }
+
+    @Test
+    public void testConvert() {
+        var res = versionAliasConvertor.convert(null);
+        assertThat(res, nullValue());
+
+        res = versionAliasConvertor.convert(1L);
+        assertThat(res, is("v1"));
+
+        res = versionAliasConvertor.convert(100L);
+        assertThat(res, is("v100"));
+    }
+
+    @Test
+    public void testRevert() {
+        var res = versionAliasConvertor.revert(null);
+        assertThat(res, nullValue());
+
+        res = versionAliasConvertor.revert("");
+        assertThat(res, nullValue());
+
+        res = versionAliasConvertor.revert("v1");
+        assertThat(res, is(1L));
+
+        res = versionAliasConvertor.revert("v100");
+        assertThat(res, is(100L));
+
+        assertThrows(ConvertException.class,
+                () -> versionAliasConvertor.revert("v"));
+
+        assertThrows(ConvertException.class,
+                () -> versionAliasConvertor.revert("vv100"));
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/bundle/BundleManagerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/bundle/BundleManagerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.bundle;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
+import ai.starwhale.mlops.domain.bundle.base.BundleVersionEntity;
+import ai.starwhale.mlops.domain.project.ProjectAccessor;
+import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
+import ai.starwhale.mlops.exception.api.StarwhaleApiException;
+import lombok.Builder;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class BundleManagerTest {
+
+    private BundleManager bundleManager;
+    private ProjectAccessor projectAccessor;
+    private BundleAccessor bundleAccessor;
+    private BundleVersionAccessor bundleVersionAccessor;
+
+    @BeforeEach
+    public void setUp() {
+        projectAccessor = mock(ProjectAccessor.class);
+        bundleAccessor = mock(BundleAccessor.class);
+        bundleVersionAccessor = mock(BundleVersionAccessor.class);
+        bundleManager = new BundleManager(
+                new IdConvertor(),
+                new VersionAliasConvertor(),
+                projectAccessor,
+                bundleAccessor,
+                bundleVersionAccessor,
+                ValidSubject.PROJECT
+        );
+    }
+
+    @Test
+    public void testGetBundleVersionId() {
+        given(bundleVersionAccessor.findVersionById(same(1L)))
+                .willReturn(EntityWrapper.builder().id(1L).name("byId").build());
+        given(bundleVersionAccessor.findVersionByAliasAndBundleId(anyString(), anyLong()))
+                .willReturn(EntityWrapper.builder().id(2L).name("byAlias").build());
+        given(bundleVersionAccessor.findVersionByNameAndBundleId(anyString(), anyLong()))
+                .willReturn(EntityWrapper.builder().id(3L).name("byName").build());
+
+        var res = bundleManager.getBundleVersionId(
+                BundleVersionUrl.create("", "", "1"), 1L);
+        assertThat(res, is(1L));
+
+        res = bundleManager.getBundleVersionId(
+                BundleVersionUrl.create("", "", "v1"), 1L);
+        assertThat(res, is(2L));
+
+        res = bundleManager.getBundleVersionId(
+                BundleVersionUrl.create("", "", "vName"), 1L);
+        assertThat(res, is(3L));
+
+        assertThrows(StarwhaleApiException.class,
+                () -> bundleManager.getBundleVersionId(BundleVersionUrl.create("", "", "2"), 1L));
+
+
+    }
+
+    @Data
+    @Builder
+    private static class EntityWrapper implements BundleVersionEntity {
+
+        private Long id;
+        private String name;
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeManagerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeManagerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.runtime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
+import ai.starwhale.mlops.domain.runtime.mapper.RuntimeMapper;
+import ai.starwhale.mlops.domain.runtime.mapper.RuntimeVersionMapper;
+import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
+import ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RuntimeManagerTest {
+
+    private RuntimeManager manager;
+    private RuntimeMapper runtimeMapper;
+    private RuntimeVersionMapper versionMapper;
+
+    @BeforeEach
+    public void setUp() {
+        runtimeMapper = mock(RuntimeMapper.class);
+        versionMapper = mock(RuntimeVersionMapper.class);
+        manager = new RuntimeManager(
+                runtimeMapper,
+                versionMapper,
+                new IdConvertor(),
+                new VersionAliasConvertor()
+        );
+    }
+
+    @Test
+    public void testFindVersionByAliasAndBundleId() {
+        given(versionMapper.findByVersionOrderAndRuntimeId(anyLong(), anyLong()))
+                .willReturn(RuntimeVersionEntity.builder()
+                        .id(1L)
+                        .versionName("runtime1")
+                        .build());
+        var res = manager.findVersionByAliasAndBundleId("v1", 1L);
+        assertThat(res, allOf(
+                notNullValue(),
+                isA(SwModelPackageVersionEntity.class),
+                hasProperty("id", is(1L)),
+                hasProperty("versionName", is("runtime1"))
+        ));
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeManagerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeManagerTest.java
@@ -31,7 +31,6 @@ import ai.starwhale.mlops.common.VersionAliasConvertor;
 import ai.starwhale.mlops.domain.runtime.mapper.RuntimeMapper;
 import ai.starwhale.mlops.domain.runtime.mapper.RuntimeVersionMapper;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
-import ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +62,7 @@ public class RuntimeManagerTest {
         var res = manager.findVersionByAliasAndBundleId("v1", 1L);
         assertThat(res, allOf(
                 notNullValue(),
-                isA(SwModelPackageVersionEntity.class),
+                isA(RuntimeVersionEntity.class),
                 hasProperty("id", is(1L)),
                 hasProperty("versionName", is("runtime1"))
         ));

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConvertorTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConvertorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.runtime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import ai.starwhale.mlops.api.protocol.runtime.RuntimeVersionVo;
+import ai.starwhale.mlops.api.protocol.user.UserVo;
+import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.LocalDateTimeConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
+import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
+import ai.starwhale.mlops.domain.user.UserConvertor;
+import ai.starwhale.mlops.domain.user.po.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RuntimeVersionConvertorTest {
+
+    private RuntimeVersionConvertor runtimeVersionConvertor;
+
+    @BeforeEach
+    public void setUp() {
+        UserConvertor userConvertor = mock(UserConvertor.class);
+        given(userConvertor.convert(any(UserEntity.class))).willReturn(UserVo.empty());
+        given(userConvertor.revert(any(UserVo.class))).willReturn(UserEntity.builder().build());
+        runtimeVersionConvertor = new RuntimeVersionConvertor(
+                new IdConvertor(),
+                userConvertor,
+                new LocalDateTimeConvertor(),
+                new VersionAliasConvertor()
+        );
+    }
+
+    @Test
+    public void testConvert() {
+        var res = runtimeVersionConvertor.convert(RuntimeVersionEntity.builder()
+                .id(1L)
+                .versionName("name1")
+                .versionOrder(2L)
+                .owner(UserEntity.builder().build())
+                .versionTag("tag1")
+                .versionMeta("meta1")
+                .image("image1")
+                .build());
+        assertThat(res, allOf(
+                notNullValue(),
+                hasProperty("name", is("name1")),
+                hasProperty("alias", is("v2")),
+                hasProperty("owner", isA(UserVo.class)),
+                hasProperty("tag", is("tag1")),
+                hasProperty("meta", is("meta1")),
+                hasProperty("image", is("image1"))
+        ));
+    }
+
+    @Test
+    public void testRevert() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> runtimeVersionConvertor.revert(RuntimeVersionVo.builder().build()));
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/SwdsManagerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/SwdsManagerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.swds;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
+import ai.starwhale.mlops.domain.swds.mapper.SwDatasetMapper;
+import ai.starwhale.mlops.domain.swds.mapper.SwDatasetVersionMapper;
+import ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SwdsManagerTest {
+
+    private SwdsManager manager;
+    private SwDatasetMapper datasetMapper;
+    private SwDatasetVersionMapper versionMapper;
+
+    @BeforeEach
+    public void setUp() {
+        datasetMapper = mock(SwDatasetMapper.class);
+        versionMapper = mock(SwDatasetVersionMapper.class);
+        manager = new SwdsManager(
+                datasetMapper,
+                versionMapper,
+                new IdConvertor(),
+                new VersionAliasConvertor()
+        );
+    }
+
+    @Test
+    public void testFindVersionByAliasAndBundleId() {
+        given(versionMapper.findByDsIdAndVersionOrder(anyLong(), anyLong()))
+                .willReturn(SwDatasetVersionEntity.builder()
+                        .id(1L)
+                        .versionName("dataset1")
+                        .build());
+        var res = manager.findVersionByAliasAndBundleId("v1", 1L);
+        assertThat(res, allOf(
+                notNullValue(),
+                isA(SwDatasetVersionEntity.class),
+                hasProperty("id", is(1L)),
+                hasProperty("versionName", is("dataset1"))
+        ));
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/convertor/SwdsVersionConvertorTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/convertor/SwdsVersionConvertorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.swds.convertor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import ai.starwhale.mlops.api.protocol.swds.DatasetVersionVo;
+import ai.starwhale.mlops.api.protocol.user.UserVo;
+import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.LocalDateTimeConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
+import ai.starwhale.mlops.domain.swds.converter.SwdsVersionConvertor;
+import ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity;
+import ai.starwhale.mlops.domain.user.UserConvertor;
+import ai.starwhale.mlops.domain.user.po.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SwdsVersionConvertorTest {
+
+    private SwdsVersionConvertor swdsVersionConvertor;
+
+    @BeforeEach
+    public void setUp() {
+        UserConvertor userConvertor = mock(UserConvertor.class);
+        given(userConvertor.convert(any(UserEntity.class))).willReturn(UserVo.empty());
+        given(userConvertor.revert(any(UserVo.class))).willReturn(UserEntity.builder().build());
+        swdsVersionConvertor = new SwdsVersionConvertor(
+                new IdConvertor(),
+                userConvertor,
+                new LocalDateTimeConvertor(),
+                new VersionAliasConvertor()
+        );
+    }
+
+    @Test
+    public void testConvert() {
+        var res = swdsVersionConvertor.convert(SwDatasetVersionEntity.builder()
+                .id(1L)
+                .versionName("name1")
+                .versionOrder(2L)
+                .owner(UserEntity.builder().build())
+                .versionTag("tag1")
+                .versionMeta("meta1")
+                .build());
+        assertThat(res, allOf(
+                notNullValue(),
+                hasProperty("name", is("name1")),
+                hasProperty("alias", is("v2")),
+                hasProperty("owner", isA(UserVo.class)),
+                hasProperty("tag", is("tag1")),
+                hasProperty("meta", is("meta1"))
+        ));
+    }
+
+    @Test
+    public void testRevert() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> swdsVersionConvertor.revert(DatasetVersionVo.builder().build()));
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swmp/SwmpManagerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swmp/SwmpManagerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.swmp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
+import ai.starwhale.mlops.domain.swmp.mapper.SwModelPackageMapper;
+import ai.starwhale.mlops.domain.swmp.mapper.SwModelPackageVersionMapper;
+import ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SwmpManagerTest {
+
+    private SwmpManager manager;
+    private SwModelPackageMapper modelMapper;
+    private SwModelPackageVersionMapper versionMapper;
+
+    @BeforeEach
+    public void setUp() {
+        modelMapper = mock(SwModelPackageMapper.class);
+        versionMapper = mock(SwModelPackageVersionMapper.class);
+        manager = new SwmpManager(
+                modelMapper,
+                versionMapper,
+                new IdConvertor(),
+                new VersionAliasConvertor()
+        );
+    }
+
+    @Test
+    public void testFindVersionByAliasAndBundleId() {
+        given(versionMapper.findByVersionOrderAndSwmpId(anyLong(), anyLong()))
+                .willReturn(SwModelPackageVersionEntity.builder()
+                        .id(1L)
+                        .versionName("model1")
+                        .build());
+        var res = manager.findVersionByAliasAndBundleId("v1", 1L);
+        assertThat(res, allOf(
+                notNullValue(),
+                isA(SwModelPackageVersionEntity.class),
+                hasProperty("id", is(1L)),
+                hasProperty("versionName", is("model1"))
+        ));
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swmp/SwmpVersionConvertorTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swmp/SwmpVersionConvertorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.swmp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import ai.starwhale.mlops.api.protocol.swmp.SwModelPackageVersionVo;
+import ai.starwhale.mlops.api.protocol.user.UserVo;
+import ai.starwhale.mlops.common.IdConvertor;
+import ai.starwhale.mlops.common.LocalDateTimeConvertor;
+import ai.starwhale.mlops.common.VersionAliasConvertor;
+import ai.starwhale.mlops.domain.swmp.po.SwModelPackageVersionEntity;
+import ai.starwhale.mlops.domain.user.UserConvertor;
+import ai.starwhale.mlops.domain.user.po.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SwmpVersionConvertorTest {
+
+    private SwmpVersionConvertor swmpVersionConvertor;
+
+    @BeforeEach
+    public void setUp() {
+        UserConvertor userConvertor = mock(UserConvertor.class);
+        given(userConvertor.convert(any(UserEntity.class))).willReturn(UserVo.empty());
+        given(userConvertor.revert(any(UserVo.class))).willReturn(UserEntity.builder().build());
+        swmpVersionConvertor = new SwmpVersionConvertor(
+                new IdConvertor(),
+                userConvertor,
+                new LocalDateTimeConvertor(),
+                new VersionAliasConvertor()
+        );
+    }
+
+    @Test
+    public void testConvert() {
+        var res = swmpVersionConvertor.convert(SwModelPackageVersionEntity.builder()
+                .id(1L)
+                .versionName("name1")
+                .versionOrder(2L)
+                .owner(UserEntity.builder().build())
+                .versionTag("tag1")
+                .versionMeta("meta1")
+                .manifest("manifest1")
+                .build());
+        assertThat(res, allOf(
+                notNullValue(),
+                hasProperty("name", is("name1")),
+                hasProperty("alias", is("v2")),
+                hasProperty("owner", isA(UserVo.class)),
+                hasProperty("tag", is("tag1")),
+                hasProperty("meta", is("meta1")),
+                hasProperty("manifest", is("manifest1"))
+        ));
+    }
+
+    @Test
+    public void testRevert() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> swmpVersionConvertor.revert(SwModelPackageVersionVo.builder().build()));
+    }
+}


### PR DESCRIPTION
## Description
1. Auto add alias when the version is created (stored in version_order field)
2. Update the alias when reverting an old version
3. Version alias is supported in "versionUrl" field

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
