### PR TITLE
fix(controller): fix job status is unknown occasionally

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/JobController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/JobController.java
@@ -142,7 +142,7 @@ public class JobController implements JobApi {
 
     @Override
     public ResponseEntity<ResponseMessage<Graph>> getJobDag(String projectUrl, String jobUrl) {
-        return ResponseEntity.ok(Code.success.asResponse(dagQuerier.dagOfJob(jobUrl, true)));
+        return ResponseEntity.ok(Code.success.asResponse(dagQuerier.dagOfJob(jobUrl)));
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/HotJobsLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/HotJobsLoader.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.domain.job.cache;
 
+import ai.starwhale.mlops.domain.job.converter.JobBoConverter;
 import ai.starwhale.mlops.domain.job.mapper.JobMapper;
 import ai.starwhale.mlops.domain.job.po.JobEntity;
 import ai.starwhale.mlops.domain.job.status.JobStatus;
@@ -43,13 +44,16 @@ public class HotJobsLoader implements CommandLineRunner {
 
     final JobStatusMachine jobStatusMachine;
 
+    final JobBoConverter jobBoConverter;
+
     public HotJobsLoader(
             JobMapper jobMapper,
             JobLoader jobLoader,
-            JobStatusMachine jobStatusMachine) {
+            JobStatusMachine jobStatusMachine, JobBoConverter jobBoConverter) {
         this.jobMapper = jobMapper;
         this.jobLoader = jobLoader;
         this.jobStatusMachine = jobStatusMachine;
+        this.jobBoConverter = jobBoConverter;
     }
 
 
@@ -69,7 +73,9 @@ public class HotJobsLoader implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        jobLoader.loadEntities(hotJobsFromDb(), false, true);
+        hotJobsFromDb().forEach(jobEntity -> {
+            jobLoader.load(jobBoConverter.fromEntity(jobEntity), false);
+        });
         log.info("hot jobs loaded");
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
@@ -17,143 +17,53 @@
 package ai.starwhale.mlops.domain.job.cache;
 
 import ai.starwhale.mlops.domain.job.bo.Job;
-import ai.starwhale.mlops.domain.job.converter.JobBoConverter;
-import ai.starwhale.mlops.domain.job.po.JobEntity;
-import ai.starwhale.mlops.domain.job.status.JobUpdateHelper;
-import ai.starwhale.mlops.domain.job.step.StepConverter;
-import ai.starwhale.mlops.domain.job.step.StepHelper;
-import ai.starwhale.mlops.domain.job.step.bo.Step;
-import ai.starwhale.mlops.domain.job.step.mapper.StepMapper;
-import ai.starwhale.mlops.domain.job.step.po.StepEntity;
-import ai.starwhale.mlops.domain.job.step.status.StepStatus;
-import ai.starwhale.mlops.domain.job.step.trigger.StepTrigger;
 import ai.starwhale.mlops.domain.task.bo.Task;
-import ai.starwhale.mlops.domain.task.converter.TaskBoConverter;
-import ai.starwhale.mlops.domain.task.mapper.TaskMapper;
-import ai.starwhale.mlops.domain.task.po.TaskEntity;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
 import ai.starwhale.mlops.domain.task.status.WatchableTaskFactory;
-import ai.starwhale.mlops.exception.SwProcessException;
-import ai.starwhale.mlops.exception.SwProcessException.ErrorType;
 import ai.starwhale.mlops.schedule.SwTaskScheduler;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 /**
- * load job to JobHolder
+ * load job to JobHolder as active state
  */
 @Slf4j
 @Service
 public class JobLoader {
 
-    final SwTaskScheduler swTaskScheduler;
-
-    final TaskMapper taskMapper;
-
-    final TaskBoConverter taskBoConverter;
-
-    final JobBoConverter jobBoConverter;
-
     final HotJobHolder jobHolder;
-
-    final StepMapper stepMapper;
-
-    final StepConverter stepConverter;
 
     final WatchableTaskFactory watchableTaskFactory;
 
-    final StepTrigger stepTrigger;
+    final SwTaskScheduler swTaskScheduler;
 
-    final StepHelper stepHelper;
-
-    final JobUpdateHelper jobUpdateHelper;
-
-    public JobLoader(SwTaskScheduler swTaskScheduler,
-            TaskMapper taskMapper, TaskBoConverter taskBoConverter,
-            JobBoConverter jobBoConverter, HotJobHolder jobHolder,
-            StepMapper stepMapper, StepConverter stepConverter,
-            WatchableTaskFactory watchableTaskFactory,
-            StepTrigger stepTrigger, StepHelper stepHelper,
-            JobUpdateHelper jobUpdateHelper) {
-        this.swTaskScheduler = swTaskScheduler;
-        this.taskMapper = taskMapper;
-        this.taskBoConverter = taskBoConverter;
-        this.jobBoConverter = jobBoConverter;
+    public JobLoader(HotJobHolder jobHolder, WatchableTaskFactory watchableTaskFactory,
+            SwTaskScheduler swTaskScheduler) {
         this.jobHolder = jobHolder;
-        this.stepMapper = stepMapper;
-        this.stepConverter = stepConverter;
         this.watchableTaskFactory = watchableTaskFactory;
-        this.stepTrigger = stepTrigger;
-        this.stepHelper = stepHelper;
-        this.jobUpdateHelper = jobUpdateHelper;
+        this.swTaskScheduler = swTaskScheduler;
     }
 
-    public List<Job> loadEntities(List<JobEntity> jobEntityList, Boolean resumePausedOrFailTasks, Boolean doCache) {
-        if (CollectionUtils.isEmpty(jobEntityList)) {
-            return new ArrayList<>(0);
-        }
-        if (resumePausedOrFailTasks && !doCache) {
-            throw new SwProcessException(ErrorType.SYSTEM).tip(
-                    "unsupported params combination: resumePausedOrFailTasks:true & doCache:false");
-        }
-        return jobEntityList.parallelStream()
-                .map(jobBoConverter::fromEntity)
-                .peek(job -> {
-                    fillStepsAndTasks(job, resumePausedOrFailTasks, doCache);
-                    if (doCache) {
-                        jobHolder.adopt(job);
-                    }
-                })
-                .collect(Collectors.toList());
+    public Job load(@NotNull Job job, Boolean resumePausedOrFailTasks) {
+        job.getSteps().forEach(step -> {
+            List<Task> tasks = step.getTasks();
+            if (resumePausedOrFailTasks) {
+                resumeFrozenTasks(tasks);
+            }
+            List<Task> watchableTasks = watchableTaskFactory.wrapTasks(tasks);
+            step.setTasks(watchableTasks);
+            scheduleReadyTasks(watchableTasks.parallelStream()
+                    .filter(t -> t.getStatus() == TaskStatus.READY)
+                    .collect(Collectors.toSet()));
+        });
+        jobHolder.adopt(job);
+        return job;
 
-    }
-
-    private void fillStepsAndTasks(Job job, Boolean resumePausedOrFailTasks, Boolean doCache) {
-        List<StepEntity> stepEntities = stepMapper.findByJobId(job.getId());
-        List<Step> steps = stepEntities.parallelStream().map(stepConverter::fromEntity)
-                .peek(step -> {
-                    log.debug("start");
-                    step.setJob(job);
-                    List<TaskEntity> taskEntities = taskMapper.findByStepId(step.getId());
-                    List<Task> tasks = taskBoConverter.fromTaskEntity(taskEntities, step); // PAUSED, FAIL
-                    if (resumePausedOrFailTasks) {
-                        resumeFrozenTasks(tasks);
-                    }
-                    log.debug("start cache");
-                    if (doCache) {
-                        List<Task> watchableTasks = watchableTaskFactory.wrapTasks(tasks);
-                        scheduleReadyTasks(watchableTasks.parallelStream()
-                                .filter(t -> t.getStatus() == TaskStatus.READY)
-                                .collect(
-                                        Collectors.toSet()));
-                        step.setTasks(watchableTasks);
-                    } else {
-                        step.setTasks(tasks);
-                    }
-
-                    log.debug("start set status");
-                    step.setStatus(stepHelper.desiredStepStatus(tasks.parallelStream().map(Task::getStatus).collect(
-                            Collectors.toSet())));
-                    if (step.getStatus() == StepStatus.RUNNING) {
-                        if (job.getCurrentStep() != null) {
-                            log.error("FATAL!!!!! A job has two running steps job id: {}", job.getId());
-                        }
-                        job.setCurrentStep(step);
-                    }
-                }).collect(Collectors.toList());
-        linkSteps(steps, stepEntities);
-        job.setSteps(steps);
-        if (null == job.getCurrentStep() && doCache) {
-            triggerPossibleNextStep(job);
-        }
-        jobUpdateHelper.updateJob(job);
     }
 
     private void resumeFrozenTasks(List<Task> tasks) {
@@ -161,21 +71,6 @@ public class JobLoader {
                         || t.getStatus() == TaskStatus.FAIL
                         || t.getStatus() == TaskStatus.CANCELED)
                 .forEach(t -> t.updateStatus(TaskStatus.READY));
-    }
-
-    private void linkSteps(List<Step> steps, List<StepEntity> stepEntities) {
-        Map<Long, Step> stepMap = steps.parallelStream()
-                .collect(Collectors.toMap(Step::getId, Function.identity()));
-        Map<Long, Long> linkMap = stepEntities.parallelStream()
-                .filter(stepEntity -> null != stepEntity.getLastStepId())
-                .collect(Collectors.toMap(StepEntity::getLastStepId, StepEntity::getId));
-        steps.forEach(step -> {
-            Long nextStepId = linkMap.get(step.getId());
-            if (null == nextStepId) {
-                return;
-            }
-            step.setNextStep(stepMap.get(nextStepId));
-        });
     }
 
     /**
@@ -186,28 +81,6 @@ public class JobLoader {
             return;
         }
         swTaskScheduler.schedule(tasks);
-    }
-
-    private void triggerPossibleNextStep(Job job) {
-        log.warn("a job shall has a current step after fill steps job id: {} trying to trigger one", job.getId());
-        Step stepPointer = stepHelper.firsStep(job.getSteps());
-        do {
-            if (stepPointer.getStatus() == StepStatus.SUCCESS) {
-                Step nextStep = stepPointer.getNextStep();
-                if (null == nextStep) {
-                    break;
-                }
-                if (nextStep.getStatus() == StepStatus.CREATED) {
-                    stepTrigger.triggerNextStep(stepPointer);
-                    break;
-                }
-            } else {
-                log.warn("step is not success and is not job current status {} id:{}", stepPointer.getStatus(),
-                        stepPointer.getId());
-            }
-            stepPointer = stepPointer.getNextStep();
-
-        } while (null != stepPointer);
     }
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/split/JobSpliterator.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/split/JobSpliterator.java
@@ -16,7 +16,7 @@
 
 package ai.starwhale.mlops.domain.job.split;
 
-import ai.starwhale.mlops.domain.job.bo.Job;
+import ai.starwhale.mlops.domain.job.po.JobEntity;
 import ai.starwhale.mlops.domain.job.step.po.StepEntity;
 import java.util.List;
 
@@ -25,5 +25,5 @@ import java.util.List;
  */
 public interface JobSpliterator {
 
-    List<StepEntity> split(Job job);
+    List<StepEntity> split(JobEntity job);
 }

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -84,3 +84,4 @@ logging:
   level:
     root: info
     ai.starwhale.mlops: debug
+    org.springframework.transaction.interceptor: TRACE

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -84,4 +84,3 @@ logging:
   level:
     root: info
     ai.starwhale.mlops: debug
-    org.springframework.transaction.interceptor: TRACE

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
@@ -16,7 +16,6 @@
 
 package ai.starwhale.mlops.domain.job;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -24,39 +23,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.starwhale.mlops.JobMockHolder;
-import ai.starwhale.mlops.ObjectMockHolder;
 import ai.starwhale.mlops.domain.job.bo.Job;
 import ai.starwhale.mlops.domain.job.cache.HotJobHolder;
 import ai.starwhale.mlops.domain.job.cache.JobLoader;
-import ai.starwhale.mlops.domain.job.converter.JobBoConverter;
-import ai.starwhale.mlops.domain.job.mapper.JobMapper;
-import ai.starwhale.mlops.domain.job.po.JobEntity;
-import ai.starwhale.mlops.domain.job.status.JobStatus;
-import ai.starwhale.mlops.domain.job.status.JobUpdateHelper;
-import ai.starwhale.mlops.domain.job.step.StepConverter;
-import ai.starwhale.mlops.domain.job.step.StepHelper;
-import ai.starwhale.mlops.domain.job.step.bo.Step;
-import ai.starwhale.mlops.domain.job.step.mapper.StepMapper;
-import ai.starwhale.mlops.domain.job.step.po.StepEntity;
-import ai.starwhale.mlops.domain.job.step.status.StepStatus;
-import ai.starwhale.mlops.domain.job.step.trigger.StepTrigger;
-import ai.starwhale.mlops.domain.node.Device.Clazz;
 import ai.starwhale.mlops.domain.task.bo.Task;
-import ai.starwhale.mlops.domain.task.converter.TaskBoConverter;
-import ai.starwhale.mlops.domain.task.mapper.TaskMapper;
-import ai.starwhale.mlops.domain.task.po.TaskEntity;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
-import ai.starwhale.mlops.domain.task.status.TaskStatusMachine;
-import ai.starwhale.mlops.domain.task.status.WatchableTask;
 import ai.starwhale.mlops.domain.task.status.WatchableTaskFactory;
-import ai.starwhale.mlops.exception.SwProcessException;
 import ai.starwhale.mlops.schedule.SwTaskScheduler;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -64,298 +40,47 @@ import org.junit.jupiter.api.Test;
  */
 public class JobLoaderTest {
 
+    Job mockJob;
+
+    HotJobHolder jobHolder;
+
+    WatchableTaskFactory watchableTaskFactory;
+
+    JobLoader jobLoader;
+
+    SwTaskScheduler swTaskScheduler;
+
+    @BeforeEach
+    public void setUp() {
+        mockJob = new JobMockHolder().mockJob();
+        jobHolder = mock(HotJobHolder.class);
+        watchableTaskFactory = mock(WatchableTaskFactory.class);
+        swTaskScheduler = mock(SwTaskScheduler.class);
+        jobLoader = new JobLoader(jobHolder, watchableTaskFactory, swTaskScheduler);
+    }
+
 
     @Test
-    public void testJobLoaderCacheOnly() {
-
-        JobMapper jobMapper = mock(JobMapper.class);
-        JobEntity jobEntity = JobEntity.builder().id(1L).jobStatus(JobStatus.RUNNING).build();
-        when(jobMapper.findJobById(1L)).thenReturn(
-                jobEntity);
-        StepMapper stepMapper = mock(StepMapper.class);
-        when(stepMapper.findByJobId(1L)).thenReturn(List.of(
-                        StepEntity.builder().id(1L).status(StepStatus.RUNNING).name("PPL").build(),
-                        StepEntity.builder().id(2L).lastStepId(1L).status(StepStatus.CREATED).name("CMP")
-                                .build()
-                )
-        );
-        TaskMapper taskMapper = mock(TaskMapper.class);
-        when(taskMapper.findByStepId(1L)).thenReturn(List.of(
-                TaskEntity.builder().id(1L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(TASK_REQUEST)
-                        .taskStatus(TaskStatus.RUNNING)
-                        .build(),
-                TaskEntity.builder().id(2L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(TASK_REQUEST)
-                        .taskStatus(TaskStatus.RUNNING)
-                        .build()
-        ));
-
-        when(taskMapper.findByStepId(2L)).thenReturn(List.of(
-                TaskEntity.builder()
-                        .id(3L)
-                        .taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(
-                                "{\"project\":\"starwhale\",\"index\":0,\"datasetUris\":"
-                                        + "[\"mnist/version/myztqzrtgm3tinrtmftdgyjzob2ggni\"],"
-                                        + "\"jobId\":\"3d32264ce5054fa69190167e15d6303d\","
-                                        + "\"total\":1,\"stepName\":\"cmp\"}")
-                        .taskStatus(TaskStatus.CREATED)
-                        .build()
-        ));
-
-        Job mockJob = new JobMockHolder().mockJob();
-        mockJob.setSteps(null);
-        mockJob.setCurrentStep(null);
-        SwTaskScheduler swTaskScheduler = mock(SwTaskScheduler.class);
-        TaskBoConverter taskBoConverter = ObjectMockHolder.taskBoConverter();
-        JobBoConverter jobBoConverter = mock(JobBoConverter.class);
-        when(jobBoConverter.fromEntity(any(JobEntity.class))).thenReturn(mockJob);
-        HotJobHolder jobHolder = mock(HotJobHolder.class);
-        StepConverter stepConverter = new StepConverter();
-        WatchableTaskFactory watchableTaskFactory = mock(WatchableTaskFactory.class);
-        StepTrigger stepTriggerContext = mock(StepTrigger.class);
-        JobUpdateHelper jobUpdateHelper = mock(JobUpdateHelper.class);
-
-        JobLoader jobLoader = new JobLoader(swTaskScheduler, taskMapper,
-                taskBoConverter, jobBoConverter, jobHolder, stepMapper, stepConverter,
-                watchableTaskFactory, stepTriggerContext, new StepHelper(), jobUpdateHelper);
-
-        List<Job> jobs = jobLoader.loadEntities(List.of(jobEntity), false, true);
-        Assertions.assertEquals(1, jobs.size());
-        Job loadedJob = jobs.get(0);
-        Assertions.assertEquals(2, loadedJob.getSteps().size());
-        Assertions.assertNotNull(loadedJob.getCurrentStep());
-        Assertions.assertNotNull(loadedJob.getCurrentStep().getNextStep());
-
+    public void testJobLoader() {
+        Task failedTask = mock(Task.class);
+        when(failedTask.getStatus()).thenReturn(TaskStatus.FAIL);
+        Task readyTask = mock(Task.class);
+        when(readyTask.getStatus()).thenReturn(TaskStatus.READY);
+        when(watchableTaskFactory.wrapTasks(anyCollection())).thenReturn(List.of(failedTask, readyTask));
+        jobLoader.load(mockJob, false);
         verify(jobHolder, times(1)).adopt(mockJob);
-        verify(swTaskScheduler, times(0)).schedule(anyCollection());
-        verify(watchableTaskFactory, times(2)).wrapTasks(anyCollection());
-        loadedJob.getSteps().parallelStream().map(Step::getTasks).flatMap(Collection::stream)
-                .forEach(t -> {
-                    Assertions.assertTrue(t instanceof WatchableTask);
-                });
-
+        verify(watchableTaskFactory, times(mockJob.getSteps().size())).wrapTasks(anyCollection());
+        verify(swTaskScheduler, times(mockJob.getSteps().size())).schedule(Set.of(readyTask));
+        verify(failedTask, times(0)).updateStatus(TaskStatus.READY);
     }
 
     @Test
     public void testJobLoaderResume() {
-
-        JobMapper jobMapper = mock(JobMapper.class);
-        JobEntity jobEntity = JobEntity.builder().id(1L).jobStatus(JobStatus.RUNNING).build();
-        when(jobMapper.findJobById(1L)).thenReturn(
-                jobEntity);
-        StepMapper stepMapper = mock(StepMapper.class);
-        when(stepMapper.findByJobId(1L)).thenReturn(List.of(
-                        StepEntity.builder().id(1L).status(StepStatus.FAIL).name("PPL").build(),
-                        StepEntity.builder().id(2L).lastStepId(1L).status(StepStatus.CREATED).name("CMP")
-                                .build()
-                )
-        );
-        TaskMapper taskMapper = mock(TaskMapper.class);
-
-        when(taskMapper.findByStepId(1L)).thenReturn(List.of(
-                TaskEntity.builder().id(1L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(TASK_REQUEST)
-                        .taskStatus(TaskStatus.ASSIGNING)
-                        .build(),
-                TaskEntity.builder().id(2L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(TASK_REQUEST)
-                        .taskStatus(TaskStatus.FAIL)
-                        .build()
-        ));
-
-        when(taskMapper.findByStepId(2L)).thenReturn(List.of(
-                TaskEntity.builder().id(3L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(
-                                "{\"project\":\"starwhale\",\"index\":0,\"datasetUris\":"
-                                        + "[\"mnist/version/myztqzrtgm3tinrtmftdgyjzob2ggni\"],"
-                                        + "\"jobId\":\"3d32264ce5054fa69190167e15d6303d\","
-                                        + "\"total\":1,\"stepName\":\"cmp\"}")
-                        .taskStatus(TaskStatus.CREATED)
-                        .build()
-        ));
-
-        Job mockJob = new JobMockHolder().mockJob();
-        mockJob.setSteps(null);
-        mockJob.setCurrentStep(null);
-        mockJob.setStatus(JobStatus.FAIL);
-        SwTaskScheduler swTaskScheduler = mock(SwTaskScheduler.class);
-        TaskBoConverter taskBoConverter = ObjectMockHolder.taskBoConverter();
-        JobBoConverter jobBoConverter = mock(JobBoConverter.class);
-        when(jobBoConverter.fromEntity(any(JobEntity.class))).thenReturn(mockJob);
-        HotJobHolder jobHolder = mock(HotJobHolder.class);
-        StepConverter stepConverter = new StepConverter();
-        WatchableTaskFactory watchableTaskFactory = new WatchableTaskFactory(List.of(),
-                new TaskStatusMachine());
-        StepTrigger stepTriggerContext = mock(StepTrigger.class);
-        JobUpdateHelper jobUpdateHelper = mock(JobUpdateHelper.class);
-
-        JobLoader jobLoader = new JobLoader(swTaskScheduler, taskMapper,
-                taskBoConverter, jobBoConverter, jobHolder, stepMapper, stepConverter,
-                watchableTaskFactory, stepTriggerContext, new StepHelper(), jobUpdateHelper);
-
-        List<Job> jobs = jobLoader.loadEntities(List.of(jobEntity), true, true);
-        Assertions.assertEquals(1, jobs.size());
-        Job loadedJob = jobs.get(0);
-        Assertions.assertEquals(2, loadedJob.getSteps().size());
-        Assertions.assertNotNull(loadedJob.getCurrentStep());
-        Assertions.assertEquals(StepStatus.RUNNING, loadedJob.getCurrentStep().getStatus());
-        Assertions.assertNotNull(loadedJob.getCurrentStep().getNextStep());
-
-        verify(jobUpdateHelper).updateJob(mockJob);
+        Task mockTask = mock(Task.class);
+        when(mockTask.getStatus()).thenReturn(TaskStatus.FAIL);
+        mockJob.getSteps().get(0).getTasks().add(mockTask);
+        jobLoader.load(mockJob, true);
+        verify(mockTask).updateStatus(TaskStatus.READY);
         verify(jobHolder, times(1)).adopt(mockJob);
-        verify(swTaskScheduler, times(1)).schedule(anyCollection());
-        Set<Task> tasks = loadedJob.getSteps().parallelStream().map(Step::getTasks)
-                .flatMap(Collection::stream).collect(
-                        Collectors.toSet());
-        Assertions.assertEquals(3, tasks.size());
-        tasks.forEach(t -> {
-            Assertions.assertTrue(t instanceof WatchableTask);
-        });
-
-
     }
-
-
-    @Test
-    public void testJobLoaderNoCache() {
-
-        JobMapper jobMapper = mock(JobMapper.class);
-        JobEntity jobEntity = JobEntity.builder().id(1L).jobStatus(JobStatus.RUNNING).build();
-        when(jobMapper.findJobById(1L)).thenReturn(
-                jobEntity);
-        StepMapper stepMapper = mock(StepMapper.class);
-        when(stepMapper.findByJobId(1L)).thenReturn(List.of(
-                        StepEntity.builder().id(1L).status(StepStatus.FAIL).name("PPL").build(),
-                        StepEntity.builder().id(2L).lastStepId(1L).status(StepStatus.CREATED).name("CMP")
-                                .build()
-                )
-        );
-        TaskMapper taskMapper = mock(TaskMapper.class);
-
-        when(taskMapper.findByStepId(1L)).thenReturn(List.of(
-                TaskEntity.builder().id(1L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(TASK_REQUEST)
-                        .taskStatus(TaskStatus.ASSIGNING)
-                        .build(),
-                TaskEntity.builder().id(2L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(TASK_REQUEST)
-                        .taskStatus(TaskStatus.FAIL)
-                        .build()
-        ));
-
-        when(taskMapper.findByStepId(2L)).thenReturn(List.of(
-                TaskEntity.builder().id(3L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(
-                                "{\"project\":\"starwhale\",\"index\":0,\"datasetUris\":"
-                                        + "[\"mnist/version/myztqzrtgm3tinrtmftdgyjzob2ggni\"],"
-                                        + "\"jobId\":\"3d32264ce5054fa69190167e15d6303d\","
-                                        + "\"total\":1,\"stepName\":\"cmp\"}")
-                        .taskStatus(TaskStatus.CREATED)
-                        .build()
-        ));
-
-        Job mockJob = new JobMockHolder().mockJob();
-        mockJob.setSteps(null);
-        mockJob.setCurrentStep(null);
-        mockJob.setStatus(JobStatus.FAIL);
-        SwTaskScheduler swTaskScheduler = mock(SwTaskScheduler.class);
-        TaskBoConverter taskBoConverter = ObjectMockHolder.taskBoConverter();
-        JobBoConverter jobBoConverter = mock(JobBoConverter.class);
-        when(jobBoConverter.fromEntity(any(JobEntity.class))).thenReturn(mockJob);
-        HotJobHolder jobHolder = mock(HotJobHolder.class);
-        StepConverter stepConverter = new StepConverter();
-        WatchableTaskFactory watchableTaskFactory = new WatchableTaskFactory(List.of(),
-                new TaskStatusMachine());
-        StepTrigger stepTriggerContext = mock(StepTrigger.class);
-        JobUpdateHelper jobUpdateHelper = mock(JobUpdateHelper.class);
-
-        JobLoader jobLoader = new JobLoader(swTaskScheduler, taskMapper,
-                taskBoConverter, jobBoConverter, jobHolder, stepMapper, stepConverter,
-                watchableTaskFactory, stepTriggerContext, new StepHelper(), jobUpdateHelper);
-
-        List<Job> jobs = jobLoader.loadEntities(List.of(jobEntity), false, false);
-        Assertions.assertEquals(1, jobs.size());
-        Job loadedJob = jobs.get(0);
-        Assertions.assertEquals(2, loadedJob.getSteps().size());
-        Assertions.assertNull(loadedJob.getCurrentStep());
-
-        verify(jobUpdateHelper).updateJob(mockJob);
-        verify(jobHolder, times(0)).adopt(mockJob);
-        verify(swTaskScheduler, times(0)).schedule(anyCollection());
-        Set<Task> tasks = loadedJob.getSteps().parallelStream().map(Step::getTasks)
-                .flatMap(Collection::stream).collect(
-                        Collectors.toSet());
-        Assertions.assertEquals(3, tasks.size());
-        tasks.forEach(t -> {
-            Assertions.assertTrue(!(t instanceof WatchableTask));
-        });
-    }
-
-    @Test
-    public void testException() {
-        JobMapper jobMapper = mock(JobMapper.class);
-        JobEntity jobEntity = JobEntity.builder().id(1L).jobStatus(JobStatus.RUNNING).build();
-        when(jobMapper.findJobById(1L)).thenReturn(
-                jobEntity);
-        StepMapper stepMapper = mock(StepMapper.class);
-        when(stepMapper.findByJobId(1L)).thenReturn(List.of(
-                        StepEntity.builder().id(1L).status(StepStatus.FAIL).name("PPL").build(),
-                        StepEntity.builder().id(2L).lastStepId(1L).status(StepStatus.CREATED).name("CMP")
-                                .build()
-                )
-        );
-        TaskMapper taskMapper = mock(TaskMapper.class);
-
-        when(taskMapper.findByStepId(1L)).thenReturn(List.of(
-                TaskEntity.builder().id(1L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(TASK_REQUEST)
-                        .taskStatus(TaskStatus.ASSIGNING)
-                        .build(),
-                TaskEntity.builder().id(2L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(TASK_REQUEST)
-                        .taskStatus(TaskStatus.FAIL)
-                        .build()
-        ));
-
-        when(taskMapper.findByStepId(2L)).thenReturn(List.of(
-                TaskEntity.builder().id(3L).taskUuid(UUID.randomUUID().toString())
-                        .taskRequest(
-                                "{\"project\":\"starwhale\",\"index\":0,\"datasetUris\":"
-                                        + "[\"mnist/version/myztqzrtgm3tinrtmftdgyjzob2ggni\"],"
-                                        + "\"jobId\":\"3d32264ce5054fa69190167e15d6303d\","
-                                        + "\"total\":1,\"stepName\":\"cmp\"}")
-                        .taskStatus(TaskStatus.CREATED)
-                        .build()
-        ));
-
-        Job mockJob = new JobMockHolder().mockJob();
-        mockJob.setSteps(null);
-        mockJob.setCurrentStep(null);
-        mockJob.setStatus(JobStatus.FAIL);
-        SwTaskScheduler swTaskScheduler = mock(SwTaskScheduler.class);
-        TaskBoConverter taskBoConverter = ObjectMockHolder.taskBoConverter();
-        JobBoConverter jobBoConverter = mock(JobBoConverter.class);
-        when(jobBoConverter.fromEntity(any(JobEntity.class))).thenReturn(mockJob);
-        HotJobHolder jobHolder = mock(HotJobHolder.class);
-        StepConverter stepConverter = new StepConverter();
-        WatchableTaskFactory watchableTaskFactory = new WatchableTaskFactory(List.of(),
-                new TaskStatusMachine());
-        StepTrigger stepTriggerContext = mock(StepTrigger.class);
-        JobUpdateHelper jobUpdateHelper = mock(JobUpdateHelper.class);
-
-        JobLoader jobLoader = new JobLoader(swTaskScheduler, taskMapper,
-                taskBoConverter, jobBoConverter, jobHolder, stepMapper, stepConverter,
-                watchableTaskFactory, stepTriggerContext, new StepHelper(), jobUpdateHelper);
-
-        Assertions.assertThrowsExactly(SwProcessException.class, () -> {
-            jobLoader.loadEntities(List.of(jobEntity), true, false);
-        });
-
-    }
-
-    static final String TASK_REQUEST = "{\"project\":\"starwhale\",\"index\":0,\"datasetUris\":"
-            + "[\"mnist/version/myztqzrtgm3tinrtmftdgyjzob2ggni\"],\"jobId\":\"3d32264ce5054fa69190167e15d6303d\","
-            + "\"total\":1,\"stepName\":\"ppl\"}";
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobSpliteratorEvaluationTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobSpliteratorEvaluationTest.java
@@ -21,9 +21,11 @@ import static org.mockito.Mockito.mock;
 import ai.starwhale.mlops.JobMockHolder;
 import ai.starwhale.mlops.domain.job.bo.Job;
 import ai.starwhale.mlops.domain.job.mapper.JobMapper;
+import ai.starwhale.mlops.domain.job.po.JobEntity;
 import ai.starwhale.mlops.domain.job.spec.JobSpecParser;
 import ai.starwhale.mlops.domain.job.spec.StepSpec;
 import ai.starwhale.mlops.domain.job.split.JobSpliteratorEvaluation;
+import ai.starwhale.mlops.domain.job.status.JobStatus;
 import ai.starwhale.mlops.domain.job.step.mapper.StepMapper;
 import ai.starwhale.mlops.domain.storage.StoragePathCoordinator;
 import ai.starwhale.mlops.domain.task.mapper.TaskMapper;
@@ -41,9 +43,7 @@ import org.junit.jupiter.api.Test;
 public class JobSpliteratorEvaluationTest {
 
     @Test
-    public void testJobSpliteratorEvaluation() throws IOException {
-
-
+    public void testJobSpliteratorEvaluation() {
         JobMockHolder jobMockHolder = new JobMockHolder();
         Job mockJob = jobMockHolder.mockJob();
         mockJob.setCurrentStep(null);
@@ -59,10 +59,16 @@ public class JobSpliteratorEvaluationTest {
         StepMapper stepMapper = mock(StepMapper.class);
         JobSpliteratorEvaluation jobSpliteratorEvaluation = new JobSpliteratorEvaluation(
                 new StoragePathCoordinator("/test"), taskMapper, jobMapper, stepMapper,
-                new JobSpecParser(new YAMLMapper()));
-        jobSpliteratorEvaluation.split(mockJob);
-        mockJob.setStepSpec("xxx");
-        Assertions.assertThrows(SwValidationException.class, () -> jobSpliteratorEvaluation.split(mockJob));
+                mock(JobSpecParser.class));
+        JobEntity build = JobEntity.builder()
+                .id(1L)
+                .jobUuid("uuid")
+                .jobStatus(JobStatus.CREATED)
+                .stepSpec("xxx")
+                .build();
+        jobSpliteratorEvaluation.split(build);
+        build.setJobStatus(JobStatus.RUNNING);
+        Assertions.assertThrows(SwValidationException.class, () -> jobSpliteratorEvaluation.split(build));
 
     }
 }


### PR DESCRIPTION
## Description
#### BUG:
 job status become unknown when it's DAG is queried before job is split
#### Resolve:
  - decouple job status update from `JobLoader`
  - move step link opt from `JobLoader` to `JobBoConverter`

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
