### PR TITLE
fix(client): get instance wrong when multi instances has the same uri

### DIFF
--- a/client/starwhale/utils/config.py
+++ b/client/starwhale/utils/config.py
@@ -158,9 +158,18 @@ class SWCliConfigMixed:
             return self.current_instance
 
         if instance not in self._config["instances"]:
+            _count = 0
+            _alias = None
             for k, v in self._config["instances"].items():
                 if v["uri"] == instance:
-                    return str(k)
+                    _alias = str(k)
+                    _count += 1
+            if _count > 1:
+                raise RuntimeError(
+                    f"instance uri:{instance} has multi items!! please use alias."
+                )
+            if _alias:
+                return _alias
 
         return instance
 

--- a/client/tests/base/test_uri.py
+++ b/client/tests/base/test_uri.py
@@ -157,3 +157,6 @@ class URITestCase(TestCase):
 
         uri = URI("", expected_type=URIType.PROJECT)
         assert uri.project == "self"
+
+        with self.assertRaises(RuntimeError):
+            URI("http://2.2.2.2:8182", expected_type=URIType.INSTANCE)

--- a/client/tests/data/config.yaml
+++ b/client/tests/data/config.yaml
@@ -19,7 +19,23 @@ instances:
     sw_token: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxLHN0YXJ3aGFsZSIsImlzcyI6InN0YXJXaGFsZSIsImlhdCI6MTY1MzIyNjQ2MSwiZXhwIjoxNjUzMzEyODYxfQ.CKtNePJJekDKBYN5HaLvUaZqiFOR4ghhWIyuqtCYmj02r6Ymm4t6N21xkNdd7sljoT-ffr_QIxkkAeyxOHcieA
     type: cloud
     updated_at: 2022-05-22 21:34:24 CST
-    uri: http://1.1.1.1:8182
+    uri: http://1.1.1.2:8182
+    user_name: starwhale
+    user_role: admin
+  pre-repeat:
+    current_project: self
+    sw_token: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxLHN0YXJ3aGFsZSIsImlzcyI6InN0YXJXaGFsZSIsImlhdCI6MTY1MzIyNjQ2MSwiZXhwIjoxNjUzMzEyODYxfQ.CKtNePJJekDKBYN5HaLvUaZqiFOR4ghhWIyuqtCYmj02r6Ymm4t6N21xkNdd7sljoT-ffr_QIxkkAeyxOHcieA
+    type: cloud
+    updated_at: 2022-05-22 21:34:24 CST
+    uri: http://2.2.2.2:8182
+    user_name: starwhale
+    user_role: admin
+  pre-repeat2:
+    current_project: self
+    sw_token: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxLHN0YXJ3aGFsZSIsImlzcyI6InN0YXJXaGFsZSIsImlhdCI6MTY1MzIyNjQ2MSwiZXhwIjoxNjUzMzEyODYxfQ.CKtNePJJekDKBYN5HaLvUaZqiFOR4ghhWIyuqtCYmj02r6Ymm4t6N21xkNdd7sljoT-ffr_QIxkkAeyxOHcieA
+    type: cloud
+    updated_at: 2022-05-22 21:34:24 CST
+    uri: http://2.2.2.2:8182
     user_name: starwhale
     user_role: admin
 storage:

--- a/client/tests/utils/test_config.py
+++ b/client/tests/utils/test_config.py
@@ -75,7 +75,7 @@ class SWCliConfigTestCase(TestCase):
         self.fs.create_file(path, contents=_existed_config_contents)
         _config = load_swcli_config()
 
-        assert len(_config["instances"]) == 3
+        assert len(_config["instances"]) == 5
         assert "pre-bare" == _config["current_instance"]
         assert "cloud" == _config["instances"]["pre-bare"]["type"]
         assert "starwhale" == _config["instances"]["pre-bare"]["user_name"]
@@ -98,7 +98,7 @@ class SWCliConfigTestCase(TestCase):
 
         _config = load_swcli_config()
         assert "local" == sw.current_instance
-        assert len(_config["instances"]) == 1
+        assert len(_config["instances"]) == 3
 
         sw.update_instance(
             uri="console.pre.intra.starwhale.ai",
@@ -107,7 +107,7 @@ class SWCliConfigTestCase(TestCase):
         )
 
         _config = load_swcli_config()
-        assert len(_config["instances"]) == 2
+        assert len(_config["instances"]) == 4
         assert "pre-k8s" in _config["instances"]
         assert (
             "http://console.pre.intra.starwhale.ai"


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
