### PR TITLE
enhance(client): tune runtime process logger with the external swcli verbose setting

### DIFF
--- a/client/starwhale/consts/__init__.py
+++ b/client/starwhale/consts/__init__.py
@@ -7,6 +7,7 @@ SW_CLI_CONFIG = CONFIG_DIR / "config.yaml"
 
 ENV_SW_CLI_CONFIG = "SW_CLI_CONFIG"
 ENV_LOG_LEVEL = "SW_LOG_LEVEL"
+ENV_LOG_VERBOSE_COUNT = "SW_LOG_VERBOSE_COUNT"
 ENV_SW_IMAGE_REPO = "SW_IMAGE_REPO"
 # SW_LOCAL_STORAGE env used for generating default swcli config
 # and overriding 'storage.root' swcli config in runtime

--- a/client/starwhale/core/runtime/process.py
+++ b/client/starwhale/core/runtime/process.py
@@ -9,7 +9,7 @@ from functools import partial
 import dill
 
 from starwhale.utils import console
-from starwhale.consts import PythonRunEnv
+from starwhale.consts import PythonRunEnv, ENV_LOG_VERBOSE_COUNT
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType, InstanceType
 from starwhale.utils.venv import (
@@ -57,19 +57,19 @@ class Process:
         if not os.path.exists(_pkl_path):
             raise NotFoundError(f"dill file: {_pkl_path}")
 
+        verbose = int(os.environ.get(ENV_LOG_VERBOSE_COUNT, "0"))
         try:
             cmd = [
                 self._get_activate_cmd(),
-                f'{self._prefix_path}/bin/python3 -c \'import dill; dill.load(open("{_pkl_path}", "rb"))()\'',
+                f'{self._prefix_path}/bin/python3 -c \'from starwhale.utils.debug import init_logger; init_logger({verbose}); import dill; dill.load(open("{_pkl_path}", "rb"))()\'',
             ]
             console.print(
                 f":rooster: run process in the python isolated environment(prefix: {self._prefix_path})"
             )
-            # TODO: tune subprocess output with log-level
             check_call(
                 ["bash", "-c", " && ".join(cmd)],
                 env={self.EnvInActivatedProcess: "1"},
-                log=console.print,
+                log=print,
             )
         finally:
             os.unlink(_pkl_path)

--- a/client/starwhale/utils/debug.py
+++ b/client/starwhale/utils/debug.py
@@ -5,7 +5,7 @@ import logging
 from rich import traceback
 from loguru import logger
 
-from starwhale.consts import ENV_LOG_LEVEL
+from starwhale.consts import ENV_LOG_LEVEL, ENV_LOG_VERBOSE_COUNT
 
 
 def init_logger(verbose: int) -> None:
@@ -15,16 +15,11 @@ def init_logger(verbose: int) -> None:
     elif verbose == 1:
         lvl = logging.INFO
     else:
-        fmt = (
-            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-            "<level>{level: <6}</level> | "
-            "<level>{message}</level>"
-        )
         lvl = logging.DEBUG
 
     lvl_name = logging.getLevelName(lvl)
-
     os.environ[ENV_LOG_LEVEL] = lvl_name
+    os.environ[ENV_LOG_VERBOSE_COUNT] = str(verbose)
 
     # TODO: custom debug for tb install
     traceback.install(show_locals=True, max_frames=1, width=200)

--- a/client/starwhale/utils/process.py
+++ b/client/starwhale/utils/process.py
@@ -20,19 +20,20 @@ def log_check_call(*args: t.Any, **kwargs: t.Any) -> int:
     p = Popen(*args, **kwargs)
     logger.debug(f"cmd: {p.args!r}")
 
-    def _print_log() -> None:
+    while True:
         line = p.stdout.readline()  # type: ignore
         if line:
             log(line.rstrip())
             output.append(line)
 
-    while True:
-        _print_log()
         if p.poll() is not None:
             break
 
     p.wait()
-    _print_log()
+    for line in p.stdout.readlines():  # type: ignore
+        if line:
+            log(line.rstrip())
+            output.append(line)
 
     try:
         p.stdout.close()  # type: ignore

--- a/client/tests/utils/test_process.py
+++ b/client/tests/utils/test_process.py
@@ -16,9 +16,9 @@ class TestCheckCall(unittest.TestCase):
             log=_log,
         )
 
-        assert len(save_logs) >= 2
+        assert len(save_logs) >= 1
 
         with self.assertRaises(FileNotFoundError):
             log_check_call(["err"])
 
-        assert len(save_logs) >= 2
+        assert len(save_logs) >= 1


### PR DESCRIPTION
## Description
related: https://github.com/star-whale/starwhale/issues/1378
- realtime output
- use the external verbose argument for runtime subprocess

![image](https://user-images.githubusercontent.com/590748/196157903-8e44c2f7-2ed9-4001-905d-7ade1b7a2e13.png)


## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
