### PR TITLE
chore(client): use sys.ver when python version not specified in runtime.yaml

### DIFF
--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -42,7 +42,6 @@ from starwhale.consts import (
     SW_DEV_DUMMY_VERSION,
     DEFAULT_CONDA_CHANNEL,
     DEFAULT_MANIFEST_NAME,
-    DEFAULT_PYTHON_VERSION,
 )
 from starwhale.version import STARWHALE_VERSION
 from starwhale.base.tag import StandaloneTag
@@ -114,7 +113,7 @@ class Environment(ASDictMixin):
         self,
         arch: _t_mixed_str_list = "",
         os: str = SupportOS.UBUNTU,
-        python: str = DEFAULT_PYTHON_VERSION,
+        python: str = "",
         cuda: str = "",
         cudnn: str = "",
         **kw: t.Any,
@@ -122,7 +121,8 @@ class Environment(ASDictMixin):
         self.arch = _list(arch)
         self.os = os.lower()
 
-        # TODO: use user's swcli python version as the python argument version
+        if not python:
+            python = get_python_version()
         self.python = trunc_python_version(str(python))
         self.cuda = str(cuda).strip()
         self.cudnn = str(cudnn).strip()

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -21,7 +21,6 @@ from starwhale.consts import (
     SW_DEV_DUMMY_VERSION,
     WHEEL_FILE_EXTENSION,
     DEFAULT_CONDA_CHANNEL,
-    DEFAULT_PYTHON_VERSION,
 )
 from starwhale.version import STARWHALE_VERSION
 from starwhale.utils.fs import empty_dir, ensure_dir, ensure_file
@@ -593,7 +592,7 @@ def create_python_env(
     mode: str,
     name: str,
     workdir: Path,
-    python_version: str = DEFAULT_PYTHON_VERSION,
+    python_version: str,
     force: bool = False,
 ) -> str:
     if mode == PythonRunEnv.VENV:

--- a/example/runtime/pytorch/runtime.yaml
+++ b/example/runtime/pytorch/runtime.yaml
@@ -35,6 +35,5 @@ environment:
   arch: noarch
   os: ubuntu:20.04
   cuda: 11.4
-  python: 3.8
 mode: venv
 name: pytorch


### PR DESCRIPTION
## Description
* Use current python version (swcli) when python version not specified in runtime.yaml 
* Remove python version in pytorch runtime.yaml in example

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
