### PR TITLE
ci(client): fix datastore atexit dump test error

### DIFF
--- a/client/tests/core/test_eval.py
+++ b/client/tests/core/test_eval.py
@@ -18,7 +18,6 @@ from .. import ROOT_DIR, get_predefined_config_yaml
 
 _job_data_dir = f"{ROOT_DIR}/data/job"
 _job_manifest = open(f"{_job_data_dir}/job_manifest.yaml").read()
-_cmp_report = open(f"{_job_data_dir}/cmp_report.jsonl").read()
 _job_list = open(f"{_job_data_dir}/job_list_resp.json").read()
 _task_list = open(f"{_job_data_dir}/task_list.json").read()
 _existed_config_contents = get_predefined_config_yaml()
@@ -68,7 +67,7 @@ class StandaloneEvaluationJobTestCase(TestCase):
         assert all_jobs[0][0] == (Path(self.job_dir) / DEFAULT_MANIFEST_NAME).absolute()
         assert not all_jobs[0][1]
 
-    def test_standalone_list(self):
+    def test_list(self):
         uri = URI("")
         jobs, _ = StandaloneEvaluationJob.list(uri)
         assert len(jobs) == 1
@@ -76,9 +75,12 @@ class StandaloneEvaluationJobTestCase(TestCase):
         assert jobs[0]["manifest"]["version"] == self.job_name
         assert jobs[0]["manifest"]["model"] == "mnist:meydczbrmi2g"
 
+    @patch("starwhale.api._impl.data_store.atexit")
     @patch("starwhale.api._impl.wrapper.Evaluation.get")
     @patch("starwhale.api._impl.wrapper.Evaluation.get_metrics")
-    def test_standalone_info(self, m_get_metrics: MagicMock, m_get: MagicMock):
+    def test_info(
+        self, m_get_metrics: MagicMock, m_get: MagicMock, m_atexit: MagicMock
+    ):
         m_get.return_value = {}
         m_get_metrics.return_value = {"kind": "multi_classification"}
 
@@ -90,7 +92,7 @@ class StandaloneEvaluationJobTestCase(TestCase):
         assert info["manifest"]["model"] == "mnist:meydczbrmi2g"
         assert info["report"]["kind"] == "multi_classification"
 
-    def test_stanalone_remove(self):
+    def test_remove(self):
         uri = URI(f"local/project/self/{URIType.EVALUATION}/{self.job_name[:6]}")
         job = StandaloneEvaluationJob(uri)
 
@@ -120,7 +122,7 @@ class StandaloneEvaluationJobTestCase(TestCase):
 
     @patch("starwhale.core.eval.model.subprocess.check_output")
     @patch("starwhale.core.eval.model.check_call")
-    def test_stanalone_actions(self, m_call: MagicMock, m_call_output: MagicMock):
+    def test_actions(self, m_call: MagicMock, m_call_output: MagicMock):
         uri = URI(f"local/project/self/{URIType.EVALUATION}/{self.job_name}")
         job = StandaloneEvaluationJob(uri)
 
@@ -153,7 +155,7 @@ class CloudJobTestCase(TestCase):
 
     @Mocker()
     @patch("starwhale.core.eval.view.console.print")
-    def test_cloud_create(self, rm: Mocker, m_console: MagicMock):
+    def test_create(self, rm: Mocker, m_console: MagicMock):
         rm.request(
             HTTPMethod.POST,
             f"{self.instance_uri}/api/v1/project/self/job",
@@ -183,7 +185,7 @@ class CloudJobTestCase(TestCase):
 
     @Mocker()
     @patch("starwhale.core.eval.view.console.print")
-    def test_cloud_list(self, rm: Mocker, m_console: MagicMock):
+    def test_list(self, rm: Mocker, m_console: MagicMock):
         rm.request(
             HTTPMethod.GET,
             f"{self.instance_uri}/api/v1/project/self/job",
@@ -215,7 +217,7 @@ class CloudJobTestCase(TestCase):
     @patch("starwhale.api._impl.wrapper.Evaluation.get")
     @patch("starwhale.api._impl.wrapper.Evaluation.get_metrics")
     @patch("starwhale.core.eval.view.console.print")
-    def test_cloud_info(
+    def test_info(
         self,
         rm: Mocker,
         m_console: MagicMock,
@@ -252,7 +254,7 @@ class CloudJobTestCase(TestCase):
 
     @Mocker()
     @patch("starwhale.core.eval.view.console.print")
-    def test_cloud_actions(self, rm: Mocker, m_console: MagicMock):
+    def test_actions(self, rm: Mocker, m_console: MagicMock):
         rm.request(
             HTTPMethod.POST,
             f"{self.instance_uri}/api/v1/project/self/job/{self.job_name}/resume",
@@ -273,7 +275,7 @@ class CloudJobTestCase(TestCase):
         JobTermView(self.job_uri).cancel()
         JobTermView(self.job_uri).resume()
 
-    def test_cloud_utils(self):
+    def test_utils(self):
         assert (1, 1) == CloudEvaluationJob.parse_device("cpu:1")
         assert (2, 1) == CloudEvaluationJob.parse_device("gpu:1")
         assert (1, 10) == CloudEvaluationJob.parse_device("xxx:10")

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -187,9 +187,12 @@ class StandaloneModelTestCase(TestCase):
         with self.assertRaises(Exception):
             default_handler._get_cls(Path(_model_data_dir))
 
+    @patch("starwhale.api._impl.data_store.atexit")
     @patch("starwhale.core.model.default_handler.StandaloneModel")
     @patch("starwhale.core.model.default_handler.import_cls")
-    def test_default_handler(self, m_import: MagicMock, m_model: MagicMock):
+    def test_default_handler(
+        self, m_import: MagicMock, m_model: MagicMock, m_atexit: MagicMock
+    ):
         from starwhale.core.model import default_handler
 
         class SimpleHandler(PipelineHandler):

--- a/client/tests/sdk/test_base.py
+++ b/client/tests/sdk/test_base.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 from starwhale.utils import config as sw_config
 from starwhale.consts import ENV_SW_CLI_CONFIG, ENV_SW_LOCAL_STORAGE
 from starwhale.utils.fs import empty_dir, ensure_dir
+from starwhale.api._impl.data_store import LocalDataStore
 
 
 class BaseTestCase(unittest.TestCase):
@@ -14,6 +15,7 @@ class BaseTestCase(unittest.TestCase):
         os.environ[ENV_SW_CLI_CONFIG] = os.path.join(self.local_storage, "config.yaml")
         os.environ[ENV_SW_LOCAL_STORAGE] = self.local_storage
         sw_config._config = {}
+        LocalDataStore._instance = None
 
         self.datastore_root = str(sw_config.SWCliConfigMixed().datastore_dir)
         ensure_dir(self.datastore_root)

--- a/client/tests/sdk/test_wrapper.py
+++ b/client/tests/sdk/test_wrapper.py
@@ -25,19 +25,21 @@ class TestEvaluation(BaseTestCase):
         eval.log_result("0", 3)
         eval.log_result("1", 4)
         eval.log_result("2", 5, a="0", B="1")
+        eval.log_result("3", 6, c=None)
         eval.close()
         self.assertEqual(
             [
                 {"id": "0", "result": 3},
                 {"id": "1", "result": 4},
                 {"id": "2", "result": 5, "a": "0", "b": "1"},
+                {"id": "3", "result": 6},
             ],
             list(eval.get_results()),
         )
 
     def test_log_metrics(self) -> None:
         eval = wrapper.Evaluation()
-        eval.log_metrics(a=0, B=1)
+        eval.log_metrics(a=0, B=1, c=None)
         eval.log_metrics({"a/b": 2})
         eval.close()
         self.assertEqual(


### PR DESCRIPTION
## Description
- fix atexit error 
  ![image](https://user-images.githubusercontent.com/590748/190946247-c7d1cdd3-952b-4cc1-ba64-81fc7834e113.png)
- reset `LocalStore._instance` single instance state which will inject the wrong variable by another test case.


## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
