### PR TITLE
fix(controller) : fix job status error when deploy task to k8s failed

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
@@ -98,12 +98,12 @@ public class K8sTaskScheduler implements SwTaskScheduler {
 
     @Override
     public void schedule(Collection<Task> tasks) {
-        tasks.parallelStream().forEach(this::deployTaskToK8s);
+        tasks.stream().forEach(this::deployTaskToK8s);
     }
 
     @Override
     public void stopSchedule(Collection<Long> taskIds) {
-        taskIds.parallelStream().forEach(id -> {
+        taskIds.stream().forEach(id -> {
             try {
                 k8sClient.deleteJob(id.toString());
             } catch (ApiException e) {
@@ -225,7 +225,7 @@ public class K8sTaskScheduler implements SwTaskScheduler {
 
     private void taskFailed(Task task) {
         TaskStatusChangeWatcher.SKIPPED_WATCHERS.set(
-                Set.of(TaskWatcherForJobStatus.class, TaskWatcherForSchedule.class, TaskWatcherForLogging.class));
+                Set.of(TaskWatcherForSchedule.class, TaskWatcherForLogging.class));
         // todo save log
         task.updateStatus(TaskStatus.FAIL);
         TaskStatusChangeWatcher.SKIPPED_WATCHERS.remove();


### PR DESCRIPTION
## Description
Job status is `RUNNING` ,but task inside it is FAIL.
### Recurrence
use unkown resource like `gpu` when create a job

### Solution
remove skipped watcher

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
