### PR TITLE
fix(datastore): fix copyTo/setBytes function of SwByteBuffer

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/memory/impl/SwByteBuffer.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/memory/impl/SwByteBuffer.java
@@ -122,6 +122,9 @@ public class SwByteBuffer implements SwBuffer {
     @Override
     public void setBytes(int index, byte[] b, int offset, int len) {
         this.buf.position(index);
+        if (len > this.buf.remaining()) {
+            len = this.buf.remaining();
+        }
         this.buf.put(b, offset, len);
     }
 
@@ -141,7 +144,7 @@ public class SwByteBuffer implements SwBuffer {
 
     @Override
     public void copyTo(SwBuffer buf) {
-        buf.setBytes(0, this.buf.array(), 0, this.buf.limit());
+        buf.setBytes(0, this.buf.array(), this.buf.arrayOffset(), this.buf.limit());
     }
 
     @Override

--- a/server/controller/src/test/java/ai/starwhale/mlops/memory/impl/SwByteBufferTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/memory/impl/SwByteBufferTest.java
@@ -19,6 +19,7 @@ package ai.starwhale.mlops.memory.impl;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import ai.starwhale.mlops.memory.SwBuffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -78,5 +79,32 @@ public class SwByteBufferTest {
         assertThat(buf.asByteBuffer(), is(ByteBuffer.wrap("12345".getBytes(StandardCharsets.UTF_8))));
         this.buffer.setString(0, "1234567890");
         assertThat(buf.asByteBuffer(), is(ByteBuffer.wrap("23456".getBytes(StandardCharsets.UTF_8))));
+    }
+
+    @Test
+    public void testCopyTo() {
+        var base = new SwByteBuffer(5);
+        base.setBytes(0, new byte[]{1, 2, 3, 4, 5}, 0, 5);
+        // make a SwBuffer with non-zero offset
+        var src = base.slice(1, base.capacity() - 1);
+        var dst = new SwByteBuffer(5);
+        src.copyTo(dst);
+        assertThat(dst.getByte(0), is(src.getByte(0)));
+    }
+
+    @Test
+    void testSetBytes() {
+        final int cap = 3;
+        var buf = new SwByteBuffer(cap);
+        var src = new byte[]{1, 2, 3, 4};
+        buf.setBytes(0, src, 0, src.length);
+
+        var b = new byte[5];
+        assertThat(buf.getBytes(0, b, 0, b.length), is(cap));
+        assertThat(b, is(new byte[]{1, 2, 3, 0, 0}));
+
+        buf.setBytes(1, src, 0, src.length);
+        assertThat(buf.getBytes(0, b, 0, b.length), is(cap));
+        assertThat(b, is(new byte[]{1, 1, 2, 0, 0}));
     }
 }


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
