### PR TITLE
fix(statsotre):  hex str encode/decode error when value miss "0"

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -205,9 +205,7 @@ class SwScalarType(SwType):
         if self.name == "int":
             return int(value, 16)
         if self.name == "float":
-            raw = binascii.unhexlify(
-                value if value != "0" else "".zfill(int(self.nbits / 4))
-            )
+            raw = binascii.unhexlify(value.zfill(int(self.nbits / 4)))
             if self.nbits == 16:
                 return struct.unpack(">e", raw)[0]
             if self.nbits == 32:

--- a/client/tests/sdk/test_data_store.py
+++ b/client/tests/sdk/test_data_store.py
@@ -1629,6 +1629,7 @@ class TestRemoteDataStore(unittest.TestCase):
                     {"name": "n", "type": "FLOAT16"},
                     {"name": "o", "type": "FLOAT32"},
                     {"name": "p", "type": "FLOAT64"},
+                    {"name": "q", "type": "FLOAT64"},
                 ],
                 "records": [
                     {
@@ -1652,6 +1653,7 @@ class TestRemoteDataStore(unittest.TestCase):
                         "n": "0",  # client(python):0000, server(java):0
                         "o": "0",  # client(python):00000000, server(java):0
                         "p": "0",  # client(python):0000000000000000, server(java):0
+                        "q": "111111",  # client(python):000000000111111, server(java):111111
                     }
                 ],
             }
@@ -1679,6 +1681,7 @@ class TestRemoteDataStore(unittest.TestCase):
                     "n": 0.0,
                     "o": 0.0,
                     "p": 0.0,
+                    "q": 5.52603e-318,
                 }
             ],
             list(


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
