### PR TITLE
fix(client): unit test works with macos

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -90,8 +90,8 @@ jobs:
           - "3.9"
           - "3.10.6" # https://github.com/python/mypy/issues/13627
         os:
-          - ubuntu-latest
           - macos-latest
+          - ubuntu-latest
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -82,7 +82,6 @@ jobs:
         run: make ci-isort
 
   unittest:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
@@ -90,6 +89,10 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10.6" # https://github.com/python/mypy/issues/13627
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -1,5 +1,6 @@
 import os
 import typing as t
+import tempfile
 from pathlib import Path
 from unittest.mock import call, patch, MagicMock
 
@@ -737,7 +738,7 @@ class StandaloneRuntimeTestCase(TestCase):
                     "--require-virtualenv",
                     "--exclude-editable",
                     ">>",
-                    "/tmp/starwhale-lock-",
+                    f"{tempfile.gettempdir()}/starwhale-lock-",
                 ]
             )
         )
@@ -758,7 +759,7 @@ class StandaloneRuntimeTestCase(TestCase):
                     "--require-virtualenv",
                     "--exclude-editable",
                     ">>",
-                    "/tmp/starwhale-lock-",
+                    f"{tempfile.gettempdir()}/starwhale-lock-",
                 ]
             )
         )

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -126,7 +126,7 @@ class TestDatasetBuildExecutor(BaseTestCase):
 
         data_path = (
             Path(self.object_store_dir) / self.data_file_sign[:2] / self.data_file_sign
-        )
+        ).resolve()
 
         assert link_path.resolve() == data_path
         assert data_path.exists()
@@ -168,7 +168,7 @@ class TestDatasetBuildExecutor(BaseTestCase):
         assert len(data_files_sign) == 10
 
         for _sign in data_files_sign:
-            _sign_fpath = Path(self.object_store_dir) / _sign[:2] / _sign
+            _sign_fpath = (Path(self.object_store_dir) / _sign[:2] / _sign).resolve()
             assert _sign_fpath.exists()
             assert _sign == blake2b_file(_sign_fpath)
             assert (
@@ -221,7 +221,7 @@ class TestDatasetBuildExecutor(BaseTestCase):
             summary = e.make_swds()
 
         assert link_data_path.resolve() != dummy_path
-        assert link_data_path.resolve() == src_data_path
+        assert link_data_path.resolve() == src_data_path.resolve()
 
 
 class TestDatasetType(TestCase):

--- a/scripts/run_demo.sh
+++ b/scripts/run_demo.sh
@@ -4,11 +4,19 @@ set -e
 
 PYTHON_VERSION="${PYTHON_VERSION:=3.7}"
 
+python3 -V
+
 in_github_action() {
   [ -n "$GITHUB_ACTION" ]
 }
 
-script_dir="$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}")")"
+# macos do not support realpath
+# use ad-hoc method from https://stackoverflow.com/questions/3572030/bash-script-absolute-path-with-os-x
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+script_dir="$(dirname -- "$(realpath "${BASH_SOURCE[0]}")")"
 cd "$script_dir"/..
 if in_github_action; then
   WORK_DIR="$(pwd)"


### PR DESCRIPTION
## Description
Unit test works with macOS
* symlink can not work with virtualenv (not only in macOS)
* temp dir under macOS is like `/var/folders/xx/xxxxxxxxxxxxxxxx/X/`, not `/tmp/`
* macOS use a symlink temp dir for users

mnist demo can not run under macOS for now, will fix it in further PR.

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [x] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
