### PR TITLE
refactor(controller): refactor storage env related code

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swds/SwDatasetInfoVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/swds/SwDatasetInfoVo.java
@@ -17,7 +17,7 @@
 package ai.starwhale.mlops.api.protocol.swds;
 
 import ai.starwhale.mlops.api.protocol.StorageFileVo;
-import ai.starwhale.mlops.storage.fs.FileStorageEnv;
+import ai.starwhale.mlops.storage.env.StorageEnv;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
@@ -50,11 +50,6 @@ public class SwDatasetInfoVo implements Serializable {
      * the table name for index in DataStore
      */
     String indexTable;
-
-    /**
-     * the necessary information to access to file storages key: storage name value: envs
-     */
-    Map<String, FileStorageEnv> fileStorageEnvs;
 
     @JsonProperty("versionTag")
     private String versionTag;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwDatasetService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwDatasetService.java
@@ -55,7 +55,7 @@ import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
 import ai.starwhale.mlops.exception.api.StarwhaleApiException;
 import ai.starwhale.mlops.storage.configuration.StorageProperties;
-import ai.starwhale.mlops.storage.fs.FileStorageEnv;
+import ai.starwhale.mlops.storage.env.StorageEnv;
 import cn.hutool.core.util.StrUtil;
 import com.github.pagehelper.PageHelper;
 import com.github.pagehelper.PageInfo;
@@ -106,9 +106,6 @@ public class SwDatasetService {
 
     @Resource
     private UserService userService;
-
-    @Resource
-    private StorageProperties storageProperties;
 
     @Resource
     private DsFileGetter dsFileGetter;
@@ -180,9 +177,6 @@ public class SwDatasetService {
         try {
             String storagePath = versionEntity.getStoragePath();
             List<StorageFileVo> collect = storageService.listStorageFile(storagePath);
-            Map<String, FileStorageEnv> fileStorageEnvs = storageProperties.toFileStorageEnvs();
-            fileStorageEnvs.values().forEach(fileStorageEnv -> fileStorageEnv.add(FileStorageEnv.ENV_KEY_PREFIX,
-                    versionEntity.getStoragePath()));
             return SwDatasetInfoVo.builder()
                     .id(idConvertor.convert(ds.getId()))
                     .name(ds.getDatasetName())
@@ -191,7 +185,6 @@ public class SwDatasetService {
                     .versionTag(versionEntity.getVersionTag())
                     .versionMeta(versionEntity.getVersionMeta())
                     .createdTime(localDateTimeConvertor.convert(versionEntity.getCreatedTime()))
-                    .fileStorageEnvs(fileStorageEnvs)
                     .indexTable(versionEntity.getIndexTable())
                     .files(collect)
                     .build();

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/bo/SwDataSet.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/bo/SwDataSet.java
@@ -16,7 +16,7 @@
 
 package ai.starwhale.mlops.domain.swds.bo;
 
-import ai.starwhale.mlops.storage.fs.FileStorageEnv;
+import ai.starwhale.mlops.storage.env.StorageEnv;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -65,5 +65,5 @@ public class SwDataSet {
     /**
      * the necessary information to access to file storages key: storage name value: envs
      */
-    Map<String, FileStorageEnv> fileStorageEnvs;
+    Map<String, StorageEnv> fileStorageEnvs;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/converter/SwdsBoConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/converter/SwdsBoConverter.java
@@ -17,10 +17,10 @@
 package ai.starwhale.mlops.domain.swds.converter;
 
 import ai.starwhale.mlops.domain.swds.bo.SwDataSet;
-import ai.starwhale.mlops.domain.swds.objectstore.StorageAuths;
 import ai.starwhale.mlops.domain.swds.po.SwDatasetVersionEntity;
-import ai.starwhale.mlops.storage.configuration.StorageProperties;
-import ai.starwhale.mlops.storage.fs.FileStorageEnv;
+import ai.starwhale.mlops.storage.env.StorageEnv;
+import ai.starwhale.mlops.storage.env.StorageEnvsPropertiesConverter;
+import ai.starwhale.mlops.storage.env.UserStorageAuthEnv;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -28,21 +28,21 @@ import org.springframework.util.StringUtils;
 @Component
 public class SwdsBoConverter {
 
-    final StorageProperties storageProperties;
+    final StorageEnvsPropertiesConverter storageEnvsPropertiesConverter;
 
-    public SwdsBoConverter(StorageProperties storageProperties) {
-        this.storageProperties = storageProperties;
+    public SwdsBoConverter(StorageEnvsPropertiesConverter storageEnvsPropertiesConverter) {
+        this.storageEnvsPropertiesConverter = storageEnvsPropertiesConverter;
     }
 
     public SwDataSet fromEntity(SwDatasetVersionEntity swDatasetVersionEntity) {
-        Map<String, FileStorageEnv> fileStorageEnvs;
+        Map<String, StorageEnv> fileStorageEnvs;
         if (StringUtils.hasText(swDatasetVersionEntity.getStorageAuths())) {
-            StorageAuths storageAuths = new StorageAuths(swDatasetVersionEntity.getStorageAuths());
+            UserStorageAuthEnv storageAuths = new UserStorageAuthEnv(swDatasetVersionEntity.getStorageAuths());
             fileStorageEnvs = storageAuths.allEnvs();
         } else {
-            fileStorageEnvs = storageProperties.toFileStorageEnvs();
+            fileStorageEnvs = storageEnvsPropertiesConverter.propertiesToEnvs();
         }
-        fileStorageEnvs.values().forEach(fileStorageEnv -> fileStorageEnv.add(FileStorageEnv.ENV_KEY_PREFIX,
+        fileStorageEnvs.values().forEach(fileStorageEnv -> fileStorageEnv.add(StorageEnv.ENV_KEY_PREFIX,
                 swDatasetVersionEntity.getStoragePath()));
         return SwDataSet.builder()
                 .id(swDatasetVersionEntity.getId())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/objectstore/DsFileGetter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/objectstore/DsFileGetter.java
@@ -23,6 +23,7 @@ import ai.starwhale.mlops.exception.SwProcessException;
 import ai.starwhale.mlops.exception.SwProcessException.ErrorType;
 import ai.starwhale.mlops.storage.StorageAccessService;
 import ai.starwhale.mlops.storage.StorageObjectInfo;
+import ai.starwhale.mlops.storage.StorageUri;
 import java.io.IOException;
 import java.io.InputStream;
 import lombok.extern.slf4j.Slf4j;

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
@@ -32,9 +32,8 @@ import ai.starwhale.mlops.domain.task.status.watchers.TaskWatcherForLogging;
 import ai.starwhale.mlops.domain.task.status.watchers.TaskWatcherForSchedule;
 import ai.starwhale.mlops.schedule.SwTaskScheduler;
 import ai.starwhale.mlops.storage.configuration.StorageProperties;
-import ai.starwhale.mlops.storage.fs.AliyunEnv;
-import ai.starwhale.mlops.storage.fs.BotoS3Config;
-import ai.starwhale.mlops.storage.fs.FileStorageEnv;
+import ai.starwhale.mlops.storage.env.StorageEnv;
+import ai.starwhale.mlops.storage.env.StorageEnvsPropertiesConverter;
 import cn.hutool.json.JSONUtil;
 import io.kubernetes.client.informer.ResourceEventHandler;
 import io.kubernetes.client.openapi.ApiException;
@@ -75,6 +74,7 @@ public class K8sTaskScheduler implements SwTaskScheduler {
     final ResourceEventHandler<V1Job> eventHandlerJob;
     final ResourceEventHandler<V1Node> eventHandlerNode;
     final String instanceUri;
+    final StorageEnvsPropertiesConverter storageEnvsPropertiesConverter;
 
     public K8sTaskScheduler(K8sClient k8sClient,
             StorageProperties storageProperties,
@@ -83,7 +83,8 @@ public class K8sTaskScheduler implements SwTaskScheduler {
             K8sResourcePoolConverter resourcePoolConverter,
             K8sJobTemplate k8sJobTemplate,
             ResourceEventHandler<V1Job> eventHandlerJob,
-            ResourceEventHandler<V1Node> eventHandlerNode, @Value("${sw.instance-uri}") String instanceUri) {
+            ResourceEventHandler<V1Node> eventHandlerNode, @Value("${sw.instance-uri}") String instanceUri,
+            StorageEnvsPropertiesConverter storageEnvsPropertiesConverter) {
         this.k8sClient = k8sClient;
         this.storageProperties = storageProperties;
         this.jobTokenConfig = jobTokenConfig;
@@ -93,6 +94,7 @@ public class K8sTaskScheduler implements SwTaskScheduler {
         this.eventHandlerJob = eventHandlerJob;
         this.eventHandlerNode = eventHandlerNode;
         this.instanceUri = instanceUri;
+        this.storageEnvsPropertiesConverter = storageEnvsPropertiesConverter;
     }
 
     @Override
@@ -190,7 +192,7 @@ public class K8sTaskScheduler implements SwTaskScheduler {
         swDataSets.forEach(ds -> ds.getFileStorageEnvs().values()
                 .forEach(fileStorageEnv -> coreContainerEnvs.putAll(fileStorageEnv.getEnvs())));
 
-        coreContainerEnvs.put(FileStorageEnv.ENV_KEY_PREFIX, swDataSet.getPath());
+        coreContainerEnvs.put(StorageEnv.ENV_KEY_PREFIX, swDataSet.getPath());
 
         // datastore env
         coreContainerEnvs.put("SW_TOKEN", jobTokenConfig.getToken());
@@ -204,9 +206,9 @@ public class K8sTaskScheduler implements SwTaskScheduler {
         Job swJob = task.getStep().getJob();
         JobRuntime jobRuntime = swJob.getJobRuntime();
         Map<String, String> initContainerEnvs = new HashMap<>();
-        Map<String, FileStorageEnv> fileStorageEnvs = storageProperties.toFileStorageEnvs();
+        Map<String, StorageEnv> fileStorageEnvs = storageEnvsPropertiesConverter.propertiesToEnvs();
         // Ignore keys, we use only one key by now
-        fileStorageEnvs.values().forEach((FileStorageEnv env) -> initContainerEnvs.putAll(env.getEnvs()));
+        fileStorageEnvs.values().forEach((StorageEnv env) -> initContainerEnvs.putAll(env.getEnvs()));
 
         List<String> downloads = new ArrayList<>();
         String prefix = "s3://" + storageProperties.getS3Config().getBucket() + "/";

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -33,7 +33,7 @@ sw:
       host-path-for-cache: ${SW_K8S_HOST_PATH_FOR_CACHE:/mnt/data}
       job-template-path: ${SW_K8S_JOB_TEMPLATE_PATH:}
   storage:
-    type: ${SW_STORAGE_TYPE:s3}
+    type: ${SW_STORAGE_TYPE:minio}
     path-prefix: ${SW_STORAGE_PREFIX:starwhale}
     fs-root-dir: ${SW_STORAGE_FS_ROOT_DIR:/usr/local/starwhale}
     s3-config:

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/objectstore/StorageUriTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/objectstore/StorageUriTest.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.domain.swds.objectstore;
 
+import ai.starwhale.mlops.storage.StorageUri;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/objectstore/UserStorageAuthEnvTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/objectstore/UserStorageAuthEnvTest.java
@@ -16,12 +16,13 @@
 
 package ai.starwhale.mlops.domain.swds.objectstore;
 
-import ai.starwhale.mlops.storage.fs.FileStorageEnv;
-import ai.starwhale.mlops.storage.fs.FileStorageEnv.FileSystemEnvType;
+import ai.starwhale.mlops.storage.env.StorageEnv;
+import ai.starwhale.mlops.storage.env.StorageEnv.StorageEnvType;
+import ai.starwhale.mlops.storage.env.UserStorageAuthEnv;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class StorageAuthsTest {
+public class UserStorageAuthEnvTest {
 
     @Test
     public void testS3() {
@@ -33,23 +34,23 @@ public class StorageAuthsTest {
                 + "USER.S3.myname.SECRET=secret1\n"
                 + "USER.S3.MNIST.SECRET=\n"
                 + "USER.S3.myname.ACCESS_KEY=access_key1\n";
-        StorageAuths storageAuths = new StorageAuths(auths);
-        FileStorageEnv defaultEnv = storageAuths.getEnv("");
-        Assertions.assertEquals(FileSystemEnvType.S3, defaultEnv.getEnvType());
+        UserStorageAuthEnv storageAuths = new UserStorageAuthEnv(auths);
+        StorageEnv defaultEnv = storageAuths.getEnv("");
+        Assertions.assertEquals(StorageEnvType.S3, defaultEnv.getEnvType());
         Assertions.assertEquals("region", defaultEnv.getEnvs().get("USER.S3.REGION"));
         Assertions.assertEquals("endpoint", defaultEnv.getEnvs().get("USER.S3.ENDPOINT"));
         Assertions.assertEquals("secret", defaultEnv.getEnvs().get("USER.S3.SECRET"));
         Assertions.assertEquals("access_key", defaultEnv.getEnvs().get("USER.S3.ACCESS_KEY"));
 
-        FileStorageEnv myEnv = storageAuths.getEnv("myname");
-        Assertions.assertEquals(FileSystemEnvType.S3, myEnv.getEnvType());
+        StorageEnv myEnv = storageAuths.getEnv("myname");
+        Assertions.assertEquals(StorageEnvType.S3, myEnv.getEnvType());
         Assertions.assertNull(myEnv.getEnvs().get("USER.S3.myname.REGION"));
         Assertions.assertEquals("endpoint1", myEnv.getEnvs().get("USER.S3.MYNAME.ENDPOINT"));
         Assertions.assertEquals("secret1", myEnv.getEnvs().get("USER.S3.MYNAME.SECRET"));
         Assertions.assertEquals("access_key1", myEnv.getEnvs().get("USER.S3.MYNAME.ACCESS_KEY"));
 
-        FileStorageEnv mnist = storageAuths.getEnv("MNIST");
-        Assertions.assertEquals(FileSystemEnvType.S3, mnist.getEnvType());
+        StorageEnv mnist = storageAuths.getEnv("MNIST");
+        Assertions.assertEquals(StorageEnvType.S3, mnist.getEnvType());
         Assertions.assertEquals("", mnist.getEnvs().get("USER.S3.MNIST.SECRET"));
     }
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -35,6 +35,7 @@
     <testcontainers.version>1.17.3</testcontainers.version>
     <awssdk.version>2.17.159</awssdk.version>
     <aliyunoss.version>3.15.1</aliyunoss.version>
+    <minio.version>8.4.4</minio.version>
     <test.mybatis.version>2.2.2</test.mybatis.version>
     <starwhale.version>0.1.0-SNAPSHOT</starwhale.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -178,6 +179,11 @@
         <groupId>com.aliyun.oss</groupId>
         <artifactId>aliyun-sdk-oss</artifactId>
         <version>${aliyunoss.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.minio</groupId>
+        <artifactId>minio</artifactId>
+        <version>${minio.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/server/storage-access-layer/pom.xml
+++ b/server/storage-access-layer/pom.xml
@@ -24,10 +24,14 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
     </dependency>
-      <dependency>
-        <groupId>com.aliyun.oss</groupId>
-        <artifactId>aliyun-sdk-oss</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>com.aliyun.oss</groupId>
+      <artifactId>aliyun-sdk-oss</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.minio</groupId>
+      <artifactId>minio</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/StorageUri.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/StorageUri.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.domain.swds.objectstore;
+package ai.starwhale.mlops.storage;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/configuration/StorageAccessConfig.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/configuration/StorageAccessConfig.java
@@ -18,6 +18,9 @@ package ai.starwhale.mlops.storage.configuration;
 
 import ai.starwhale.mlops.storage.StorageAccessService;
 import ai.starwhale.mlops.storage.aliyun.StorageAccessServiceAliyun;
+import ai.starwhale.mlops.storage.env.StorageEnvsPropertiesConverter;
+import ai.starwhale.mlops.storage.env.UserStorageAccessServiceBuilder;
+import ai.starwhale.mlops.storage.minio.StorageAccessServiceMinio;
 import ai.starwhale.mlops.storage.s3.StorageAccessServiceS3;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -29,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 public class StorageAccessConfig {
 
     @Bean
-    @ConditionalOnProperty(prefix = "sw.storage", name = "type", havingValue = "s3", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "sw.storage", name = "type", havingValue = "s3")
     public StorageAccessService s3(StorageProperties storageProperties) {
         return new StorageAccessServiceS3(storageProperties.getS3Config());
     }
@@ -39,4 +42,22 @@ public class StorageAccessConfig {
     public StorageAccessService aliyun(StorageProperties storageProperties) {
         return new StorageAccessServiceAliyun(storageProperties.getS3Config());
     }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "sw.storage", name = "type", havingValue = "minio", matchIfMissing = true)
+    public StorageAccessService minio(StorageProperties storageProperties) {
+        return new StorageAccessServiceMinio(storageProperties.getS3Config());
+    }
+
+    @Bean
+    public StorageEnvsPropertiesConverter storageEnvsPropertiesConverter(StorageProperties storageProperties) {
+        return new StorageEnvsPropertiesConverter(storageProperties);
+    }
+
+    @Bean
+    public UserStorageAccessServiceBuilder userStorageAccessServiceBuilder(
+            StorageEnvsPropertiesConverter storageEnvsPropertiesConverter) {
+        return new UserStorageAccessServiceBuilder(storageEnvsPropertiesConverter);
+    }
+
 }

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/configuration/StorageProperties.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/configuration/StorageProperties.java
@@ -16,13 +16,7 @@
 
 package ai.starwhale.mlops.storage.configuration;
 
-import ai.starwhale.mlops.storage.fs.AliyunEnv;
-import ai.starwhale.mlops.storage.fs.BotoS3Config;
-import ai.starwhale.mlops.storage.fs.FileStorageEnv;
-import ai.starwhale.mlops.storage.fs.S3Env;
 import ai.starwhale.mlops.storage.s3.S3Config;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -34,39 +28,4 @@ public class StorageProperties {
     String pathPrefix;
     S3Config s3Config;
 
-    public Map<String, FileStorageEnv> toFileStorageEnvs() {
-        Map<String, FileStorageEnv> ret = new HashMap<>();
-        if (s3Config == null) {
-            return ret;
-        }
-
-        String t = type;
-        if (t == null || t.isEmpty()) {
-            // make s3 as default type
-            t = FileStorageEnv.FileSystemEnvType.S3.name();
-        }
-
-        if (t.equalsIgnoreCase(FileStorageEnv.FileSystemEnvType.S3.name())) {
-            var s3Env = new S3Env();
-            updateS3Config(s3Env);
-            ret.put(s3Env.getEnvType().name(), s3Env);
-        } else if (t.equalsIgnoreCase(FileStorageEnv.FileSystemEnvType.ALIYUN.name())) {
-            var aliyunEnv = new AliyunEnv();
-            updateS3Config(aliyunEnv);
-            // force using virtual host path
-            aliyunEnv.setExtraS3Configs(new BotoS3Config(BotoS3Config.AddressingStyleType.VIRTUAL).toEnvStr());
-            ret.put(aliyunEnv.getEnvType().name(), aliyunEnv);
-        }
-
-        return ret;
-    }
-
-    private void updateS3Config(S3Env s3Env) {
-        s3Env.setEndPoint(s3Config.getEndpoint())
-                .setBucket(s3Config.getBucket())
-                .setAccessKey(s3Config.getAccessKey())
-                .setSecret(s3Config.getSecretKey())
-                .setRegion(s3Config.getRegion())
-                .setKeyPrefix(pathPrefix);
-    }
 }

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/AliyunEnv.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/AliyunEnv.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.storage.fs;
+package ai.starwhale.mlops.storage.env;
 
 public class AliyunEnv extends S3Env {
     public static final String ENV_EXTRA_S3_CONFIGS = "SW_S3_EXTRA_CONFIGS";
 
     public AliyunEnv() {
-        super(FileSystemEnvType.ALIYUN);
+        super(StorageEnvType.ALIYUN);
     }
 
     public void setExtraS3Configs(String extraS3Configs) {

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/S3Env.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/S3Env.java
@@ -14,28 +14,28 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.storage.fs;
+package ai.starwhale.mlops.storage.env;
 
 /**
  * holds s3 env keys
  */
-public class S3Env extends FileStorageEnv {
+public class S3Env extends StorageEnv {
 
     public static final String ENV_BUCKET = "SW_S3_BUCKET";
 
     public static final String ENV_SECRET_KEY = "SW_S3_SECRET";
 
-    public static final String ENV_SECRET_ID = "SW_S3_ACCESS_KEY";
+    public static final String ENV_ACCESS_KEY = "SW_S3_ACCESS_KEY";
 
     public static final String ENV_REGION = "SW_S3_REGION";
 
     public static final String ENV_ENDPOINT = "SW_S3_ENDPOINT";
 
     public S3Env() {
-        super(FileSystemEnvType.S3);
+        super(StorageEnvType.S3);
     }
 
-    public S3Env(FileSystemEnvType t) {
+    public S3Env(StorageEnvType t) {
         super(t);
     }
 
@@ -50,7 +50,7 @@ public class S3Env extends FileStorageEnv {
     }
 
     public S3Env setAccessKey(String accessKey) {
-        this.add(ENV_SECRET_ID, accessKey);
+        this.add(ENV_ACCESS_KEY, accessKey);
         return this;
     }
 

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/StorageEnv.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/StorageEnv.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.storage.fs;
+package ai.starwhale.mlops.storage.env;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,28 +23,28 @@ import lombok.Getter;
 /**
  * holds storage connection information
  */
-public class FileStorageEnv {
+public class StorageEnv {
 
     @Getter
     Map<String, String> envs = new HashMap<>();
 
     @Getter
-    FileSystemEnvType envType;
+    StorageEnvType envType;
 
     public static final String ENV_TYPE = "SW_STORAGE_ENV_TYPE";
 
     public static final String ENV_KEY_PREFIX = "SW_OBJECT_STORE_KEY_PREFIX";
 
-    public enum FileSystemEnvType {
-        S3, ALIYUN, HDFS, NFS, LOCAL_FS, REST_RESOURCE, FTP
+    public enum StorageEnvType {
+        S3, MINIO, ALIYUN, HDFS, NFS, LOCAL_FS, REST_RESOURCE, FTP
     }
 
-    public FileStorageEnv add(String name, String value) {
+    public StorageEnv add(String name, String value) {
         envs.put(name.toUpperCase(), value);
         return this;
     }
 
-    public FileStorageEnv(FileSystemEnvType envType) {
+    public StorageEnv(StorageEnvType envType) {
         this.envType = envType;
         envs.put(ENV_TYPE, envType.name());
     }

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/StorageEnvsPropertiesConverter.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/StorageEnvsPropertiesConverter.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.env;
+
+import ai.starwhale.mlops.storage.StorageUri;
+import ai.starwhale.mlops.storage.configuration.StorageProperties;
+import ai.starwhale.mlops.storage.env.StorageEnv.StorageEnvType;
+import ai.starwhale.mlops.storage.s3.BotoS3Config;
+import ai.starwhale.mlops.storage.s3.S3Config;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+public class StorageEnvsPropertiesConverter {
+
+    final StorageProperties storageProperties;
+
+    static final String KEY_BUCKET = "USER.%s.%sBUCKET";
+    static final String KEY_REGION = "USER.%s.%sREGION";
+    static final String KEY_ENDPOINT = "USER.%s.%sENDPOINT";
+    static final String KEY_SECRET = "USER.%s.%sSECRET";
+    static final String KEY_ACCESS_KEY = "USER.%s.%sACCESS_KEY";
+
+    public StorageEnvsPropertiesConverter(StorageProperties storageProperties) {
+        this.storageProperties = storageProperties;
+    }
+
+    public S3Config envToS3Config(StorageEnv env, StorageUri storageUri, String authName) {
+        if (StringUtils.hasText(authName)) {
+            authName = authName + ".";
+        } else {
+            authName = "";
+        }
+        authName = authName.toUpperCase();
+        Map<String, String> envs = env.getEnvs();
+        String bucket = null != storageUri && StringUtils.hasText(storageUri.getBucket()) ? storageUri.getBucket()
+                : envs.get(String.format(KEY_BUCKET, env.getEnvType().name(), authName));
+        String accessKey =
+                null != storageUri && StringUtils.hasText(storageUri.getUsername()) ? storageUri.getUsername()
+                        : envs.get(String.format(KEY_ACCESS_KEY, env.getEnvType().name(), authName));
+        String accessSecret =
+                null != storageUri && StringUtils.hasText(storageUri.getPassword()) ? storageUri.getPassword()
+                        : envs.get(String.format(KEY_SECRET, env.getEnvType().name(), authName));
+        String endpoint = null != storageUri && StringUtils.hasText(storageUri.getHost()) ? buildEndPoint(storageUri)
+                : envs.get(String.format(KEY_ENDPOINT, env.getEnvType().name(), authName));
+        return S3Config.builder()
+                .bucket(bucket)
+                .accessKey(accessKey)
+                .secretKey(accessSecret)
+                .region(envs.get(String.format(KEY_REGION, env.getEnvType().name(), authName)))
+                .endpoint(endpoint)
+                .build();
+    }
+
+    private String buildEndPoint(StorageUri storageUri) {
+        if (null == storageUri.getPort() || 80 == storageUri.getPort()) {
+            return "http://" + storageUri.getHost();
+        } else if (443 == storageUri.getPort()) {
+            return "https://" + storageUri.getHost();
+        } else {
+            return "http://" + storageUri.getHost() + ":" + storageUri.getPort();
+        }
+
+    }
+
+    public Map<String, StorageEnv> propertiesToEnvs() {
+        Map<String, StorageEnv> ret = new HashMap<>();
+        if (null == storageProperties || storageProperties.getS3Config() == null) {
+            return ret;
+        }
+
+        String t = storageProperties.getType();
+        if (t == null || t.isEmpty()) {
+            // make s3 as default type
+            t = StorageEnvType.S3.name();
+        }
+
+        if (t.equalsIgnoreCase(StorageEnvType.S3.name()) || t.equalsIgnoreCase(
+                StorageEnvType.MINIO.name())) {
+            var s3Env = new S3Env();
+            updateS3Env(s3Env, storageProperties);
+            ret.put(s3Env.getEnvType().name(), s3Env);
+        } else if (t.equalsIgnoreCase(StorageEnvType.ALIYUN.name())) {
+            var aliyunEnv = new AliyunEnv();
+            updateS3Env(aliyunEnv, storageProperties);
+            // force using virtual host path
+            aliyunEnv.setExtraS3Configs(new BotoS3Config(BotoS3Config.AddressingStyleType.VIRTUAL).toEnvStr());
+            ret.put(aliyunEnv.getEnvType().name(), aliyunEnv);
+        } else {
+            log.error("storage type {} is not supported yet", t);
+        }
+
+        return ret;
+    }
+
+    private void updateS3Env(S3Env s3Env, StorageProperties storageProperties) {
+        s3Env.setEndPoint(storageProperties.getS3Config().getEndpoint())
+                .setBucket(storageProperties.getS3Config().getBucket())
+                .setAccessKey(storageProperties.getS3Config().getAccessKey())
+                .setSecret(storageProperties.getS3Config().getSecretKey())
+                .setRegion(storageProperties.getS3Config().getRegion())
+                .setKeyPrefix(storageProperties.getPathPrefix());
+    }
+
+}

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/UserStorageAccessServiceBuilder.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/UserStorageAccessServiceBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.env;
+
+import ai.starwhale.mlops.storage.StorageAccessService;
+import ai.starwhale.mlops.storage.StorageUri;
+import ai.starwhale.mlops.storage.aliyun.StorageAccessServiceAliyun;
+import ai.starwhale.mlops.storage.minio.StorageAccessServiceMinio;
+import ai.starwhale.mlops.storage.s3.StorageAccessServiceS3;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class UserStorageAccessServiceBuilder {
+
+    final StorageEnvsPropertiesConverter storageEnvsPropertiesConverter;
+
+    public UserStorageAccessServiceBuilder(
+            StorageEnvsPropertiesConverter storageEnvsPropertiesConverter) {
+        this.storageEnvsPropertiesConverter = storageEnvsPropertiesConverter;
+    }
+
+    @Nullable
+    public StorageAccessService build(StorageEnv userEnvs, StorageUri storageUri, String authName) {
+        switch (userEnvs.getEnvType()) {
+            case S3:
+                return new StorageAccessServiceS3(
+                        storageEnvsPropertiesConverter.envToS3Config(userEnvs, storageUri, authName));
+            case ALIYUN:
+                return new StorageAccessServiceAliyun(
+                        storageEnvsPropertiesConverter.envToS3Config(userEnvs, storageUri, authName));
+            case MINIO:
+                return new StorageAccessServiceMinio(
+                        storageEnvsPropertiesConverter.envToS3Config(userEnvs, storageUri, authName));
+            default:
+                log.warn("storage type {} not supported yet", userEnvs.getEnvType());
+                return null;
+        }
+    }
+
+}

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/UserStorageAuthEnv.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/UserStorageAuthEnv.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.domain.swds.objectstore;
+package ai.starwhale.mlops.storage.env;
 
-import ai.starwhale.mlops.storage.fs.FileStorageEnv;
-import ai.starwhale.mlops.storage.fs.FileStorageEnv.FileSystemEnvType;
+import ai.starwhale.mlops.storage.env.StorageEnv.StorageEnvType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -27,16 +26,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
 @Slf4j
-public class StorageAuths {
+public class UserStorageAuthEnv {
 
-    Map<String, FileStorageEnv> envMap = new HashMap<>();
+    Map<String, StorageEnv> envMap = new HashMap<>();
 
     static final String NAME_DEFAULT = "";
 
     static final Pattern LINE_PATTERN = Pattern.compile(
             "^(USER\\.(S3|ALIYUN|HDFS|WEBHDFS|LOCALFS|NFS|FTP|SFTP|HTTP|HTTPS)\\.((\\w+)\\.)?(\\w+))=(\\w*)$");
 
-    public StorageAuths(String authsText) {
+    public UserStorageAuthEnv(String authsText) {
         String[] lines = authsText.split("\n");
         Stream.of(lines).forEach(line -> {
             Matcher matcher = LINE_PATTERN.matcher(line);
@@ -51,21 +50,21 @@ public class StorageAuths {
             if (!StringUtils.hasText(name)) {
                 name = NAME_DEFAULT;
             }
-            FileStorageEnv fileStorageEnv = envMap.computeIfAbsent(name,
-                    k -> new FileStorageEnv(FileSystemEnvType.valueOf(type)));
-            fileStorageEnv.add(envName, envValue);
+            StorageEnv storageEnv = envMap.computeIfAbsent(name,
+                    k -> new StorageEnv(StorageEnvType.valueOf(type)));
+            storageEnv.add(envName, envValue);
         });
 
     }
 
-    public FileStorageEnv getEnv(String authName) {
+    public StorageEnv getEnv(String authName) {
         if (!StringUtils.hasText(authName)) {
             return envMap.get(NAME_DEFAULT);
         }
         return envMap.get(authName);
     }
 
-    public Map<String, FileStorageEnv> allEnvs() {
+    public Map<String, StorageEnv> allEnvs() {
         return envMap;
     }
 

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/minio/StorageAccessServiceMinio.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/minio/StorageAccessServiceMinio.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.minio;
+
+import ai.starwhale.mlops.storage.LengthAbleInputStream;
+import ai.starwhale.mlops.storage.StorageAccessService;
+import ai.starwhale.mlops.storage.StorageObjectInfo;
+import ai.starwhale.mlops.storage.s3.S3Config;
+import ai.starwhale.mlops.storage.util.MetaHelper;
+import io.minio.GetObjectArgs;
+import io.minio.GetObjectResponse;
+import io.minio.ListObjectsArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import io.minio.RemoveObjectArgs;
+import io.minio.StatObjectArgs;
+import io.minio.StatObjectResponse;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.MinioException;
+import io.minio.messages.Item;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.integration.IntegrationProperties.Error;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+@Slf4j
+public class StorageAccessServiceMinio implements StorageAccessService {
+
+    final String bucket;
+
+    final MinioClient minioClient;
+
+    public StorageAccessServiceMinio(S3Config s3Config) {
+        this.bucket = s3Config.getBucket();
+        minioClient =
+                MinioClient.builder()
+                        .endpoint(s3Config.getEndpoint())
+                        .credentials(s3Config.getAccessKey(), s3Config.getSecretKey())
+                        .build();
+    }
+
+    @Override
+    public StorageObjectInfo head(String path) throws IOException {
+        try {
+            StatObjectResponse resp = this.minioClient.statObject(
+                    StatObjectArgs.builder().bucket(bucket).object(path).build());
+            return new StorageObjectInfo(true, resp.size(), MetaHelper.mapToString(resp.userMetadata()));
+        } catch (ErrorResponseException e) {
+            if ("NoSuchKey".equals(e.errorResponse().code())) {
+                return new StorageObjectInfo(false, null, null);
+            } else {
+                log.error("head object fails", e);
+                throw new IOException(e);
+            }
+        } catch (MinioException e) {
+            log.error("head object fails", e);
+            throw new IOException(e);
+        } catch (InvalidKeyException e) {
+            return new StorageObjectInfo(false, null, null);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("head object fails", e);
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void put(String path, InputStream inputStream, long size) throws IOException {
+        try {
+            this.minioClient.putObject(
+                    PutObjectArgs.builder().bucket(this.bucket).object(path).stream(inputStream, size, -1).build());
+        } catch (MinioException e) {
+            log.error("head object fails", e);
+            throw new IOException(e);
+        } catch (InvalidKeyException e) {
+            log.error("head object fails", e);
+            throw new IOException(e);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("head object fails", e);
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void put(String path, byte[] body) throws IOException {
+        try {
+            this.minioClient.putObject(
+                    PutObjectArgs.builder().bucket(this.bucket).object(path)
+                            .stream(new ByteArrayInputStream(body), body.length, -1).build());
+        } catch (MinioException e) {
+            log.error("head object fails", e);
+            throw new IOException(e);
+        } catch (InvalidKeyException e) {
+            log.error("head object fails", e);
+            throw new IOException(e);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("head object fails", e);
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public LengthAbleInputStream get(String path) throws IOException {
+        StorageObjectInfo objectInfo = this.head(path);
+        try {
+            GetObjectResponse resp = this.minioClient.getObject(GetObjectArgs.builder()
+                    .bucket(this.bucket)
+                    .object(path)
+                    .build());
+            return new LengthAbleInputStream(resp, objectInfo.getContentLength());
+        } catch (MinioException e) {
+            log.error("get object fails", e);
+            throw new IOException(e);
+        } catch (InvalidKeyException e) {
+            log.error("get object fails", e);
+            throw new IOException(e);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("get object fails", e);
+            throw new IOException(e);
+        }
+
+    }
+
+    @Override
+    public LengthAbleInputStream get(String path, Long offset, Long size) throws IOException {
+        try {
+            GetObjectResponse resp = this.minioClient.getObject(GetObjectArgs.builder()
+                    .bucket(this.bucket)
+                    .offset(offset)
+                    .length(size)
+                    .object(path)
+                    .build());
+            return new LengthAbleInputStream(resp, size);
+        } catch (MinioException e) {
+            log.error("get object fails", e);
+            throw new IOException(e);
+        } catch (InvalidKeyException e) {
+            log.error("get object fails", e);
+            throw new IOException(e);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("get object fails", e);
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Stream<String> list(String path) throws IOException {
+        var resp = this.minioClient.listObjects(
+                ListObjectsArgs.builder().bucket(this.bucket).prefix(path).recursive(true).build());
+        return StreamSupport.stream(resp.spliterator(), false).map(rt -> {
+            try {
+                return rt.get();
+            } catch (MinioException e) {
+                log.error("list object fails", e);
+                return null;
+            } catch (InvalidKeyException e) {
+                log.error("list object fails", e);
+                return null;
+            } catch (IOException e) {
+                log.error("list object fails", e);
+                return null;
+            } catch (NoSuchAlgorithmException e) {
+                log.error("list object fails", e);
+                return null;
+            }
+
+        }).filter(Objects::nonNull).filter(item -> !item.isDir()).map(Item::objectName);
+    }
+
+    @Override
+    public void delete(String path) throws IOException {
+        try {
+            this.minioClient.removeObject(RemoveObjectArgs.builder().bucket(this.bucket).object(path).build());
+        } catch (MinioException e) {
+            log.error("delete object fails", e);
+            throw new IOException(e);
+        } catch (InvalidKeyException e) {
+            log.error("delete object fails", e);
+            throw new IOException(e);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("delete object fails", e);
+            throw new IOException(e);
+        }
+    }
+}

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/s3/BotoS3Config.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/s3/BotoS3Config.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.storage.fs;
+package ai.starwhale.mlops.storage.s3;
 
 /**
  * BotoS3Config is for boto3 configuration communicate with starwhale python sdk

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/s3/StorageAccessServiceS3.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/s3/StorageAccessServiceS3.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
+@Slf4j
 public class StorageAccessServiceS3 implements StorageAccessService {
 
     final S3Config s3Config;
@@ -154,11 +156,13 @@ public class StorageAccessServiceS3 implements StorageAccessService {
                             .build())
                     .build());
         } catch (Throwable t) {
+            log.error("multipart file upload aborted", t);
             this.s3client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
                     .bucket(this.s3Config.getBucket())
                     .key(path)
                     .uploadId(uploadId)
                     .build());
+            throw new IOException(t);
         }
     }
 

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/env/AliyunEnvTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/env/AliyunEnvTest.java
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.storage.fs;
+package ai.starwhale.mlops.storage.env;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import ai.starwhale.mlops.storage.env.StorageEnv.StorageEnvType;
 import org.junit.jupiter.api.Test;
 
 public class AliyunEnvTest extends S3EnvTest {
     @Test
     public void testSet() {
         var aliyunEnv = new AliyunEnv();
-        assertThat(aliyunEnv.getEnvType(), is(FileStorageEnv.FileSystemEnvType.ALIYUN));
+        assertThat(aliyunEnv.getEnvType(), is(StorageEnvType.ALIYUN));
         var conf = randomString();
         aliyunEnv.setExtraS3Configs(conf);
         assertThat(mapContains(aliyunEnv.getEnvs(), AliyunEnv.ENV_EXTRA_S3_CONFIGS, conf), is(true));

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/env/S3EnvTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/env/S3EnvTest.java
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.storage.fs;
+package ai.starwhale.mlops.storage.env;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import ai.starwhale.mlops.storage.env.StorageEnv.StorageEnvType;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 public class S3EnvTest {
+
     @Test
     public void testSet() {
         var s3Env = new S3Env();
-        assertThat(s3Env.getEnvType(), is(FileStorageEnv.FileSystemEnvType.S3));
+        assertThat(s3Env.getEnvType(), is(StorageEnvType.S3));
         var envValue = randomString();
         s3Env.setEndPoint(envValue);
         assertThat(mapContains(s3Env.getEnvs(), S3Env.ENV_ENDPOINT, envValue), is(true));
@@ -38,7 +40,7 @@ public class S3EnvTest {
 
         envValue = randomString();
         s3Env.setAccessKey(envValue);
-        assertThat(mapContains(s3Env.getEnvs(), S3Env.ENV_SECRET_ID, envValue), is(true));
+        assertThat(mapContains(s3Env.getEnvs(), S3Env.ENV_ACCESS_KEY, envValue), is(true));
 
         envValue = randomString();
         s3Env.setSecret(envValue);

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/env/StorageEnvsPropertiesConverterTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/env/StorageEnvsPropertiesConverterTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.env;
+
+import ai.starwhale.mlops.storage.StorageUri;
+import ai.starwhale.mlops.storage.configuration.StorageProperties;
+import ai.starwhale.mlops.storage.env.StorageEnv.StorageEnvType;
+import ai.starwhale.mlops.storage.s3.S3Config;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class StorageEnvsPropertiesConverterTest {
+
+    @Test
+    public void testUserEnv2Config() {
+        StorageEnvsPropertiesConverter storageEnvsPropertiesConverter = new StorageEnvsPropertiesConverter(null);
+        S3Config s3Config = storageEnvsPropertiesConverter.envToS3Config(new StorageEnv(
+                StorageEnvType.S3)
+                .add("USER.S3.MYTEST.ENDPOINT", "endpoint")
+                .add("USER.S3.URTEST.ENDPOINT", "EDP")
+                .add("USER.S4.mytest.endpoint", "dpd")
+                .add("USER.S3.mytest.SECRET", "SCret")
+                .add("USER.S3.mytest.ACCESS_KEY", "ack")
+                .add("USER.S3.mytest.BUCKET", "bkt")
+                .add("USER.S3.MYTEST.REGION", "region"), new StorageUri("s3://renyanda/bdc/xyf"), "mytest");
+        Assertions.assertEquals("renyanda", s3Config.getBucket());
+        Assertions.assertEquals("ack", s3Config.getAccessKey());
+        Assertions.assertEquals("SCret", s3Config.getSecretKey());
+        Assertions.assertEquals("region", s3Config.getRegion());
+    }
+
+    public static final String bucket = "bucket";
+    public static final String accessKey = "accessKey";
+    public static final String secretKey = "secretKey";
+    public static final String region = "region";
+    public static final String endpoint = "endpoint";
+    public static final String prefixKey = "controller";
+
+    private StorageProperties storageProperties;
+
+    @BeforeEach
+    public void setUp() {
+        storageProperties = new StorageProperties();
+        storageProperties.setS3Config(
+                S3Config.builder()
+                        .bucket(bucket)
+                        .accessKey(accessKey)
+                        .secretKey(secretKey)
+                        .region(region)
+                        .endpoint(endpoint)
+                        .build());
+        storageProperties.setPathPrefix(prefixKey);
+    }
+
+    @Test
+    public void testAliyunPropertiesToEnvs() {
+        storageProperties.setType("aliyun");
+        StorageEnvsPropertiesConverter storageEnvsPropertiesConverter = new StorageEnvsPropertiesConverter(
+                storageProperties);
+        Map<String, StorageEnv> stringStorageEnvMap = storageEnvsPropertiesConverter.propertiesToEnvs();
+        Assertions.assertEquals(1, stringStorageEnvMap.size());
+        StorageEnv storageEnv = stringStorageEnvMap.get(StorageEnvType.ALIYUN.name());
+        Assertions.assertEquals(StorageEnvType.ALIYUN.name(), storageEnv.getEnvs().get(S3Env.ENV_TYPE));
+        Assertions.assertEquals(secretKey, storageEnv.getEnvs().get(S3Env.ENV_SECRET_KEY));
+        Assertions.assertEquals(accessKey, storageEnv.getEnvs().get(S3Env.ENV_ACCESS_KEY));
+        Assertions.assertEquals(endpoint, storageEnv.getEnvs().get(S3Env.ENV_ENDPOINT));
+        Assertions.assertEquals(bucket, storageEnv.getEnvs().get(S3Env.ENV_BUCKET));
+        Assertions.assertEquals(region, storageEnv.getEnvs().get(S3Env.ENV_REGION));
+        Assertions.assertEquals(prefixKey, storageEnv.getEnvs().get(S3Env.ENV_KEY_PREFIX));
+        Assertions.assertEquals("{\"addressing_style\": \"virtual\"}",
+                storageEnv.getEnvs().get(AliyunEnv.ENV_EXTRA_S3_CONFIGS));
+    }
+
+    @Test
+    public void testS3PropertiesToEnvs() {
+        storageProperties.setType("s3");
+        StorageEnvsPropertiesConverter storageEnvsPropertiesConverter = new StorageEnvsPropertiesConverter(
+                storageProperties);
+        Map<String, StorageEnv> stringStorageEnvMap = storageEnvsPropertiesConverter.propertiesToEnvs();
+        Assertions.assertEquals(1, stringStorageEnvMap.size());
+        StorageEnv storageEnv = stringStorageEnvMap.get(StorageEnvType.S3.name());
+        Assertions.assertEquals(StorageEnvType.S3.name(), storageEnv.getEnvs().get(S3Env.ENV_TYPE));
+        Assertions.assertEquals(secretKey, storageEnv.getEnvs().get(S3Env.ENV_SECRET_KEY));
+        Assertions.assertEquals(accessKey, storageEnv.getEnvs().get(S3Env.ENV_ACCESS_KEY));
+        Assertions.assertEquals(endpoint, storageEnv.getEnvs().get(S3Env.ENV_ENDPOINT));
+        Assertions.assertEquals(bucket, storageEnv.getEnvs().get(S3Env.ENV_BUCKET));
+        Assertions.assertEquals(region, storageEnv.getEnvs().get(S3Env.ENV_REGION));
+        Assertions.assertEquals(prefixKey, storageEnv.getEnvs().get(S3Env.ENV_KEY_PREFIX));
+    }
+
+    @Test
+    public void testMinioPropertiesToEnvs() {
+        storageProperties.setType("minio");
+        StorageEnvsPropertiesConverter storageEnvsPropertiesConverter = new StorageEnvsPropertiesConverter(
+                storageProperties);
+        Map<String, StorageEnv> stringStorageEnvMap = storageEnvsPropertiesConverter.propertiesToEnvs();
+        Assertions.assertEquals(1, stringStorageEnvMap.size());
+        StorageEnv storageEnv = stringStorageEnvMap.get(StorageEnvType.S3.name());
+        Assertions.assertEquals(StorageEnvType.S3.name(), storageEnv.getEnvs().get(S3Env.ENV_TYPE));
+        Assertions.assertEquals(secretKey, storageEnv.getEnvs().get(S3Env.ENV_SECRET_KEY));
+        Assertions.assertEquals(accessKey, storageEnv.getEnvs().get(S3Env.ENV_ACCESS_KEY));
+        Assertions.assertEquals(endpoint, storageEnv.getEnvs().get(S3Env.ENV_ENDPOINT));
+        Assertions.assertEquals(bucket, storageEnv.getEnvs().get(S3Env.ENV_BUCKET));
+        Assertions.assertEquals(region, storageEnv.getEnvs().get(S3Env.ENV_REGION));
+        Assertions.assertEquals(prefixKey, storageEnv.getEnvs().get(S3Env.ENV_KEY_PREFIX));
+    }
+
+}

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/env/UserStorageAccessServiceBuilderTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/env/UserStorageAccessServiceBuilderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.env;
+
+import ai.starwhale.mlops.storage.env.StorageEnv.StorageEnvType;
+import ai.starwhale.mlops.storage.minio.StorageAccessServiceMinio;
+import com.aliyun.oss.common.auth.InvalidCredentialsException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+public class UserStorageAccessServiceBuilderTest {
+
+    private UserStorageAccessServiceBuilder userStorageAccessServiceBuilder;
+
+    @BeforeEach
+    public void setUp() {
+        userStorageAccessServiceBuilder = new UserStorageAccessServiceBuilder(new StorageEnvsPropertiesConverter(null));
+    }
+
+    @Test
+    public void testAliyun() {
+        Assertions.assertThrows(InvalidCredentialsException.class,
+                () -> userStorageAccessServiceBuilder.build(new StorageEnv(
+                        StorageEnvType.ALIYUN)
+                        .add("USER.ALIYUN.ENDPOINT", "endpoint")
+                        .add("USER.ALIYUN.ENDPOINT", "EDP")
+                        .add("USER.ALIYUN.endpoint", "dpd")
+                        .add("USER.S3.SECRET", "SCret")
+                        .add("USER.ALIYUN.ACCESS_KEY", "ack")
+                        .add("USER.ALIYUN.BUCKET", "bkt")
+                        .add("USER.ALIYUN.REGION", "region"), null, null));
+    }
+
+    @Test
+    public void testS3() {
+        Assertions.assertThrows(SdkClientException.class, () -> userStorageAccessServiceBuilder.build(
+                new StorageEnv(
+                        StorageEnvType.S3)
+                        .add("USER.S3.URTEST.ENDPOINT", "http://abcd.com")
+                        .add("USER.S5.URTEST.ENDPOINT", "http://abcd.com/d")
+                        .add("USER.S4.URTEST.endpoint", "dpd")
+                        .add("USER.S3.URTEST.SECRET", "SCret")
+                        .add("USER.S3.URTEST.ACCESS_KEY", "ack")
+                        .add("USER.S3.URTEST.BUCKET", "bkt")
+                        .add("USER.S3.URTEST.REGION", "region"), null,
+                "URTEST"));
+    }
+
+    @Test
+    public void testMinio() {
+        Assertions.assertEquals(StorageAccessServiceMinio.class,
+                userStorageAccessServiceBuilder.build(new StorageEnv(
+                        StorageEnvType.MINIO)
+                        .add("USER.MINIO.MYTEST.ENDPOINT", "endpoint")
+                        .add("USER.MINIO.URTEST.ENDPOINT", "EDP")
+                        .add("USER.S3.MYTEST.endpoint", "dpd")
+                        .add("USER.MINIO.MYTEST.SECRET", "SCret")
+                        .add("USER.MINIO.MYTEST.ACCESS_KEY", "ack")
+                        .add("USER.MINIO.MYTEST.BUCKET", "bkt")
+                        .add("USER.MINIO.MYTEST.REGION", "region"), null, "MYTEST").getClass());
+    }
+
+    @Test
+    public void testNotSupported() {
+        Assertions.assertNull(userStorageAccessServiceBuilder.build(new StorageEnv(
+                StorageEnvType.FTP), null, null));
+    }
+
+}

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/minio/StorageAccessServiceMinioTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/minio/StorageAccessServiceMinioTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.minio;
+
+import ai.starwhale.mlops.storage.LengthAbleInputStream;
+import ai.starwhale.mlops.storage.StorageObjectInfo;
+import ai.starwhale.mlops.storage.s3.S3Config;
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class StorageAccessServiceMinioTest {
+
+    @Container
+    private static final S3MockContainer s3Mock =
+            new S3MockContainer(System.getProperty("s3mock.version", "latest"))
+                    .withValidKmsKeys("arn:aws:kms:us-east-1:1234567890:key/valid-test-key-ref")
+                    .withInitialBuckets("test");
+
+    private StorageAccessServiceMinio minio;
+
+    @BeforeEach
+    public void setUp() {
+        minio = new StorageAccessServiceMinio(S3Config.builder()
+                .bucket("test")
+                .accessKey("ak")
+                .secretKey("sk")
+                .region("us-west-1")
+                .endpoint(s3Mock.getHttpEndpoint())
+                .build());
+    }
+
+    @Test
+    public void testPutAndGet() throws IOException {
+        String path = "unit_test/x";
+        String content = "hello word";
+        minio.put(path, content.getBytes(StandardCharsets.UTF_8));
+        LengthAbleInputStream lengthAbleInputStream = minio.get(path);
+        Assertions.assertEquals(content.length(), lengthAbleInputStream.getSize());
+        Assertions.assertEquals(content, new String(lengthAbleInputStream.readAllBytes()));
+    }
+
+
+    @Test
+    public void testPutAndGetRange() throws IOException {
+        String path = "unit_test/x/r";
+        String content = "hello word";
+        minio.put(path, content.getBytes(StandardCharsets.UTF_8));
+        LengthAbleInputStream lengthAbleInputStream = minio.get(path, 3L, 4L);
+        Assertions.assertEquals(4, lengthAbleInputStream.getSize());
+        Assertions.assertEquals("lo w", new String(lengthAbleInputStream.readAllBytes()));
+    }
+
+    @Test
+    public void testPutAndList() throws IOException {
+        String path = "unit_test/y/z";
+        String content = "hello word";
+        minio.put(path, content.getBytes(StandardCharsets.UTF_8));
+        minio.put(path + "1", content.getBytes(StandardCharsets.UTF_8));
+        Stream<String> stream = minio.list("unit_test/y");
+        List<String> list = stream.sorted().collect(Collectors.toList());
+        Assertions.assertIterableEquals(list, List.of("unit_test/y/z", "unit_test/y/z1"));
+    }
+
+    @Test
+    public void testPutAndDelete() throws IOException {
+        String path = "unit_test/x/d";
+        String content = "hello word";
+        minio.put(path, content.getBytes(StandardCharsets.UTF_8));
+        StorageObjectInfo objectInfo = minio.head(path);
+        Assertions.assertTrue(objectInfo.isExists());
+
+        minio.delete(path);
+        objectInfo = minio.head(path);
+        Assertions.assertFalse(objectInfo.isExists());
+    }
+
+
+}

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/s3/BotoS3ConfigTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/s3/BotoS3ConfigTest.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.storage.fs;
+package ai.starwhale.mlops.storage.s3;
 
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import ai.starwhale.mlops.storage.s3.BotoS3Config;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Description
As uploading multipart file to minio is failing with s3 sdk, minio sdk is introduced. Maybe caused by sha256 calcaluation not matching between two sides.
![image](https://user-images.githubusercontent.com/89630947/191021386-3dfe83b9-a8a2-45cc-af68-4d3c1252ea21.png)

As we have 3 type of stroage implementions, a small refactor is needed. With the refafctor being done, when new storage implemention is introduced , modification could be limited within `storage-access-layer` module
- add minio sdk
- refactor storage env related code
- change the default storage type to minio
- bind some multipart uploading config to env
- tune exception processing when multipart uploading fails in `StorageAccessServiceS3`
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
