### PR TITLE
chore: allow `SW_PYPI_EXTRA_INDEX_URL` be override by env var

### DIFF
--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -15,9 +15,9 @@ file_exists() {
 }
 
 if in_github_action; then
-    export SW_PYPI_EXTRA_INDEX_URL='https://pypi.org/simple'
+    export SW_PYPI_EXTRA_INDEX_URL="${SW_PYPI_EXTRA_INDEX_URL:=https://pypi.org/simple}"
 else
-    export SW_PYPI_EXTRA_INDEX_URL='https://pypi.doubanio.com/simple/'
+    export SW_PYPI_EXTRA_INDEX_URL="${SW_PYPI_EXTRA_INDEX_URL:=https://pypi.doubanio.com/simple}"
     export PARENT_CLEAN="${PARENT_CLEAN:=true}"
 fi
 


### PR DESCRIPTION
## Description
allow `SW_PYPI_EXTRA_INDEX_URL` be override by env var
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
