### PR TITLE
chore(controller): make host path for pip cache optional

### DIFF
--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -30,7 +30,7 @@ sw:
   infra:
     k8s:
       name-space: ${SW_K8S_NAME_SPACE:default}
-      host-path-for-cache: ${SW_K8S_HOST_PATH_FOR_CACHE:/mnt/data}
+      host-path-for-cache: ${SW_K8S_HOST_PATH_FOR_CACHE:}
       job-template-path: ${SW_K8S_JOB_TEMPLATE_PATH:}
   storage:
     type: ${SW_STORAGE_TYPE:minio}

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
@@ -123,7 +123,7 @@ public class K8sTaskSchedulerTest {
     public static class K8sJobTemplateMock extends K8sJobTemplate {
 
         public K8sJobTemplateMock(String templatePath) throws IOException {
-            super("");
+            super("", "/path");
         }
 
         @Override


### PR DESCRIPTION
## Description
Make host path for pip cache optional
## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
