### PR TITLE
fix(console): remove tsc from package

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -97,7 +97,6 @@
     "styletron-engine-atomic": "^1.4.8",
     "styletron-react": "^6.0.1",
     "ts-auto-mock": "^3.5.0",
-    "tsc": "^2.0.4",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "typescript": "^4.6.4",
     "uuid": "^8.3.2",

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -1310,6 +1310,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.18.0":
+  version "7.19.0"
+  resolved "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@~7.5.4":
   version "7.5.5"
   resolved "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
@@ -5549,10 +5556,10 @@ async-each@^1.0.1:
   resolved "https://registry.npmmirror.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async-validator@^4.0.2:
-  version "4.0.7"
-  resolved "https://registry.npmmirror.com/async-validator/-/async-validator-4.0.7.tgz#034a0fd2103a6b2ebf010da75183bec299247afe"
-  integrity sha512-Pj2IR7u8hmUEDOwB++su6baaRi+QvsgajuFB9j95foM1N2gy5HM4z60hfusIO0fBPG5uLAEl6yCJr1jNSVugEQ==
+async-validator@^4.1.0:
+  version "4.2.5"
+  resolved "https://registry.npmmirror.com/async-validator/-/async-validator-4.2.5.tgz#c96ea3332a521699d0afaaceed510a54656c6339"
+  integrity sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==
 
 async@2.6.4, async@^3.2.0, async@^3.2.3:
   version "2.6.4"
@@ -15474,13 +15481,13 @@ rc-dialog@~8.7.0:
     rc-motion "^2.3.0"
     rc-util "^5.6.1"
 
-rc-field-form@^1.21.1:
-  version "1.25.2"
-  resolved "https://registry.npmmirror.com/rc-field-form/-/rc-field-form-1.25.2.tgz#de418194b7aca2f1b6e0e059edd97b5cf624f68a"
-  integrity sha512-FXGScWibDlwIlKY15T1YOA7VTtMJwqxxXdDjHB56ZNx7wGbE4vK+Fe2zcymyakGZD0ej8NUP5LGr7qBVWaVpUQ==
+rc-field-form@^1.27.1:
+  version "1.27.2"
+  resolved "https://registry.npmmirror.com/rc-field-form/-/rc-field-form-1.27.2.tgz#5123282cf1561ba34f3197c37b8b9a8b710dd7dd"
+  integrity sha512-NaTjkSB8JsHRgm52wkDorsDzFf2HH6GmCQ2AqkwO8zo+zIqybw8K1lkzDBMDJI8nw1pFuD46U5QsYZv4blYvdw==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    async-validator "^4.0.2"
+    "@babel/runtime" "^7.18.0"
+    async-validator "^4.1.0"
     rc-util "^5.8.0"
 
 rc-image@^5.2.5:
@@ -19742,6 +19749,11 @@ yargs@17.5.1, yargs@^17.0.1, yargs@^17.5.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yarn@^1.22.19:
+  version "1.22.19"
+  resolved "https://registry.npmmirror.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
## Description

Fix CI issue
https://github.com/star-whale/starwhale/actions/runs/3209393519/jobs/5246068593

```
yarn lint
yarn run v1.22.19
$ eslint -c .eslintrc.js './src/**/*.{ts,tsx}'
Done in 31.9[5](https://github.com/star-whale/starwhale/actions/runs/3209393519/jobs/5246068593#step:8:6)s.
yarn typecheck
yarn run v1.22.19
$ tsc --noEmit -p ./tsconfig.json


                This is not the tsc command you are looking for                


To get access to the TypeScript compiler, tsc, from the command line either:

- Use npm install typescript to first add TypeScript to your project before using npx
- Use yarn to avoid accidentally running code from un-installed packages
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [Makefile:[9](https://github.com/star-whale/starwhale/actions/runs/3209393519/jobs/5246068593#step:8:10): ci-lint] Error 1
Error: Process completed with exit code 2.
```

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
