### PR TITLE
feat: use signed url instead of auth propagation

### DIFF
--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -5,7 +5,6 @@ import sys
 import math
 import typing as t
 from abc import ABCMeta, abstractmethod
-from urllib.parse import urlparse
 
 import loguru
 from loguru import logger as _logger

--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -66,7 +66,7 @@ class DataLoader(metaclass=ABCMeta):
         self._stores[_k] = _store
         return _store
 
-    def _get_key_compose(self, row: TabularDatasetRow, store: ObjectStore) -> str:
+    def _get_key_compose(self, row: TabularDatasetRow, store: ObjectStore) -> t.Tuple[str, int, int]:
         if row.object_store_type == ObjectStoreType.REMOTE:
             data_uri = row.data_uri
         else:

--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -49,7 +49,7 @@ class DataLoader(metaclass=ABCMeta):
             load_dotenv(auth_env_fpath)
 
     def _get_store(self, row: TabularDatasetRow) -> ObjectStore:
-        _k = f"{row.object_store_type.value}.{row.auth_name}"
+        _k = f"{self.dataset_uri}.{row.auth_name}"
         _store = self._stores.get(_k)
         if _store:
             return _store

--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -66,7 +66,9 @@ class DataLoader(metaclass=ABCMeta):
         self._stores[_k] = _store
         return _store
 
-    def _get_key_compose(self, row: TabularDatasetRow, store: ObjectStore) -> t.Tuple[str, int, int]:
+    def _get_key_compose(
+        self, row: TabularDatasetRow, store: ObjectStore
+    ) -> t.Tuple[str, int, int]:
         if row.object_store_type == ObjectStoreType.REMOTE:
             data_uri = row.data_uri
         else:

--- a/client/starwhale/consts/__init__.py
+++ b/client/starwhale/consts/__init__.py
@@ -87,6 +87,7 @@ VERSION_PREFIX_CNT = 2
 class SWDSBackendType:
     S3 = "s3"
     LocalFS = "local_fs"
+    SignedUrl = "signed_url"
 
 
 class EvalHandlerType:

--- a/client/starwhale/core/dataset/store.py
+++ b/client/starwhale/core/dataset/store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import os
 import json
-import requests
 import shutil
 import typing as t
 from abc import ABCMeta, abstractmethod
@@ -11,12 +10,17 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import boto3
+import requests
 from loguru import logger
 from botocore.client import Config as S3Config
 from typing_extensions import Protocol
 
-from starwhale.consts import SWDSBackendType, VERSION_PREFIX_CNT, DEFAULT_MANIFEST_NAME, HTTPMethod
-from starwhale.base.cloud import CloudRequestMixed
+from starwhale.consts import (
+    HTTPMethod,
+    SWDSBackendType,
+    VERSION_PREFIX_CNT,
+    DEFAULT_MANIFEST_NAME,
+)
 from starwhale.base.uri import URI
 from starwhale.utils.fs import (
     ensure_dir,
@@ -24,7 +28,8 @@ from starwhale.utils.fs import (
     FilePosition,
     BLAKE2B_SIGNATURE_ALGO,
 )
-from starwhale.base.type import URIType, BundleType, InstanceType
+from starwhale.base.type import URIType, BundleType
+from starwhale.base.cloud import CloudRequestMixed
 from starwhale.base.store import BaseStorage
 from starwhale.utils.error import (
     FormatError,
@@ -316,13 +321,18 @@ class ObjectStore:
     def from_dataset_uri(cls, dataset_uri: URI) -> ObjectStore:
         if dataset_uri.object.typ != URIType.DATASET:
             raise NoSupportError(f"{dataset_uri} is not dataset uri")
-        return cls(backend=SWDSBackendType.LocalFS, bucket=str(DatasetStorage(dataset_uri).data_dir.absolute()))
+        return cls(
+            backend=SWDSBackendType.LocalFS,
+            bucket=str(DatasetStorage(dataset_uri).data_dir.absolute()),
+        )
 
     @classmethod
     def from_remote_dataset(cls, dataset_uri: URI, auth_name: str) -> ObjectStore:
         if dataset_uri.object.typ != URIType.DATASET:
             raise NoSupportError(f"{dataset_uri} is not dataset uri")
-        return cls(backend=SWDSBackendType.SignedUrl, bucket=auth_name, dataset_uri=dataset_uri)
+        return cls(
+            backend=SWDSBackendType.SignedUrl, bucket=auth_name, dataset_uri=dataset_uri
+        )
 
 
 class StorageBackend(metaclass=ABCMeta):

--- a/client/starwhale/core/dataset/store.py
+++ b/client/starwhale/core/dataset/store.py
@@ -349,7 +349,9 @@ class StorageBackend(metaclass=ABCMeta):
     __repr__ = __str__
 
     @abstractmethod
-    def _make_file(self, bucket: str, key_compose: t.Tuple[str, int, int]) -> FileLikeObj:
+    def _make_file(
+        self, bucket: str, key_compose: t.Tuple[str, int, int]
+    ) -> FileLikeObj:
         raise NotImplementedError
 
 
@@ -378,7 +380,9 @@ class S3StorageBackend(StorageBackend):
             region_name=conn.region,
         )
 
-    def _make_file(self, bucket: str, key_compose: t.Tuple[str, int, int]) -> FileLikeObj:
+    def _make_file(
+        self, bucket: str, key_compose: t.Tuple[str, int, int]
+    ) -> FileLikeObj:
         # TODO: merge connections for s3
         _key, _start, _end = key_compose
         return S3BufferedFileLike(
@@ -394,7 +398,9 @@ class LocalFSStorageBackend(StorageBackend):
     def __init__(self) -> None:
         super().__init__(kind=SWDSBackendType.LocalFS)
 
-    def _make_file(self, bucket: str, key_compose: t.Tuple[str, int, int]) -> FileLikeObj:
+    def _make_file(
+        self, bucket: str, key_compose: t.Tuple[str, int, int]
+    ) -> FileLikeObj:
         _key, _start, _end = key_compose
         bucket_path = (
             Path(bucket).expanduser() if bucket.startswith("~/") else Path(bucket)

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
@@ -71,14 +71,14 @@ public interface DatasetApi {
                     description = "Project Url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(
                     in = ParameterIn.PATH,
                     description = "Dataset Url",
                     required = true,
                     schema = @Schema())
             @PathVariable("datasetUrl")
-                    String datasetUrl,
+            String datasetUrl,
             @Valid @RequestBody RevertSwdsRequest revertRequest);
 
     @Operation(summary = "Delete a dataset")
@@ -91,10 +91,10 @@ public interface DatasetApi {
                     description = "Project Url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("datasetUrl")
-                    String datasetUrl);
+            String datasetUrl);
 
     @Operation(summary = "Recover a dataset")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})
@@ -107,10 +107,10 @@ public interface DatasetApi {
                     description = "Project Url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("datasetUrl")
-                    String datasetUrl);
+            String datasetUrl);
 
     @Operation(summary = "Get the information of a dataset",
             description = "Return the information of the latest version of the current dataset")
@@ -132,17 +132,17 @@ public interface DatasetApi {
                     description = "Project Url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("datasetUrl")
-                    String datasetUrl,
+            String datasetUrl,
             @Parameter(in = ParameterIn.QUERY,
                     description = "Dataset versionUrl. "
                             + "(Return the current version as default when the versionUrl is not set.)",
                     schema = @Schema())
             @Valid
             @RequestParam(value = "versionUrl", required = false)
-                    String versionUrl);
+            String versionUrl);
 
     @Operation(summary = "Get the list of the dataset versions")
     @ApiResponses(
@@ -163,34 +163,34 @@ public interface DatasetApi {
                     description = "Project Url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(
                     in = ParameterIn.PATH,
                     description = "Dataset Url",
                     required = true,
                     schema = @Schema())
             @PathVariable("datasetUrl")
-                    String datasetUrl,
+            String datasetUrl,
             @Parameter(
                     in = ParameterIn.QUERY,
                     description = "Dataset version name prefix",
                     schema = @Schema())
             @RequestParam(value = "name", required = false)
-                    String name,
+            String name,
             @Parameter(
                     in = ParameterIn.QUERY,
                     description = "Dataset version tag",
                     schema = @Schema())
             @RequestParam(value = "tag", required = false)
-                    String tag,
+            String tag,
             @Parameter(in = ParameterIn.QUERY, description = "The page number", schema = @Schema())
             @Valid
             @RequestParam(value = "pageNum", required = false, defaultValue = "1")
-                    Integer pageNum,
+            Integer pageNum,
             @Parameter(in = ParameterIn.QUERY, description = "Rows per page", schema = @Schema())
             @Valid
             @RequestParam(value = "pageSize", required = false, defaultValue = "10")
-                    Integer pageSize);
+            Integer pageSize);
 
     @Operation(summary = "Create a new dataset version",
             description = "Create a new version of the dataset. "
@@ -246,6 +246,24 @@ public interface DatasetApi {
             @RequestParam(name = "size", required = false) String size,
             HttpServletResponse httpResponse);
 
+    @Operation(summary = "Sign SWDS uri to get a temporarily accessible link",
+            description = "Sign SWDS uri to get a temporarily accessible link")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})
+    @GetMapping(
+            value = "/project/{projectName}/dataset/{datasetName}/version/{version}/sign-link",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER', 'GUEST')")
+    ResponseEntity<ResponseMessage<String>> signLink(
+            @PathVariable(name = "projectName") String projectUrl,
+            @PathVariable(name = "datasetName") String datasetUrl,
+            @PathVariable(name = "version") String versionUrl,
+            @Parameter(name = "uri", description = "uri of the link")
+            @RequestParam(name = "uri", required = true) String uri,
+            @Parameter(name = "authName", description = "auth name the link used")
+            @RequestParam(name = "authName", required = false) String authName,
+            @Parameter(name = "expTimeMillis", description = "the link will be expired after expTimeMillis")
+            @RequestParam(name = "expTimeMillis", required = false) Long expTimeMillis);
+
 
     @Operation(summary = "Set the tag of the dataset version")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})
@@ -257,13 +275,13 @@ public interface DatasetApi {
                     description = "Project Url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("datasetUrl")
-                    String datasetUrl,
+            String datasetUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("versionUrl")
-                    String versionUrl,
+            String versionUrl,
             @Valid @RequestBody SwdsTagRequest swdsTagRequest);
 
     @Operation(
@@ -279,13 +297,13 @@ public interface DatasetApi {
                     description = "Project url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("datasetUrl")
-                    String datasetUrl,
+            String datasetUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("versionUrl")
-                    String versionUrl,
+            String versionUrl,
             @Valid @RequestBody SwdsTagRequest swdsTagRequest);
 
     @Operation(summary = "Get the list of the datasets")
@@ -307,19 +325,19 @@ public interface DatasetApi {
                     description = "Project Url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(in = ParameterIn.QUERY, description = "Dataset versionId", schema = @Schema())
             @Valid
             @RequestParam(value = "versionId", required = false)
-                    String versionId,
+            String versionId,
             @Parameter(in = ParameterIn.QUERY, description = "Page number", schema = @Schema())
             @Valid
             @RequestParam(value = "pageNum", required = false, defaultValue = "1")
-                    Integer pageNum,
+            Integer pageNum,
             @Parameter(in = ParameterIn.QUERY, description = "Rows per page", schema = @Schema())
             @Valid
             @RequestParam(value = "pageSize", required = false, defaultValue = "10")
-                    Integer pageSize);
+            Integer pageSize);
 
     @Operation(summary = "head for swds info ",
             description = "head for swds info")
@@ -334,12 +352,12 @@ public interface DatasetApi {
                     description = "Project url",
                     schema = @Schema())
             @PathVariable("projectUrl")
-                    String projectUrl,
+            String projectUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("datasetUrl")
-                    String datasetUrl,
+            String datasetUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("versionUrl")
-                    String versionUrl);
+            String versionUrl);
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
@@ -208,6 +208,14 @@ public class DatasetController implements DatasetApi {
     }
 
     @Override
+    public ResponseEntity<ResponseMessage<String>> signLink(String projectUrl, String datasetUrl, String versionUrl,
+            String uri, String authName, Long expTimeMillis) {
+        SwDatasetVersionEntity datasetVersionEntity = swDatasetService.query(projectUrl, datasetUrl, versionUrl);
+        return ResponseEntity.ok(Code.success.asResponse(
+                swDatasetService.signLink(datasetVersionEntity.getId(), uri, authName, expTimeMillis)));
+    }
+
+    @Override
     public ResponseEntity<ResponseMessage<String>> modifyDatasetVersionInfo(
             String projectUrl, String datasetUrl, String versionUrl, SwdsTagRequest swdsTagRequest) {
         Boolean res = swDatasetService.modifySwdsVersion(projectUrl, datasetUrl, versionUrl,

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreApi.java
@@ -30,6 +30,7 @@ import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "Object Store")
 @Validated
@@ -52,6 +53,7 @@ public interface ObjectStoreApi {
     void getObjectContent(
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("path") String path,
+            @RequestHeader(name = "Range", required = false) String range,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("expTimeMillis") Long expTimeMillis,
             HttpServletResponse httpResponse);

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreApi.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Object Store")
+@Validated
+public interface ObjectStoreApi {
+
+    @Operation(summary = "Get the content of an object or a file")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "ok",
+                            content =
+                            @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = List.class)))
+            })
+    @GetMapping(
+            value = "/obj-store/{path}/{expTimeMillis}",
+            produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    void getObjectContent(
+            @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
+            @PathVariable("path") String path,
+            @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
+            @PathVariable("expTimeMillis") Long expTimeMillis,
+            HttpServletResponse httpResponse);
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreController.java
@@ -26,12 +26,14 @@ import java.io.InputStream;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequestMapping("/")
+@ConditionalOnProperty(prefix = "sw.storage", name = "type", havingValue = "fs")
 public class ObjectStoreController implements ObjectStoreApi {
 
     private final StorageAccessService storageAccessService;

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api;
+
+import ai.starwhale.mlops.exception.SwProcessException;
+import ai.starwhale.mlops.exception.SwProcessException.ErrorType;
+import ai.starwhale.mlops.exception.SwValidationException;
+import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
+import ai.starwhale.mlops.storage.StorageAccessService;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/")
+public class ObjectStoreController implements ObjectStoreApi {
+
+    private final StorageAccessService storageAccessService;
+
+    public ObjectStoreController(StorageAccessService storageAccessService) {
+        this.storageAccessService = storageAccessService;
+    }
+
+    @Override
+    public void getObjectContent(String path, Long expTimeMillis, HttpServletResponse httpResponse) {
+        if (expTimeMillis < System.currentTimeMillis()) {
+            throw new SwValidationException(ValidSubject.OBJECT_STORE).tip("link expired");
+        }
+        try (InputStream fileInputStream = storageAccessService.get(path);
+                ServletOutputStream outputStream = httpResponse.getOutputStream()) {
+            long length = fileInputStream.transferTo(outputStream);
+            httpResponse.addHeader("Content-Disposition", "attachment; filename=\"content\"");
+            httpResponse.addHeader("Content-Length", String.valueOf(length));
+            outputStream.flush();
+        } catch (IOException e) {
+            log.error("download file from storage failed {}", path, e);
+            throw new SwProcessException(ErrorType.STORAGE);
+        }
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwDatasetService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/SwDatasetService.java
@@ -291,4 +291,8 @@ public class SwDatasetService {
             String size) {
         return dsFileGetter.dataOf(datasetId, uri, authName, offset, size);
     }
+
+    public String signLink(Long id, String uri, String authName, Long expTimeMillis) {
+        return dsFileGetter.linkOf(id, uri, authName, expTimeMillis);
+    }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/objectstore/StorageAccessParser.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/swds/objectstore/StorageAccessParser.java
@@ -52,6 +52,8 @@ public class StorageAccessParser {
             String authName) {
         if (StringUtils.hasText(authName)) {
             authName = authName.toUpperCase(); // env vars are uppercase always
+        } else {
+            return defaultStorageAccessService;
         }
         StorageAccessService cachedStorageAccessService = storageAccessServicePool.get(
                 formatKey(datasetId, authName));

--- a/server/controller/src/main/java/ai/starwhale/mlops/exception/SwValidationException.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/exception/SwValidationException.java
@@ -64,7 +64,8 @@ public class SwValidationException extends StarwhaleException {
         RUNTIME("008", "Starwhale Runtime"),
         DATASTORE("009", "Starwhale Internal DataStore"),
         RESOURCE_POOL("010", "Resource Pool"),
-        SETTING("011", "System Setting");
+        SETTING("011", "System Setting"),
+        OBJECT_STORE("012", "Object Store");
         final String code;
         final String tipSubject;
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
@@ -182,11 +182,6 @@ public class K8sTaskScheduler implements SwTaskScheduler {
         coreContainerEnvs.put("SW_TASK_NUM", String.valueOf(task.getTaskRequest().getTotal()));
         coreContainerEnvs.put("SW_EVALUATION_VERSION", swJob.getUuid());
 
-        swDataSets.forEach(ds -> ds.getFileStorageEnvs().values()
-                .forEach(fileStorageEnv -> coreContainerEnvs.putAll(fileStorageEnv.getEnvs())));
-
-        coreContainerEnvs.put(StorageEnv.ENV_KEY_PREFIX, swDataSet.getPath());
-
         // datastore env
         coreContainerEnvs.put("SW_TOKEN", jobTokenConfig.getToken());
         coreContainerEnvs.put("SW_INSTANCE_URI", instanceUri);

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -34,7 +34,9 @@ sw:
   storage:
     type: ${SW_STORAGE_TYPE:minio}
     path-prefix: ${SW_STORAGE_PREFIX:starwhale}
-    fs-root-dir: ${SW_STORAGE_FS_ROOT_DIR:/usr/local/starwhale}
+    fs-config:
+      root-dir: ${SW_STORAGE_FS_ROOT_DIR:/usr/local/starwhale}
+      service-provider: ${SW_INSTANCE_URI}/obj-store
     s3-config:
       bucket: ${SW_STORAGE_BUCKET:starwhale}
       accessKey: ${SW_STORAGE_ACCESSKEY:starwhale}

--- a/server/controller/src/main/resources/template/job.yaml
+++ b/server/controller/src/main/resources/template/job.yaml
@@ -13,7 +13,7 @@ spec:
       initContainers:
         - name: data-provider
           imagePullPolicy: IfNotPresent
-          image: amazon/aws-cli:2.7.25
+          image: ghcr.io/star-whale/base:latest
           volumeMounts:
             - mountPath: /opt/starwhale
               name: data
@@ -21,35 +21,14 @@ spec:
           args:
             - -c
             - >-
-              mkdir -p $HOME/.aws;
-              CRED="$HOME/.aws/credentials";
-              echo [default] > $CRED;
-              echo "aws_access_key_id=$SW_S3_ACCESS_KEY" >> $CRED;
-              echo "aws_secret_access_key=$SW_S3_SECRET" >> $CRED;
-              if echo $SW_S3_EXTRA_CONFIGS | grep virtual; then
-                 echo [default] >> $HOME/.aws/config;
-                 echo s3= >> $HOME/.aws/config;
-                 echo '    addressing_style=virtual' >> $HOME/.aws/config;
-               fi;
                for item in $DOWNLOADS; do
-                 SRC=$(echo $item|cut -d';' -f1);
-                 DST=$(echo $item|cut -d';' -f2);
-                 echo $SRC,$DST;
-                 mkdir -p $DST;
-                 aws --endpoint-url=$SW_S3_ENDPOINT --region=$SW_S3_REGION s3 cp --recursive $SRC $DST;
-               done
-        - name: untar
-          imagePullPolicy: IfNotPresent
-          image: ghcr.io/star-whale/starwhale:latest
-          volumeMounts:
-            - mountPath: /opt/starwhale
-              name: data
-          command:
-            - sh
-            - -c
-            - >-
-              cd /opt/starwhale && find ./ -type f \( -name \*.swmp \) -exec tar -C swmp/ -xf {} \;
-              && find ./ -type f \( -name \*.swrt \) -exec tar -C swrt/ -xf {} \;
+                 wget $item -P /opt/starwhale;
+               done;
+               cd /opt/starwhale;
+               mkdir swmp;
+               mkdir swrt;
+               find ./ -type f \( -name \*.swmp\* \) -exec tar -C swmp/ -xf {} \; &&
+               find ./ -type f \( -name \*.swrt\* \) -exec tar -C swrt/ -xf {} \;
       containers:
         - name: 'worker'
           image: 'docker.io/library/busybox'

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/DatasetControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/DatasetControllerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.same;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 
 import ai.starwhale.mlops.api.protocol.swds.DatasetVersionVo;
 import ai.starwhale.mlops.api.protocol.swds.DatasetVo;
@@ -58,6 +59,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -350,5 +352,18 @@ public class DatasetControllerTest {
 
         resp = controller.headDataset("p2", "d1", "v1");
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
+    }
+
+    @Test
+    public void testSignLink() {
+        String pj = "pj";
+        String ds = "ds";
+        String v = "v";
+        String uri = "uri";
+        String auth = "auth";
+        when(swdsService.query(pj, ds, v)).thenReturn(SwDatasetVersionEntity.builder().id(1L).build());
+        String signUrl = "sign-url";
+        when(swdsService.signLink(1L, uri, auth, 100L)).thenReturn(signUrl);
+        Assertions.assertEquals(signUrl, controller.signLink(pj, ds, v, uri, auth, 100L).getBody().getData());
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/ObjectStoreControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/ObjectStoreControllerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.starwhale.mlops.storage.LengthAbleInputStream;
+import ai.starwhale.mlops.storage.StorageAccessService;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.DelegatingServletOutputStream;
+
+public class ObjectStoreControllerTest {
+
+    private ObjectStoreController objectStoreController;
+
+    private StorageAccessService storageAccessService;
+
+    @BeforeEach
+    public void setUp() {
+        storageAccessService = mock(StorageAccessService.class);
+        objectStoreController = new ObjectStoreController(storageAccessService);
+    }
+
+    @Test
+    public void testWithRange() throws IOException {
+        var rsp = mock(HttpServletResponse.class);
+        DelegatingServletOutputStream outputStream = new DelegatingServletOutputStream(new ByteArrayOutputStream());
+        when(rsp.getOutputStream()).thenReturn(outputStream);
+        var p = "p";
+        var r = "bytes=0-100";
+        String content = "content";
+        LengthAbleInputStream inputStream = new LengthAbleInputStream(new ByteArrayInputStream(content.getBytes()),
+                content.length());
+        when(storageAccessService.get(p, 0L, 101L)).thenReturn(inputStream);
+        objectStoreController.getObjectContent(p, r, System.currentTimeMillis() + 1000, rsp);
+        Assertions.assertEquals(content, outputStream.getTargetStream().toString());
+
+    }
+
+    @Test
+    public void testWithOutRange() throws IOException {
+        var rsp = mock(HttpServletResponse.class);
+        DelegatingServletOutputStream outputStream = new DelegatingServletOutputStream(new ByteArrayOutputStream());
+        when(rsp.getOutputStream()).thenReturn(outputStream);
+        var p = "p";
+        String r = null;
+        String content = "content";
+        LengthAbleInputStream inputStream = new LengthAbleInputStream(new ByteArrayInputStream(content.getBytes()),
+                content.length());
+        when(storageAccessService.get(p)).thenReturn(inputStream);
+        objectStoreController.getObjectContent(p, r, System.currentTimeMillis() + 1000, rsp);
+        Assertions.assertEquals(content, outputStream.getTargetStream().toString());
+
+    }
+
+    @Test
+    public void testWithOutRangeExcept() throws IOException {
+        var rsp = mock(HttpServletResponse.class);
+        DelegatingServletOutputStream outputStream = new DelegatingServletOutputStream(new ByteArrayOutputStream());
+        when(rsp.getOutputStream()).thenReturn(outputStream);
+        var p = "p";
+        var r = "asdfa";
+        String content = "content";
+        LengthAbleInputStream inputStream = new LengthAbleInputStream(new ByteArrayInputStream(content.getBytes()),
+                content.length());
+        when(storageAccessService.get(p)).thenReturn(inputStream);
+        objectStoreController.getObjectContent(p, r, System.currentTimeMillis() + 1000, rsp);
+        Assertions.assertEquals(content, outputStream.getTargetStream().toString());
+
+    }
+
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
@@ -58,7 +58,8 @@ public class DataStoreTest {
     @BeforeEach
     public void setUp() throws IOException {
         this.bufferManager = new SwByteBufferManager();
-        this.objectStore = new ObjectStore(bufferManager, new StorageAccessServiceFile(this.rootDir.getAbsolutePath()));
+        this.objectStore = new ObjectStore(bufferManager, new StorageAccessServiceFile(this.rootDir.getAbsolutePath(),
+                ""));
         this.walManager = new WalManager(this.objectStore, this.bufferManager, 256, 4096, "test/", 10, 3);
         this.dataStore = new DataStore(this.walManager);
     }

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/WalManagerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/WalManagerTest.java
@@ -66,7 +66,7 @@ public class WalManagerTest {
     public void setUp() throws IOException {
         this.bufferManager = new SwByteBufferManager();
         this.objectStore = new ObjectStore(this.bufferManager,
-                new StorageAccessServiceFile(this.rootDir.getAbsolutePath()));
+                new StorageAccessServiceFile(this.rootDir.getAbsolutePath(), "serviceProvider"));
         this.walManager = new WalManager(this.objectStore, this.bufferManager, 256, 4096, "test/", 10, 3);
     }
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
@@ -82,7 +82,8 @@ public class MemoryTableImplTest {
     @BeforeEach
     public void setUp() throws IOException {
         var bufferManager = new SwByteBufferManager();
-        var objectStore = new ObjectStore(bufferManager, new StorageAccessServiceFile(this.rootDir.getAbsolutePath()));
+        var objectStore = new ObjectStore(bufferManager, new StorageAccessServiceFile(this.rootDir.getAbsolutePath(),
+                "serviceProvider"));
         this.walManager = new WalManager(objectStore, bufferManager, 256, 4096, "test/", 10, 3);
     }
 
@@ -305,8 +306,8 @@ public class MemoryTableImplTest {
                     }));
             assertThat("all types",
                     scanAll(this.memoryTable,
-                        List.of("key", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"),
-                        false),
+                            List.of("key", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"),
+                            false),
                     contains(new MemoryTable.RecordResult("x",
                             new HashMap<>() {
                                 {
@@ -485,7 +486,8 @@ public class MemoryTableImplTest {
             MemoryTableImplTest.this.walManager.terminate();
             SwBufferManager bufferManager = new SwByteBufferManager();
             var objectStore = new ObjectStore(bufferManager,
-                    new StorageAccessServiceFile(MemoryTableImplTest.this.rootDir.getAbsolutePath()));
+                    new StorageAccessServiceFile(MemoryTableImplTest.this.rootDir.getAbsolutePath(),
+                            "serviceProvider"));
             MemoryTableImplTest.this.walManager = new WalManager(objectStore, bufferManager, 256, 4096, "test/", 10, 3);
             this.memoryTable = new MemoryTableImpl("test", MemoryTableImplTest.this.walManager);
             var it = MemoryTableImplTest.this.walManager.readAll();

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/SwDatasetServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/SwDatasetServiceTest.java
@@ -388,5 +388,13 @@ public class SwDatasetServiceTest {
         assertThat(res, notNullValue());
     }
 
+    @Test
+    public void testLinkOf() {
+        given(dsFileGetter.linkOf(same(1L), anyString(), anyString(), anyLong()))
+                .willReturn("link");
+
+        var res = dsFileGetter.linkOf(1L, "", "", 1L);
+        assertThat(dsFileGetter.linkOf(1L, "", "", 1L), is("link"));
+    }
 
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/objectstore/DsFileGetterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/objectstore/DsFileGetterTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public class DsFileGetterTest {
 
     @Test
-    public void testFileGetter() throws IOException {
+    public void testDataOf() throws IOException {
         StorageAccessParser storageAccessParser = mock(StorageAccessParser.class);
         StorageAccessService storageAccessService = mock(
                 StorageAccessService.class);
@@ -54,6 +54,24 @@ public class DsFileGetterTest {
                 (String) ColumnTypeScalar.INT64.encode(1, false));
         Assertions.assertEquals("abc", new String(bytes));
 
+    }
+
+    @Test
+    public void testLinkOf() throws IOException {
+        StorageAccessParser storageAccessParser = mock(StorageAccessParser.class);
+        StorageAccessService storageAccessService = mock(
+                StorageAccessService.class);
+        when(storageAccessService.head("bdcsd")).thenReturn(new StorageObjectInfo(false, 1L, null));
+        when(storageAccessService.head("bdc/bdcsd")).thenReturn(new StorageObjectInfo(true, 1L, null));
+        when(storageAccessService.signedUrl(eq("bdc/bdcsd"), anyLong())).thenReturn("abc");
+        when(storageAccessParser.getStorageAccessServiceFromAuth(anyLong(), anyString(), anyString())).thenReturn(
+                storageAccessService);
+        SwDatasetVersionMapper versionMapper = mock(SwDatasetVersionMapper.class);
+        when(versionMapper.getVersionById(anyLong())).thenReturn(
+                SwDatasetVersionEntity.builder().storagePath("bdc").build());
+        DsFileGetter fileGetter = new DsFileGetter(storageAccessParser, versionMapper);
+        Assertions.assertEquals("abc", fileGetter.linkOf(1L, "bdcsd", "", 1L));
+        Assertions.assertEquals("abc", fileGetter.linkOf(1L, "bdc/bdcsd", "", 1L));
     }
 
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/objectstore/UserStorageAuthEnvTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/swds/objectstore/UserStorageAuthEnvTest.java
@@ -27,10 +27,10 @@ public class UserStorageAuthEnvTest {
     @Test
     public void testS3() {
         final String auths = "USER.S3.REGION=region\n"
-                + "USER.S3.ENDPOINT=endpoint\n"
+                + "USER.S3.ENDPOINT=http://10.131.0.1:9000\n"
                 + "USER.S3.SECRET=secret\n"
                 + "USER.S3.ACCESS_KEY=access_key\n"
-                + "USER.S3.myname.ENDPOINT=endpoint1\n"
+                + "USER.S3.myname.ENDPOINT=http://localhost\n"
                 + "USER.S3.myname.SECRET=secret1\n"
                 + "USER.S3.MNIST.SECRET=\n"
                 + "USER.S3.myname.ACCESS_KEY=access_key1\n";
@@ -38,14 +38,14 @@ public class UserStorageAuthEnvTest {
         StorageEnv defaultEnv = storageAuths.getEnv("");
         Assertions.assertEquals(StorageEnvType.S3, defaultEnv.getEnvType());
         Assertions.assertEquals("region", defaultEnv.getEnvs().get("USER.S3.REGION"));
-        Assertions.assertEquals("endpoint", defaultEnv.getEnvs().get("USER.S3.ENDPOINT"));
+        Assertions.assertEquals("http://10.131.0.1:9000", defaultEnv.getEnvs().get("USER.S3.ENDPOINT"));
         Assertions.assertEquals("secret", defaultEnv.getEnvs().get("USER.S3.SECRET"));
         Assertions.assertEquals("access_key", defaultEnv.getEnvs().get("USER.S3.ACCESS_KEY"));
 
         StorageEnv myEnv = storageAuths.getEnv("myname");
         Assertions.assertEquals(StorageEnvType.S3, myEnv.getEnvType());
         Assertions.assertNull(myEnv.getEnvs().get("USER.S3.myname.REGION"));
-        Assertions.assertEquals("endpoint1", myEnv.getEnvs().get("USER.S3.MYNAME.ENDPOINT"));
+        Assertions.assertEquals("http://localhost", myEnv.getEnvs().get("USER.S3.MYNAME.ENDPOINT"));
         Assertions.assertEquals("secret1", myEnv.getEnvs().get("USER.S3.MYNAME.SECRET"));
         Assertions.assertEquals("access_key1", myEnv.getEnvs().get("USER.S3.MYNAME.ACCESS_KEY"));
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
@@ -213,9 +213,6 @@ public class K8sTaskSchedulerTest {
             expectedEnvs.put("SW_TOKEN", "tt");
             expectedEnvs.put("SW_INSTANCE_URI", "http://instanceUri");
             expectedEnvs.put("SW_TASK_STEP", "cmp");
-            expectedEnvs.put("ENVS4", "envS4V");
-            expectedEnvs.put(StorageEnv.ENV_KEY_PREFIX, "swds_path");
-            expectedEnvs.put(StorageEnv.ENV_TYPE, "S3");
             expectedEnvs.put("NVIDIA_VISIBLE_DEVICES", "");
             Map<String, String> actualEnv = worker.getEnvs().stream()
                     .collect(Collectors.toMap(V1EnvVar::getName, V1EnvVar::getValue));

--- a/server/controller/src/test/resources/template/job.yaml
+++ b/server/controller/src/test/resources/template/job.yaml
@@ -13,15 +13,15 @@ spec:
       initContainers:
         - name: data-provider
           imagePullPolicy: IfNotPresent
-          image: amazon/aws-cli:2.7.25
+          image: ghcr.io/star-whale/base:latest
           volumeMounts:
             - mountPath: /opt/starwhale
               name: data
           command: [ "/bin/sh" ]
-          args: [ "-c", "for item in $DOWNLOADS; do SRC=$(echo $item|cut -d';' -f1) && DST=$(echo $item|cut -d';' -f2) && echo $SRC,$DST && mkdir -p $DST && aws --endpoint-url=$ENDPOINT_URL --region=$AWS_S3_REGION s3 cp --recursive $SRC $DST; done" ]
+          args: [ "-c", "for item in $DOWNLOADS; do SRC=$(echo $item|cut -d';' -f1) && DST=$(echo $item|cut -d';' -f2) && echo $SRC,$DST && mkdir -p $DST && wget $SRC -P $DST; done" ]
         - name: untar
           imagePullPolicy: IfNotPresent
-          image: ghcr.io/star-whale/starwhale:latest
+          image: ghcr.io/star-whale/base:latest
           volumeMounts:
             - mountPath: /opt/starwhale
               name: data
@@ -29,7 +29,7 @@ spec:
             - sh
             - -c
             - >-
-              cd /opt/starwhale && find ./ -type f \( -name \*.swmp -o -name \*.swrt \) -exec tar -C swmp/ -xf {} \;
+              cd /opt/starwhale && find ./ -type f \( -name \*.swmp* -o -name \*.swrt* \) -exec tar -C swmp/ -xf {} \;
       containers:
         - name: 'worker'
           image: 'docker.io/library/busybox'

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/StorageAccessService.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/StorageAccessService.java
@@ -38,4 +38,14 @@ public interface StorageAccessService {
     Stream<String> list(String path) throws IOException;
 
     void delete(String path) throws IOException;
+
+    /**
+     * return an accessible url using http get method
+     *
+     * @param path          the key of an object or path of a file
+     * @param expTimeMillis the url will expire after expTimeMillis
+     * @return pre-signed url of an object or http get accessible url
+     * @throws IOException any possible IO exception
+     */
+    String signedUrl(String path, Long expTimeMillis) throws IOException;
 }

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/aliyun/StorageAccessServiceAliyun.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/aliyun/StorageAccessServiceAliyun.java
@@ -36,9 +36,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.stream.Stream;
 
 public class StorageAccessServiceAliyun implements StorageAccessService {
+
     final String bucket;
 
     final OSS ossClient;
@@ -110,5 +112,11 @@ public class StorageAccessServiceAliyun implements StorageAccessService {
     @Override
     public void delete(String path) throws IOException {
         this.ossClient.deleteObject(this.bucket, path);
+    }
+
+    @Override
+    public String signedUrl(String path, Long expTimeMillis) throws IOException {
+        return ossClient.generatePresignedUrl(this.bucket, path, new Date(System.currentTimeMillis() + expTimeMillis))
+                .toString();
     }
 }

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/UserStorageAuthEnv.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/env/UserStorageAuthEnv.java
@@ -33,7 +33,7 @@ public class UserStorageAuthEnv {
     static final String NAME_DEFAULT = "";
 
     static final Pattern LINE_PATTERN = Pattern.compile(
-            "^(USER\\.(S3|ALIYUN|HDFS|WEBHDFS|LOCALFS|NFS|FTP|SFTP|HTTP|HTTPS)\\.((\\w+)\\.)?(\\w+))=(\\w*)$");
+            "^(USER\\.(S3|ALIYUN|HDFS|WEBHDFS|LOCALFS|NFS|FTP|SFTP|HTTP|HTTPS)\\.((\\w+)\\.)?(\\w+))=(.*)$");
 
     public UserStorageAuthEnv(String authsText) {
         String[] lines = authsText.split("\n");

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFile.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFile.java
@@ -111,10 +111,14 @@ public class StorageAccessServiceFile implements StorageAccessService {
         if (size == null || size < 0) {
             size = -1L;
         }
-        var f = new RandomAccessFile(this.rootDir, "r");
-        f.seek(offset);
+        File f = new File(this.rootDir, path);
+        if (!f.exists()) {
+            throw new FileNotFoundException(f.getAbsolutePath());
+        }
+        RandomAccessFile rf = new RandomAccessFile(f, "r");
+        rf.seek(offset);
         //noinspection UnstableApiUsage
-        var is = ByteStreams.limit(Channels.newInputStream(f.getChannel()), size);
+        var is = ByteStreams.limit(Channels.newInputStream(rf.getChannel()), size);
         return new LengthAbleInputStream(is, size);
     }
 

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFile.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFile.java
@@ -46,8 +46,16 @@ public class StorageAccessServiceFile implements StorageAccessService {
 
     private final File rootDir;
 
-    public StorageAccessServiceFile(@Value("${sw.storage.fs-root-dir}") String rootDir) {
+    private final String serviceProvider;
+
+    /**
+     * @param rootDir the root for the storage file
+     * @param serviceProvider the service who is serving the pre-signed url
+     */
+    public StorageAccessServiceFile(@Value("${sw.storage.fs-config.root-dir}") String rootDir,
+            @Value("${sw.storage.fs-config.service-provider}") String serviceProvider) {
         this.rootDir = new File(rootDir);
+        this.serviceProvider = serviceProvider;
         if (!this.rootDir.exists()) {
             throw new IllegalArgumentException(rootDir + " does not exist");
         }
@@ -133,5 +141,10 @@ public class StorageAccessServiceFile implements StorageAccessService {
                 }
             }
         }
+    }
+
+    @Override
+    public String signedUrl(String path, Long expTimeMillis) throws IOException {
+        return serviceProvider + "/" + path + "/" + (System.currentTimeMillis() + expTimeMillis);
     }
 }

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/aliyun/StorageAccessServiceAliyunTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/aliyun/StorageAccessServiceAliyunTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.aliyun;
+
+import ai.starwhale.mlops.storage.s3.S3Config;
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class StorageAccessServiceAliyunTest {
+    @Container
+    private static final S3MockContainer s3Mock =
+            new S3MockContainer(System.getProperty("s3mock.version", "latest"))
+                    .withValidKmsKeys("arn:aws:kms:us-east-1:1234567890:key/valid-test-key-ref")
+                    .withInitialBuckets("test");
+
+    private StorageAccessServiceAliyun aliyun;
+
+    @BeforeEach
+    public void setUp() {
+        aliyun = new StorageAccessServiceAliyun(S3Config.builder()
+                .bucket("test")
+                .accessKey("ak")
+                .secretKey("sk")
+                .region("us-west-1")
+                .endpoint(s3Mock.getHttpEndpoint())
+                .build());
+    }
+
+    @Test
+    public void testSignedUrl() throws IOException {
+        String path = "unit_test/x";
+        String content = "hello word";
+        aliyun.put(path, content.getBytes(StandardCharsets.UTF_8));
+        String signedUrl = aliyun.signedUrl(path, 1000 * 60L);
+        try (InputStream inputStream = new URL(signedUrl).openStream()) {
+            Assertions.assertEquals(content, new String(inputStream.readAllBytes()));
+        }
+    }
+
+
+}

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFileTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFileTest.java
@@ -19,6 +19,7 @@ package ai.starwhale.mlops.storage.fs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import ai.starwhale.mlops.storage.LengthAbleInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,6 +73,16 @@ public class StorageAccessServiceFileTest {
         service.put(path, content.getBytes(StandardCharsets.UTF_8));
         String signedUrl = service.signedUrl(path, 1000 * 60L);
         Assertions.assertTrue(signedUrl.startsWith("http://localhost:8082/unit_test/x"));
+    }
+
+    @Test
+    public void testRange() throws IOException {
+        String path = "unit_test/x";
+        String content = "hello word";
+        service.put(path, content.getBytes(StandardCharsets.UTF_8));
+        LengthAbleInputStream lengthAbleInputStream = service.get(path, 2L, 2L);
+        Assertions.assertEquals(2, lengthAbleInputStream.getSize());
+        Assertions.assertEquals("ll", new String(lengthAbleInputStream.readAllBytes()));
     }
 
 }

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFileTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFileTest.java
@@ -21,9 +21,12 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,7 +40,7 @@ public class StorageAccessServiceFileTest {
 
     @BeforeEach
     public void setUp() {
-        this.service = new StorageAccessServiceFile(this.rootDir.getAbsolutePath());
+        this.service = new StorageAccessServiceFile(this.rootDir.getAbsolutePath(), "http://localhost:8082");
     }
 
     @Test
@@ -60,6 +63,15 @@ public class StorageAccessServiceFileTest {
         this.service.delete("d/a");
         assertThat(this.rootDir.list(), is(new String[0]));
         assertThat(this.rootDir.exists(), is(true));
+    }
+
+    @Test
+    public void testSignedUrl() throws IOException {
+        String path = "unit_test/x";
+        String content = "hello word";
+        service.put(path, content.getBytes(StandardCharsets.UTF_8));
+        String signedUrl = service.signedUrl(path, 1000 * 60L);
+        Assertions.assertTrue(signedUrl.startsWith("http://localhost:8082/unit_test/x"));
     }
 
 }

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/minio/StorageAccessServiceMinioTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/minio/StorageAccessServiceMinioTest.java
@@ -21,6 +21,8 @@ import ai.starwhale.mlops.storage.StorageObjectInfo;
 import ai.starwhale.mlops.storage.s3.S3Config;
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -96,6 +98,17 @@ public class StorageAccessServiceMinioTest {
         minio.delete(path);
         objectInfo = minio.head(path);
         Assertions.assertFalse(objectInfo.isExists());
+    }
+
+    @Test
+    public void testSignedUrl() throws IOException {
+        String path = "unit_test/x";
+        String content = "hello word";
+        minio.put(path, content.getBytes(StandardCharsets.UTF_8));
+        String signedUrl = minio.signedUrl(path, 1000 * 60L);
+        try (InputStream inputStream = new URL(signedUrl).openStream()) {
+            Assertions.assertEquals(content, new String(inputStream.readAllBytes()));
+        }
     }
 
 

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/s3/StorageAccessServiceS3Test.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/s3/StorageAccessServiceS3Test.java
@@ -25,11 +25,14 @@ import static org.hamcrest.Matchers.is;
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
@@ -186,11 +189,19 @@ public class StorageAccessServiceS3Test {
         for (int i = 0; i < count; i++) {
             var path = prefix + "/" + i;
             expectedFiles.add(path);
-            s3.put(path, new byte[] {7});
+            s3.put(path, new byte[]{7});
         }
 
         var resp = s3.list(prefix + "/").collect(Collectors.toList());
         assertThat(resp.size(), is(count));
         assertThat(resp, containsInAnyOrder(expectedFiles.toArray()));
+    }
+
+    @Test
+    public void testSignedUrl() throws IOException {
+        String signedUrl = s3.signedUrl("t1", 1000 * 60L);
+        try (InputStream content = new URL(signedUrl).openStream()) {
+            Assertions.assertEquals("a", new String(content.readAllBytes()));
+        }
     }
 }


### PR DESCRIPTION
## Description
- use signed url instead of auth propagation in initContainers
- use signed url instead of auth propagation in client dataset
## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
