### PR TITLE
fix(ci): increase minikube memory limit to 4G

### DIFF
--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -43,7 +43,7 @@ declare_env() {
 }
 
 start_minikube() {
-    minikube start -p sw-e2e-test --insecure-registry "$IP_MINIKUBE_BRIDGE_RANGE"
+    minikube start -p sw-e2e-test --memory=4G --insecure-registry "$IP_MINIKUBE_BRIDGE_RANGE"
     minikube addons enable ingress -p sw-e2e-test
     minikube addons enable ingress-dns -p sw-e2e-test
     kubectl describe node


### PR DESCRIPTION
## Description
 increase minikube memory limit to 4G from 2G 
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
