### PR TITLE
fix(console): change token key in url param

### DIFF
--- a/console/src/components/Header/index.tsx
+++ b/console/src/components/Header/index.tsx
@@ -259,14 +259,14 @@ export default function Header() {
     const ctx = useContext(SidebarContext)
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const { currentUser } = useCurrentUser()
-    const title = !!useSearchParam('token')
+    const cliToken = !!useSearchParam('cli-token')
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const { systemRole } = useUserRoles()
     const [t] = useTranslation()
     const history = useHistory()
     const { token, onLogout } = useAuth()
     const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false)
-    const [isShowTokenOpen, setIsShowTokenOpen] = useState(title)
+    const [isShowTokenOpen, setIsShowTokenOpen] = useState(cliToken)
     const handleChangePassword = useCallback(
         async (data: IChangePasswordSchema) => {
             await changePassword(data)


### PR DESCRIPTION
## Description

`token` may conflict with creating account logic
trigger URL will change to: https://my.foo.bar/?cli-token=true
Relates to #1238

cc @lijing-susan 

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
