### PR TITLE
ci: set fixed python3.10 version to workaround mypy error

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -89,7 +89,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10"
+          - "3.10.6" # https://github.com/python/mypy/issues/13627
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Description
- https://github.com/python/mypy/issues/13627
- random error: https://github.com/star-whale/starwhale/actions/runs/3111623281/jobs/5044398877
  -  ![image](https://user-images.githubusercontent.com/590748/191948489-2219e06a-6d12-4a4d-9be5-ca478f8cdfd8.png)

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
