### PR TITLE
bug(client): fix model/dataset/runtime info command

### DIFF
--- a/client/starwhale/base/bundle.py
+++ b/client/starwhale/base/bundle.py
@@ -63,7 +63,7 @@ class BaseBundle(metaclass=ABCMeta):
         self,
         page: int = DEFAULT_PAGE_IDX,
         size: int = DEFAULT_PAGE_SIZE,
-    ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
+    ) -> t.List[t.Dict[str, t.Any]]:
         raise NotImplementedError
 
     @classmethod

--- a/client/starwhale/base/uri.py
+++ b/client/starwhale/base/uri.py
@@ -51,7 +51,7 @@ class URI:
         return self.full_uri
 
     def __repr__(self) -> str:
-        return f"instance:{self.instance}, instance_type:{self.instance_type}, projec:{self.project}, object:{self.object}"
+        return f"instance:{self.instance}, instance_type:{self.instance_type}, project:{self.project}, object:{self.object}"
 
     def _do_parse_instance_uri(self, raw: str) -> t.Tuple[InstanceField, str]:
         _remain: str = raw

--- a/client/starwhale/base/view.py
+++ b/client/starwhale/base/view.py
@@ -130,9 +130,9 @@ class BaseTermView(SWCliConfigMixed):
     @staticmethod
     def _print_history(
         title: str,
-        history: t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]],
+        history: t.List[t.Dict[str, t.Any]],
         fullname: bool = False,
-    ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
+    ) -> t.List[t.Dict[str, t.Any]]:
         custom_header = {0: {"justify": "left", "style": "cyan", "no_wrap": True}}
         custom_column: t.Dict[str, t.Callable[[t.Any], str]] = {
             "tags": lambda x: ",".join(x),
@@ -151,7 +151,7 @@ class BaseTermView(SWCliConfigMixed):
             console.print(":tea: not found info")
             return
 
-        _history = _info.pop("history", (list(), dict()))
+        _history = _info.pop("history", [])
 
         console.rule("[green bold]Inspect Details")
         console.print(Pretty(_info, expand_all=True))
@@ -291,7 +291,7 @@ class BaseTermView(SWCliConfigMixed):
             return dict()
 
         result = _info
-        _history = _info.pop("history", (list(), dict()))
+        _history = _info.pop("history", [])
 
         if _history:
             result["history"] = BaseTermView.get_history_data(_history, fullname)
@@ -300,11 +300,12 @@ class BaseTermView(SWCliConfigMixed):
 
     @staticmethod
     def get_history_data(
-        history: t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]],
+        history: t.List[t.Dict[str, t.Any]],
         fullname: bool = False,
     ) -> t.List[t.Dict]:
         result = list()
-        for _h in history[0]:
+
+        for _h in history:
             _version = _h["version"] if fullname else _h["version"][:SHORT_VERSION_CNT]
             if _h.get("id"):
                 _version = f"[{_h['id']:2}] {_version}"

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -172,12 +172,15 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
         self,
         page: int = DEFAULT_PAGE_IDX,
         size: int = DEFAULT_PAGE_SIZE,
-    ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
+    ) -> t.List[t.Dict[str, t.Any]]:
         _r = []
 
         for _bf in self.store.iter_bundle_history():
-            _manifest = load_yaml(_bf.path / DEFAULT_MANIFEST_NAME)
+            _manifest_path = _bf.path / DEFAULT_MANIFEST_NAME
+            if not _manifest_path.exists():
+                continue
 
+            _manifest = load_yaml(_bf.path / DEFAULT_MANIFEST_NAME)
             _r.append(
                 dict(
                     name=_manifest["name"],
@@ -189,7 +192,7 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
                 )
             )
 
-        return _r, {}
+        return _r
 
     def remove(self, force: bool = False) -> t.Tuple[bool, str]:
         # TODO: remove by tag

--- a/client/starwhale/core/dataset/view.py
+++ b/client/starwhale/core/dataset/view.py
@@ -39,9 +39,7 @@ class DatasetTermView(BaseTermView):
 
     @BaseTermView._pager
     @BaseTermView._header
-    def history(
-        self, fullname: bool = False
-    ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
+    def history(self, fullname: bool = False) -> t.List[t.Dict[str, t.Any]]:
         fullname = fullname or self.uri.instance_type == InstanceType.CLOUD
         return self._print_history(
             title="Dataset History List",

--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -310,10 +310,13 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
         self,
         page: int = DEFAULT_PAGE_IDX,
         size: int = DEFAULT_PAGE_SIZE,
-    ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
+    ) -> t.List[t.Dict[str, t.Any]]:
 
         _r = []
         for _bf in self.store.iter_bundle_history():
+            if not _bf.path.is_file():
+                continue
+
             _manifest = ModelStorage.get_manifest_by_path(
                 _bf.path, BundleType.MODEL, URIType.MODEL
             )
@@ -328,7 +331,7 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
                     size=_bf.path.stat().st_size,
                 )
             )
-        return _r, {}
+        return _r
 
     def remove(self, force: bool = False) -> t.Tuple[bool, str]:
         _ok, _reason = move_dir(self.store.loc, self.store.recover_loc, force)
@@ -365,6 +368,9 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
             bundle_type=BundleType.MODEL,
             uri_type=URIType.MODEL,
         ):
+            if not _bf.path.is_file():
+                continue
+
             _manifest = ModelStorage.get_manifest_by_path(
                 _bf.path, BundleType.MODEL, URIType.MODEL
             )

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -35,9 +35,7 @@ class ModelTermView(BaseTermView):
 
     @BaseTermView._pager
     @BaseTermView._header
-    def history(
-        self, fullname: bool = False
-    ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
+    def history(self, fullname: bool = False) -> t.List[t.Dict[str, t.Any]]:
         fullname = fullname or self.uri.instance_type == InstanceType.CLOUD
         return self._print_history(
             title="Model History List", history=self.model.history(), fullname=fullname

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -36,9 +36,7 @@ class RuntimeTermView(BaseTermView):
 
     @BaseTermView._pager
     @BaseTermView._header
-    def history(
-        self, fullname: bool = False
-    ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
+    def history(self, fullname: bool = False) -> t.List[t.Dict[str, t.Any]]:
         fullname = fullname or self.uri.instance_type == InstanceType.CLOUD
         return self._print_history(
             title="Runtime History", history=self.runtime.history(), fullname=fullname

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -99,10 +99,11 @@ class StandaloneDatasetTestCase(TestCase):
 
         dataset_uri = URI(name, expected_type=URIType.DATASET)
         sd = StandaloneDataset(dataset_uri)
+        ensure_dir(sd.store.bundle_dir / sd.store.bundle_type)
         _info = sd.info()
-        assert len(_info["history"][0]) == 1
-        assert _info["history"][0][0]["name"] == name
-        assert _info["history"][0][0]["version"] == build_version
+        assert len(_info["history"]) == 1
+        assert _info["history"][0]["name"] == name
+        assert _info["history"][0]["version"] == build_version
 
         _history = sd.history()
         assert _info["history"] == _history

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -106,11 +106,12 @@ class StandaloneModelTestCase(TestCase):
 
         model_uri = URI(name, expected_type=URIType.MODEL)
         sm = StandaloneModel(model_uri)
+        ensure_dir(sm.store.bundle_dir / f"xx{sm.store.bundle_type}")
         _info = sm.info()
 
-        assert len(_info["history"][0]) == 1
-        assert _info["history"][0][0]["name"] == name
-        assert _info["history"][0][0]["version"] == build_version
+        assert len(_info["history"]) == 1
+        assert _info["history"][0]["name"] == name
+        assert _info["history"][0]["version"] == build_version
 
         _history = sm.history()
         assert _info["history"] == _history

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -319,11 +319,12 @@ class StandaloneRuntimeTestCase(TestCase):
 
         uri = URI(name, expected_type=URIType.RUNTIME)
         sr = StandaloneRuntime(uri)
+        ensure_dir(sr.store.bundle_dir / f"xx{sr.store.bundle_type}")
         info = sr.info()
         assert info["project"] == "self"
         assert "version" not in info
-        assert len(info["history"][0]) == 1
-        assert info["history"][0][0]["version"] == build_version
+        assert len(info["history"]) == 1
+        assert info["history"][0]["version"] == build_version
 
         uri = URI(f"{name}/version/{build_version[:6]}", expected_type=URIType.RUNTIME)
         sr = StandaloneRuntime(uri)


### PR DESCRIPTION
## Description
- related issue: https://github.com/star-whale/starwhale/issues/1141
- model info for standalone
  - ![image](https://user-images.githubusercontent.com/590748/190971651-cb45d6c8-4518-4bfb-b729-1dfa9f6731ab.png) 
- model info for cloud
  -  ![image](https://user-images.githubusercontent.com/590748/190971913-d265ae0a-016c-45cf-9ec9-7bc648f73f19.png)
- dataset info for standalone
  -   ![image](https://user-images.githubusercontent.com/590748/190972045-c2bee308-bb80-4591-939a-99bf4bb227f6.png)
- dataset info for cloud
  -  ![image](https://user-images.githubusercontent.com/590748/190983041-a10c8c31-f6ea-40c6-90bb-eb85ccfa807a.png) 
- runtime info for standalone
  - ![image](https://user-images.githubusercontent.com/590748/190983512-149251fc-72ab-4a22-af3f-b393ea803999.png) 
- runtime info for cloud
  - ![image](https://user-images.githubusercontent.com/590748/190985562-97abad45-b341-4713-b290-5672bf02de25.png)
 

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
