### PR TITLE
feat(client): support force remove for model/dataset/runtime/eval

### DIFF
--- a/client/starwhale/base/store.py
+++ b/client/starwhale/base/store.py
@@ -228,3 +228,7 @@ class BaseStorage(metaclass=ABCMeta):
         with TarFS(str(fpath)) as tar:
             with tar.open(DEFAULT_MANIFEST_NAME) as f:
                 return yaml.safe_load(f)
+
+    @property
+    def recover_snapshot_workdir(self) -> Path:
+        return self._get_recover_snapshot_workdir_for_bundle()

--- a/client/starwhale/core/dataset/cli.py
+++ b/client/starwhale/core/dataset/cli.py
@@ -94,7 +94,12 @@ def _info(view: t.Type[DatasetTermView], dataset: str, fullname: bool) -> None:
 
 @dataset_cmd.command("remove")
 @click.argument("dataset")
-@click.option("-f", "--force", is_flag=True, help="Force to remove dataset")
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Force to remove dataset, the removed dataset cannot recover",
+)
 @click.pass_obj
 def _remove(view: t.Type[DatasetTermView], dataset: str, force: bool) -> None:
     """

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -24,7 +24,7 @@ from starwhale.consts import (
 )
 from starwhale.base.tag import StandaloneTag
 from starwhale.base.uri import URI
-from starwhale.utils.fs import move_dir, copy_file, ensure_dir
+from starwhale.utils.fs import move_dir, copy_file, empty_dir, ensure_dir
 from starwhale.base.type import URIType, BundleType, InstanceType
 from starwhale.base.cloud import CloudRequestMixed, CloudBundleModelMixin
 from starwhale.utils.http import ignore_error
@@ -196,7 +196,11 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
 
     def remove(self, force: bool = False) -> t.Tuple[bool, str]:
         # TODO: remove by tag
-        return move_dir(self.store.snapshot_workdir, self.store.recover_loc, force)
+        if force:
+            empty_dir(self.store.snapshot_workdir)
+            return True, ""
+        else:
+            return move_dir(self.store.snapshot_workdir, self.store.recover_loc, False)
 
     def recover(self, force: bool = False) -> t.Tuple[bool, str]:
         dest_path = (

--- a/client/starwhale/core/eval/cli.py
+++ b/client/starwhale/core/eval/cli.py
@@ -97,7 +97,12 @@ def _run(
 
 @eval_job_cmd.command("remove", help="Remove job")
 @click.argument("job")
-@click.option("-f", "--force", is_flag=True, help="Force to remove")
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Force to remove, the removed job cannot recover",
+)
 def _remove(job: str, force: bool) -> None:
     click.confirm("continue to remove?", abort=True)
     JobTermView(job).remove(force)

--- a/client/starwhale/core/eval/model.py
+++ b/client/starwhale/core/eval/model.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from starwhale.utils import load_yaml
 from starwhale.consts import HTTPMethod, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
 from starwhale.base.uri import URI
-from starwhale.utils.fs import move_dir
+from starwhale.utils.fs import move_dir, empty_dir
 from starwhale.api._impl import wrapper
 from starwhale.base.type import InstanceType, JobOperationType
 from starwhale.base.cloud import CloudRequestMixed
@@ -262,7 +262,11 @@ class StandaloneEvaluationJob(EvaluationJob):
         }
 
     def remove(self, force: bool = False) -> t.Tuple[bool, str]:
-        return move_dir(self.store.loc, self.store.recover_loc, force)
+        if force:
+            empty_dir(self.store.loc)
+            return True, ""
+        else:
+            return move_dir(self.store.loc, self.store.recover_loc, False)
 
     def recover(self, force: bool = False) -> t.Tuple[bool, str]:
         return move_dir(self.store.recover_loc, self.store.loc, force)

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -89,9 +89,14 @@ def _history(view: t.Type[ModelTermView], model: str, fullname: bool) -> None:
 
 @model_cmd.command("remove", help="Remove model")
 @click.argument("model")
-@click.option("-f", "--force", is_flag=True, help="Force to remove model")
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Force to remove model, the removed model cannot recover",
+)
 def _remove(model: str, force: bool) -> None:
-    click.confirm("continue to delete?", abort=True)
+    click.confirm("continue to remove?", abort=True)
     ModelTermView(model).remove(force)
 
 

--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -335,13 +335,7 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
         return _r
 
     def remove(self, force: bool = False) -> t.Tuple[bool, str]:
-        _ok, _reason = move_dir(self.store.loc, self.store.recover_loc, force)
-        _ok2, _reason2 = True, ""
-        if self.store.snapshot_workdir.exists():
-            _ok2, _reason2 = move_dir(
-                self.store.snapshot_workdir, self.store.recover_snapshot_workdir, force
-            )
-        return _ok and _ok2, _reason + _reason2
+        return self._do_remove(force)
 
     def recover(self, force: bool = False) -> t.Tuple[bool, str]:
         # TODO: support short version to recover, today only support full-version

--- a/client/starwhale/core/model/store.py
+++ b/client/starwhale/core/model/store.py
@@ -33,7 +33,3 @@ class ModelStorage(BaseStorage):
     @property
     def snapshot_workdir(self) -> Path:
         return self._get_snapshot_workdir_for_bundle()
-
-    @property
-    def recover_snapshot_workdir(self) -> Path:
-        return self._get_recover_snapshot_workdir_for_bundle()

--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -165,7 +165,12 @@ def _build(
 
 @runtime_cmd.command("remove")
 @click.argument("runtime")
-@click.option("-f", "--force", is_flag=True, help="Force to remove runtime")
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Force to remove runtime, the removed runtime cannot recover",
+)
 def _remove(runtime: str, force: bool) -> None:
     """
     Remove runtime

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -406,13 +406,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         self.tag.remove(tags, quiet)
 
     def remove(self, force: bool = False) -> t.Tuple[bool, str]:
-        _ok, _reason = move_dir(self.store.loc, self.store.recover_loc, force)
-        _ok2, _reason2 = True, ""
-        if self.store.snapshot_workdir.exists():
-            _ok2, _reason2 = move_dir(
-                self.store.snapshot_workdir, self.store.recover_snapshot_workdir, force
-            )
-        return _ok and _ok2, _reason + _reason2
+        return self._do_remove(force)
 
     def recover(self, force: bool = False) -> t.Tuple[bool, str]:
         # TODO: support short version to recover, today only support full-version

--- a/client/starwhale/core/runtime/store.py
+++ b/client/starwhale/core/runtime/store.py
@@ -27,10 +27,6 @@ class RuntimeStorage(BaseStorage):
         return self._get_snapshot_workdir_for_bundle()
 
     @property
-    def recover_snapshot_workdir(self) -> Path:
-        return self._get_recover_snapshot_workdir_for_bundle()
-
-    @property
     def export_dir(self) -> Path:
         return self.snapshot_workdir / "export"
 

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -116,7 +116,7 @@ class StandaloneDatasetTestCase(TestCase):
             f"mnist/version/{build_version}", expected_type=URIType.DATASET
         )
         sd = StandaloneDataset(dataset_uri)
-        _ok, _ = sd.remove(True)
+        _ok, _ = sd.remove(False)
         assert _ok
 
         _list, _ = StandaloneDataset.list(URI(""))
@@ -134,6 +134,10 @@ class StandaloneDatasetTestCase(TestCase):
         DatasetTermView(fname).remove()
         DatasetTermView(fname).recover()
         DatasetTermView.list()
+
+        sd.remove(True)
+        _list, _ = StandaloneDataset.list(URI(""))
+        assert len(_list[name]) == 0
 
         DatasetTermView.build(workdir, "self")
 

--- a/client/tests/core/test_eval.py
+++ b/client/tests/core/test_eval.py
@@ -120,6 +120,17 @@ class StandaloneEvaluationJobTestCase(TestCase):
             / self.job_name
         ).exists()
 
+        job.remove(True)
+        assert not os.path.exists(self.job_dir)
+        assert not (
+            Path(self.root)
+            / "self"
+            / URIType.EVALUATION
+            / RECOVER_DIRNAME
+            / self.job_name[:2]
+            / self.job_name
+        ).exists()
+
     @patch("starwhale.core.eval.model.subprocess.check_output")
     @patch("starwhale.core.eval.model.check_call")
     def test_actions(self, m_call: MagicMock, m_call_output: MagicMock):

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -122,7 +122,7 @@ class StandaloneModelTestCase(TestCase):
 
         model_uri = URI(f"{name}/version/{build_version}", expected_type=URIType.MODEL)
         sd = StandaloneModel(model_uri)
-        _ok, _ = sd.remove(True)
+        _ok, _ = sd.remove(False)
         assert _ok
 
         _list, _ = StandaloneModel.list(URI(""))
@@ -141,6 +141,11 @@ class StandaloneModelTestCase(TestCase):
         ModelTermView(fname).recover()
         ModelTermView.list(show_removed=True)
         ModelTermView.list()
+
+        _ok, _ = sd.remove(True)
+        assert _ok
+        _list, _ = StandaloneModel.list(URI(""))
+        assert len(_list[name]) == 0
 
         ModelTermView.build(workdir, "self")
 

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -416,6 +416,14 @@ class StandaloneRuntimeTestCase(TestCase):
         assert not os.path.exists(recover_snapshot_path)
         assert os.path.exists(swrt_snapshot_path)
 
+        rtv = RuntimeTermView(f"{name}/version/{build_version}")
+        ok, _ = rtv.remove(True)
+        assert ok
+        assert not os.path.exists(recover_path)
+        assert not os.path.exists(swrt_path)
+        assert not os.path.exists(recover_snapshot_path)
+        assert not os.path.exists(swrt_snapshot_path)
+
     @patch("starwhale.utils.venv.get_user_runtime_python_bin")
     @patch("starwhale.utils.venv.is_venv")
     @patch("starwhale.utils.venv.is_conda")


### PR DESCRIPTION
## Description
use `--force` to remove objects directly which cannot recover.

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
