### PR TITLE
enhance(controller): tune imagePullPolicy for worker container

### DIFF
--- a/server/controller/src/test/resources/template/job.yaml
+++ b/server/controller/src/test/resources/template/job.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: 'worker'
           image: 'docker.io/library/busybox'
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           args:
             - ppl
           volumeMounts:


### PR DESCRIPTION
## Description
 `IfNotPresent` policy is changed to 'Always'
 `IfNotPresent` policy is not well fitted for images like `ghcr.io/star-whale/starwhale:latest-cuda11.4` . [ `The caching semantics of the underlying image provider make even imagePullPolicy: Always efficient, as long as the registry is reliably accessible. Your container runtime can notice that the image layers already exist on the node so that they don't need to be downloaded again.`](https://kubernetes.io/docs/concepts/containers/images/) 
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
