### PR TITLE
chore(datastore): use explicit typing in query instead of guessing type from actual column value

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
@@ -254,8 +254,7 @@ public class DataStoreController implements DataStoreApi {
 
     private static Object convertOperand(TableQueryOperandDesc operand) {
         if (operand == null) {
-            throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE).tip(
-                    "operand should not be null");
+            throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE, "operand should not be null");
         }
         if (operand.getFilter() != null) {
             return DataStoreController.convertFilter(operand.getFilter());
@@ -264,21 +263,21 @@ public class DataStoreController implements DataStoreApi {
             return new TableQueryFilter.Column(operand.getColumnName());
         }
         if (operand.getBoolValue() != null) {
-            return operand.getBoolValue();
+            return new TableQueryFilter.Constant(ColumnType.BOOL, operand.getBoolValue());
         }
         if (operand.getIntValue() != null) {
-            return operand.getIntValue();
+            return new TableQueryFilter.Constant(ColumnType.INT64, operand.getIntValue());
         }
         if (operand.getFloatValue() != null) {
-            return operand.getFloatValue();
+            return new TableQueryFilter.Constant(ColumnType.FLOAT64, operand.getFloatValue());
         }
         if (operand.getStringValue() != null) {
-            return operand.getStringValue();
+            return new TableQueryFilter.Constant(ColumnType.STRING, operand.getStringValue());
         }
         if (operand.getBytesValue() != null) {
-            return ColumnType.BYTES.decode(operand.getBytesValue());
+            return new TableQueryFilter.Constant(ColumnType.BYTES, ColumnType.BYTES.decode(operand.getBytesValue()));
         }
-        return null;
+        return new TableQueryFilter.Constant(ColumnType.UNKNOWN, null);
     }
 
     private static Map<String, String> convertColumns(List<ColumnDesc> columns) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnType.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnType.java
@@ -41,16 +41,6 @@ public class ColumnType {
     public static final ColumnType STRING = new ColumnType("string", 8);
     public static final ColumnType BYTES = new ColumnType("bytes", 8);
 
-    private static final Map<Class<?>, ColumnType> typeMap = Map.of(
-            Boolean.class, BOOL,
-            Byte.class, INT8,
-            Short.class, INT16,
-            Integer.class, INT32,
-            Long.class, INT64,
-            Float.class, FLOAT32,
-            Double.class, FLOAT64,
-            String.class, STRING);
-
     private static final Map<String, ColumnType> typeMapByName = Map.of(
             UNKNOWN.toString(), UNKNOWN,
             BOOL.toString(), BOOL,
@@ -69,20 +59,6 @@ public class ColumnType {
     ColumnType(String category, int nbits) {
         this.category = category;
         this.nbits = nbits;
-    }
-
-    public static ColumnType getColumnType(Object value) {
-        if (value == null) {
-            return UNKNOWN;
-        }
-        var ret = typeMap.get(value.getClass());
-        if (ret == null) {
-            if (value instanceof ByteBuffer) {
-                return BYTES;
-            }
-            throw new IllegalArgumentException("unsupported column type " + value.getClass());
-        }
-        return ret;
     }
 
     public static ColumnType getColumnTypeByName(String typeName) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/TableQueryFilter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/TableQueryFilter.java
@@ -43,6 +43,18 @@ public class TableQueryFilter {
         private String name;
     }
 
+    @Data
+    @AllArgsConstructor
+    public static class Constant {
+
+        private ColumnType type;
+        private Object value;
+    }
+
     private Operator operator;
+
+    /**
+     * each operand can be of type TableQueryFilter, Column, or Constant
+     */
     private List<Object> operands;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
@@ -26,6 +26,8 @@ import ai.starwhale.mlops.datastore.TableSchema;
 import ai.starwhale.mlops.datastore.TableSchemaDesc;
 import ai.starwhale.mlops.datastore.Wal;
 import ai.starwhale.mlops.datastore.WalManager;
+import ai.starwhale.mlops.exception.SwProcessException;
+import ai.starwhale.mlops.exception.SwProcessException.ErrorType;
 import ai.starwhale.mlops.exception.SwValidationException;
 import com.google.protobuf.ByteString;
 import java.nio.ByteBuffer;
@@ -311,7 +313,11 @@ public class MemoryTableImpl implements MemoryTable {
         if (orderBy != null) {
             results.sort((a, b) -> {
                 for (var col : orderBy) {
-                    var result = MemoryTableImpl.sortCompare(a.get(col.getColumnName()),
+                    var columnType = this.schema.getColumnSchemaByName(col.getColumnName()).getType();
+                    var result = MemoryTableImpl.sortCompare(
+                            columnType,
+                            a.get(col.getColumnName()),
+                            columnType,
                             b.get(col.getColumnName()));
                     if (result != 0) {
                         if (col.isDescending()) {
@@ -392,32 +398,30 @@ public class MemoryTableImpl implements MemoryTable {
         }
     }
 
-    private static int sortCompare(Object a, Object b) {
-        if (a == null && b == null) {
+    private static int sortCompare(ColumnType type1, Object value1, ColumnType type2, Object value2) {
+        if (value1 == null && value2 == null) {
             return 0;
         }
-        if (a == null) {
+        if (value1 == null) {
             return -1;
         }
-        if (b == null) {
+        if (value2 == null) {
             return 1;
         }
-        var type1 = ColumnType.getColumnType(a);
-        var type2 = ColumnType.getColumnType(b);
-        if (type1 != type2) {
+        if (!type1.equals(type2)) {
             throw new IllegalArgumentException(
                     MessageFormat.format("not same type: {0} and {1}", type1, type2));
         }
         if (type1 == ColumnType.STRING) {
-            return ((String) a).compareTo((String) b);
+            return ((String) value1).compareTo((String) value2);
         } else if (type1 == ColumnType.BYTES) {
-            return ((ByteBuffer) a).compareTo((ByteBuffer) b);
+            return ((ByteBuffer) value1).compareTo((ByteBuffer) value2);
         } else if (type1 == ColumnType.BOOL) {
-            return ((Boolean) a).compareTo((Boolean) b);
+            return ((Boolean) value1).compareTo((Boolean) value2);
         } else if (type1.getCategory().equals(ColumnType.INT32.getCategory())) {
-            return Long.compare(((Number) a).longValue(), ((Number) b).longValue());
+            return Long.compare(((Number) value1).longValue(), ((Number) value2).longValue());
         } else if (type1.getCategory().equals(ColumnType.FLOAT32.getCategory())) {
-            return Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
+            return Double.compare(((Number) value1).doubleValue(), ((Number) value2).doubleValue());
         } else {
             throw new IllegalArgumentException("invalid type " + type1);
         }
@@ -439,7 +443,9 @@ public class MemoryTableImpl implements MemoryTable {
             case LESS:
             case LESS_EQUAL:
                 return MemoryTableImpl.filterCompare(
+                        this.getType(filter.getOperands().get(0)),
                         this.getValue(filter.getOperands().get(0), record),
+                        this.getType(filter.getOperands().get(1)),
                         this.getValue(filter.getOperands().get(1), record),
                         filter.getOperator());
             default:
@@ -447,11 +453,36 @@ public class MemoryTableImpl implements MemoryTable {
         }
     }
 
+    private ColumnType getType(Object operand) {
+        if (operand instanceof TableQueryFilter.Column) {
+            var colName = ((TableQueryFilter.Column) operand).getName();
+            var colSchema = this.schema.getColumnSchemaByName(colName);
+            if (colSchema == null) {
+                throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE,
+                        "invalid filter, unknown column " + colName);
+            }
+            return colSchema.getType();
+        } else if (operand instanceof TableQueryFilter.Constant) {
+            var type = ((TableQueryFilter.Constant) operand).getType();
+            if (type == null) {
+                throw new SwProcessException(ErrorType.DATASTORE, "invalid filter, constant type is null");
+            }
+            return type;
+        } else if (operand instanceof TableQueryFilter) {
+            return ColumnType.BOOL;
+        } else {
+            throw new IllegalArgumentException("invalid operand type " + operand.getClass());
+        }
+    }
+
     private Object getValue(Object operand, Map<String, Object> record) {
         if (operand instanceof TableQueryFilter.Column) {
             return record.get(((TableQueryFilter.Column) operand).getName());
+        } else if (operand instanceof TableQueryFilter.Constant) {
+            return ((TableQueryFilter.Constant) operand).getValue();
+        } else {
+            throw new IllegalArgumentException("invalid operand type " + operand.getClass());
         }
-        return operand;
     }
 
     private void checkFilter(TableQueryFilter filter) {
@@ -476,84 +507,48 @@ public class MemoryTableImpl implements MemoryTable {
     }
 
     private void checkSameType(List<Object> operands) {
-        if (operands.isEmpty()) {
+        var types = operands.stream()
+                .map(this::getType)
+                .filter(t -> t != ColumnType.UNKNOWN)
+                .collect(Collectors.toList());
+        if (types.isEmpty()) {
             return;
         }
-        var firstCol = operands.stream()
-                .filter(x -> x instanceof TableQueryFilter.Column)
-                .map(x -> (TableQueryFilter.Column) x)
-                .findFirst();
-        var type = this.schema.getColumnSchemaByName(firstCol.orElseThrow().getName()).getType();
-        for (var op : operands) {
-            if (op instanceof TableQueryFilter.Column) {
-                var col = (TableQueryFilter.Column) op;
-                var colSchema = this.schema.getColumnSchemaByName(col.getName());
-                if (colSchema == null) {
-                    throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE,
-                            "invalid filter, unknown column " + col.getName());
-                }
-                if (!type.getCategory().equals(colSchema.getType().getCategory())) {
-                    throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE,
-                            MessageFormat.format(
-                                    "invalid filter, can not compare column {0} of type {1} "
-                                            + "with column {2} of type {3}",
-                                    col.getName(),
-                                    colSchema.getType(),
-                                    firstCol.orElseThrow().getName(),
-                                    type));
-                }
-            } else if (op != null) {
-                boolean checkFailed;
-                if (op instanceof String) {
-                    checkFailed = type != ColumnType.STRING;
-                } else if (op instanceof ByteBuffer) {
-                    checkFailed = type != ColumnType.BYTES;
-                } else if (op instanceof Boolean) {
-                    checkFailed = type != ColumnType.BOOL;
-                } else if (op instanceof Number) {
-                    checkFailed = !type.getCategory().equals(ColumnType.INT32.getCategory())
-                            && !type.getCategory().equals(ColumnType.FLOAT32.getCategory());
-                } else {
-                    throw new IllegalArgumentException("unexpected operand class " + op.getClass());
-                }
-                if (checkFailed) {
-                    throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE,
-                            MessageFormat.format(
-                                    "invalid filter, can not compare column {0} of type {1} with value {2} of type {3}",
-                                    firstCol.orElseThrow().getName(),
-                                    type,
-                                    op,
-                                    op.getClass()));
-                }
+        ColumnType type1 = types.get(0);
+        for (var type : types) {
+            if (!type.getCategory().equals(type1.getCategory())) {
+                throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE,
+                        MessageFormat.format("invalid filter, can not compare {0} with {1}", type1, type));
             }
         }
-
     }
 
-
-    private static boolean filterCompare(Object a, Object b, TableQueryFilter.Operator op) {
-        if (a == null || b == null) {
-            return a == null && b == null && op == TableQueryFilter.Operator.EQUAL;
+    private static boolean filterCompare(
+            ColumnType type1,
+            Object value1,
+            ColumnType type2,
+            Object value2,
+            TableQueryFilter.Operator op) {
+        if (value1 == null || value2 == null) {
+            return value1 == null && value2 == null && op == TableQueryFilter.Operator.EQUAL;
         }
         int result;
-        var type1 = ColumnType.getColumnType(a);
-        var type2 = ColumnType.getColumnType(b);
         if (type1.getCategory().equals(type2.getCategory())) {
             if (type1 == ColumnType.BOOL) {
-                result = ((Boolean) a).compareTo((Boolean) b);
+                result = ((Boolean) value1).compareTo((Boolean) value2);
             } else if (type1 == ColumnType.STRING) {
-                result = ((String) a).compareTo((String) b);
+                result = ((String) value1).compareTo((String) value2);
             } else if (type1 == ColumnType.BYTES) {
-                result = ((ByteBuffer) a).compareTo((ByteBuffer) b);
+                result = ((ByteBuffer) value1).compareTo((ByteBuffer) value2);
             } else if (type1.getCategory().equals(ColumnType.INT32.getCategory())) {
-                result = Long.compare(((Number) a).longValue(), ((Number) b).longValue());
+                result = Long.compare(((Number) value1).longValue(), ((Number) value2).longValue());
             } else if (type1.getCategory().equals(ColumnType.FLOAT32.getCategory())) {
-                result = Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
+                result = Double.compare(((Number) value1).doubleValue(), ((Number) value2).doubleValue());
             } else {
                 throw new IllegalArgumentException("invalid type " + type1);
             }
-        } else if (a instanceof Number && b instanceof Number) {
-            result = Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
+        } else if (value1 instanceof Number && value2 instanceof Number) {
+            result = Double.compare(((Number) value1).doubleValue(), ((Number) value2).doubleValue());
         } else {
             throw new IllegalArgumentException("can not compare " + type1 + " with " + type2);
         }

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/DataStoreControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/DataStoreControllerTest.java
@@ -500,6 +500,11 @@ public class DataStoreControllerTest {
                                     setKey("a");
                                     setValue("3");
                                 }
+                            }, new RecordValueDesc() {
+                                {
+                                    setKey("x");
+                                    setValue("9");
+                                }
                             }));
                         }
                     }, new RecordDesc() {
@@ -550,7 +555,7 @@ public class DataStoreControllerTest {
                     Objects.requireNonNull(resp.getBody()).getData().getRecords(),
                     is(List.of(Map.of("k", "0", "a", "5"),
                             Map.of("k", "1", "a", "4"),
-                            Map.of("k", "2", "a", "3"),
+                            Map.of("k", "2", "a", "3", "x", "9"),
                             Map.of("k", "3", "a", "2"),
                             Map.of("k", "4", "a", "1"))));
         }
@@ -725,6 +730,37 @@ public class DataStoreControllerTest {
             assertThrows(SwValidationException.class,
                     () -> DataStoreControllerTest.this.controller.queryTable(this.req),
                     "");
+        }
+
+        @Test
+        public void testEqualNull() {
+            this.req.setFilter(new TableQueryFilterDesc() {
+                {
+                    setOperator(TableQueryFilter.Operator.EQUAL.toString());
+                    setOperands(List.of(new TableQueryOperandDesc() {
+                        {
+                            setColumnName("x");
+                        }
+                    }, new TableQueryOperandDesc()));
+                }
+            });
+            var resp = DataStoreControllerTest.this.controller.queryTable(this.req);
+            assertThat(resp.getStatusCode().is2xxSuccessful(), is(true));
+            assertThat(Objects.requireNonNull(resp.getBody()).getData().getColumnTypes(),
+                    is(Map.of("k", ColumnType.INT32, "b", ColumnType.INT32)));
+            assertThat(Objects.requireNonNull(resp.getBody()).getData().getRecords(),
+                    is(List.of(new HashMap<>() {
+                        {
+                            put("k", "3");
+                            put("b", "2");
+                        }
+                    }, new HashMap<>() {
+                        {
+                            put("k", "1");
+                            put("b", "4");
+                        }
+                    })));
+
         }
 
         @Test

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import ai.starwhale.mlops.datastore.TableQueryFilter.Constant;
 import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.memory.impl.SwByteBufferManager;
 import ai.starwhale.mlops.storage.fs.StorageAccessServiceFile;
@@ -166,7 +167,7 @@ public class DataStoreTest {
                 .columns(Map.of("a", "a"))
                 .filter(TableQueryFilter.builder()
                         .operator(TableQueryFilter.Operator.GREATER)
-                        .operands(List.of(new TableQueryFilter.Column("a"), 1))
+                        .operands(List.of(new TableQueryFilter.Column("a"), new Constant(ColumnType.INT32, 1)))
                         .build())
                 .orderBy(List.of(new OrderByDesc("a")))
                 .start(1)
@@ -182,7 +183,7 @@ public class DataStoreTest {
                 .tableName("t1")
                 .filter(TableQueryFilter.builder()
                         .operator(TableQueryFilter.Operator.GREATER)
-                        .operands(List.of(new TableQueryFilter.Column("a"), 1))
+                        .operands(List.of(new TableQueryFilter.Column("a"), new Constant(ColumnType.INT32, 1)))
                         .build())
                 .orderBy(List.of(new OrderByDesc("a")))
                 .start(1)


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [X] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [X] add unit test
- [ ] add necessary doc
