### PR TITLE
feat(evaluation): support multi datasets

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -104,7 +104,7 @@ restore_activate_runtime() {
 
 run() {
     echo "--> start to run swmp ${STEP}, use $(which swcli) cli @ ${SWMP_DIR} ..."
-    swcli ${VERBOSE} model eval "${SWMP_DIR}"/src --dataset=${SW_DATASET_URI} --step=${STEP} --task-index=${TASK_INDEX} --override-task-num=${TASK_NUM} --version=${SW_EVALUATION_VERSION} || exit 1
+    swcli ${VERBOSE} model eval "${SWMP_DIR}"/src --step=${STEP} --task-index=${TASK_INDEX} --override-task-num=${TASK_NUM} --version=${SW_EVALUATION_VERSION} || exit 1
 }
 
 welcome() {

--- a/client/starwhale/core/eval/cli.py
+++ b/client/starwhale/core/eval/cli.py
@@ -61,9 +61,11 @@ def _list(
 @click.option("--model", required=True, help="model uri or model.yaml dir path")
 # TODO:support multi dataset
 @click.option(
+    "datasets",
     "--dataset",
     required=True,
     envvar=SWEnv.dataset_uri,
+    multiple=True,
     help=f"dataset uri, env is {SWEnv.dataset_uri}",
 )
 @click.option("--runtime", default="", help="runtime uri")
@@ -93,7 +95,7 @@ def _run(
     project: str,
     version: str,
     model: str,
-    dataset: str,
+    datasets: list,
     runtime: str,
     name: str,
     desc: str,
@@ -109,7 +111,7 @@ def _run(
         project_uri=project,
         version=version,
         model_uri=model,
-        dataset_uris=[dataset],
+        dataset_uris=datasets,
         runtime_uri=runtime,
         name=name,
         desc=desc,

--- a/client/starwhale/core/eval/executor.py
+++ b/client/starwhale/core/eval/executor.py
@@ -236,7 +236,12 @@ class EvalExecutor:
             ]
         )
         # TODO: support multi dataset
-        cmd.extend(["-e", f"{SWEnv.dataset_uri}={self.dataset_uris[0].full_uri}"])
+        cmd.extend(
+            [
+                "-e",
+                f"{SWEnv.dataset_uri}={' '.join([ds.full_uri for ds in self.dataset_uris])}",
+            ]
+        )
 
         cntr_cache_dir = os.environ.get("SW_PIP_CACHE_DIR", CNTR_DEFAULT_PIP_CACHE_DIR)
         host_cache_dir = os.path.expanduser("~/.cache/starwhale-pip")

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -156,9 +156,11 @@ def _extract(model: str, force: bool, target_dir: str) -> None:
 )
 @click.option("--runtime", default="", help="runtime uri")
 @click.option(
+    "datasets",
     "--dataset",
     required=True,
     envvar=SWEnv.dataset_uri,
+    multiple=True,
     help=f"dataset uri, env is {SWEnv.dataset_uri}",
 )
 def _eval(
@@ -166,7 +168,7 @@ def _eval(
     target: str,
     model_yaml: str,
     version: str,
-    dataset: str,
+    datasets: list,
     step: str,
     task_index: int,
     override_task_num: int,
@@ -186,5 +188,5 @@ def _eval(
         step=step,
         task_index=task_index,
         task_num=override_task_num,
-        dataset_uris=[dataset],
+        dataset_uris=datasets,
     )

--- a/scripts/client_test/cmds/eval_cmd.py
+++ b/scripts/client_test/cmds/eval_cmd.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, List
 
 from . import CLI
 from .base.invoke import invoke
@@ -11,7 +11,7 @@ class Evaluation:
     def run(
         self,
         model: str,
-        dataset: str,
+        datasets: List[str],
         project: str = "self",
         version: str = "",
         runtime: str = "",
@@ -28,7 +28,7 @@ class Evaluation:
         :param project:
         :param version: Evaluation job version
         :param model: model uri or model.yaml dir path  [required]
-        :param dataset: dataset uri, one or more  [required]
+        :param datasets: dataset uri, one or more  [required]
         :param runtime: runtime uri
         :param name: job name
         :param desc: job description
@@ -40,7 +40,9 @@ class Evaluation:
         :param resource_pool: [ONLY Cloud] which nodes should job run on
         :return:
         """
-        _args = [CLI, self._cmd, "run", "--model", model, "--dataset", dataset]
+        _args = [CLI, self._cmd, "run", "--model", model]
+        for ds in datasets:
+            _args.extend(["--dataset", ds])
         if version:
             _args.extend(["--version", version])
         if runtime:

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
@@ -19,6 +19,8 @@ package ai.starwhale.mlops.domain.dataset.dataloader;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 import ai.starwhale.mlops.api.protocol.dataset.dataloader.DataIndexDesc;
+import ai.starwhale.mlops.common.KeyLock;
+import ai.starwhale.mlops.domain.dataset.DatasetService;
 import ai.starwhale.mlops.domain.dataset.dataloader.bo.DataIndex;
 import ai.starwhale.mlops.domain.dataset.dataloader.bo.DataReadLog;
 import ai.starwhale.mlops.domain.dataset.dataloader.bo.Session;
@@ -53,39 +55,45 @@ public class DataReadManager {
     }
 
     @Transactional(propagation = REQUIRES_NEW)
-    DataReadLog getDataReadIndex(DataReadRequest request) {
+    Session getOrGenerateSession(DataReadRequest request) {
         var sessionId = request.getSessionId();
-        var consumerId = request.getConsumerId();
-
-        var session = sessionDao.selectById(sessionId);
-        if (session == null) {
-            session = Session.builder()
-                    .id(sessionId)
-                    .datasetName(request.getDatasetName())
-                    .datasetVersion(request.getDatasetVersion())
-                    .tableName(request.getTableName())
-                    .start(request.getStart())
-                    .startInclusive(request.isStartInclusive())
-                    .end(request.getEnd())
-                    .endInclusive(request.isEndInclusive())
-                    .batchSize(request.getBatchSize())
-                    .build();
-            // get data index
-            List<DataIndex> dataIndices = dataIndexProvider.returnDataIndex(
-                    QueryDataIndexRequest.builder()
-                        .tableName(session.getTableName())
-                        .batchSize(session.getBatchSize())
-                        .start(session.getStart())
-                        .startInclusive(session.isStartInclusive())
-                        .end(session.getEnd())
-                        .endInclusive(session.isEndInclusive())
-                        .build()
-            );
-
-            Iterables.partition(
-                dataIndices.stream()
-                    .map(dataIndex -> DataReadLog.builder()
-                            .sessionId(sessionId)
+        var datasetName = request.getDatasetName();
+        var datasetVersion = request.getDatasetVersion();
+        // ensure serially in the same session
+        var sessionLock = new KeyLock<>(String.format("%s-%s-%s", sessionId, datasetName, datasetVersion));
+        try {
+            sessionLock.lock();
+            var session = sessionDao.selectOne(sessionId, datasetName, datasetVersion);
+            if (session == null) {
+                session = Session.builder()
+                        .sessionId(sessionId)
+                        .datasetName(request.getDatasetName())
+                        .datasetVersion(request.getDatasetVersion())
+                        .tableName(request.getTableName())
+                        .start(request.getStart())
+                        .startInclusive(request.isStartInclusive())
+                        .end(request.getEnd())
+                        .endInclusive(request.isEndInclusive())
+                        .batchSize(request.getBatchSize())
+                        .build();
+                // insert session
+                sessionDao.insert(session);
+                // get data index
+                List<DataIndex> dataIndices = dataIndexProvider.returnDataIndex(
+                        QueryDataIndexRequest.builder()
+                            .tableName(session.getTableName())
+                            .batchSize(session.getBatchSize())
+                            .start(session.getStart())
+                            .startInclusive(session.isStartInclusive())
+                            .end(session.getEnd())
+                            .endInclusive(session.isEndInclusive())
+                            .build()
+                );
+                Long sid = session.getId();
+                Iterables.partition(
+                    dataIndices.stream()
+                        .map(dataIndex -> DataReadLog.builder()
+                            .sessionId(sid)
                             .start(dataIndex.getStart())
                             .startInclusive(dataIndex.isStartInclusive())
                             .end(dataIndex.getEnd())
@@ -93,46 +101,70 @@ public class DataReadManager {
                             .size(dataIndex.getSize())
                             .status(Status.DataStatus.UNPROCESSED)
                             .build())
-                    .collect(Collectors.toList()),
-                1000).forEach(dataReadLogDao::batchInsert);
+                        .collect(Collectors.toList()),
+                    1000).forEach(dataReadLogDao::batchInsert);
 
-            // insert session
-            sessionDao.insert(session);
-        }
-        // get first
-        var dataRange = dataReadLogDao.selectTop1UnAssignedData(sessionId);
-
-        if (Objects.isNull(dataRange)) {
-            // find timeout data to consume
-            var maxProcessedTime = dataReadLogDao.getMaxProcessedMicrosecondTime(sessionId);
-            dataRange = dataReadLogDao.selectTop1TimeoutData(
-                    sessionId, maxProcessedTime * timeoutTolerance);
+            }
+            return session;
+        } finally {
+            sessionLock.unlock();
         }
 
-        if (Objects.nonNull(dataRange)) {
-            dataRange.setConsumerId(consumerId);
-            dataReadLogDao.updateToAssigned(dataRange);
-        }
-        return dataRange;
     }
 
     @Transactional(propagation = REQUIRES_NEW)
-    void handleConsumerData(DataReadRequest request) {
-        var sessionId = request.getSessionId();
-        var consumerId = request.getConsumerId();
-        var processedData = request.getProcessedData();
+    DataReadLog assignmentData(String consumerId, Session session) {
+        var sid = session.getId();
 
-        // update processed data
-        if (CollectionUtils.isNotEmpty(processedData)) {
-            for (DataIndexDesc indexDesc : processedData) {
-                dataReadLogDao.updateToProcessed(
-                        sessionId, consumerId, indexDesc.getStart(), indexDesc.getEnd());
+        var sessionId = session.getSessionId();
+        var datasetName = session.getDatasetName();
+        var datasetVersion = session.getDatasetVersion();
+        // ensure serially in the same session
+        var sessionLock = new KeyLock<>(String.format("%s-%s-%s", sessionId, datasetName, datasetVersion));
+        try {
+            sessionLock.lock();
+            // get first
+            var dataRange = dataReadLogDao.selectTop1UnAssignedData(sid);
+
+            if (Objects.isNull(dataRange)) {
+                // find timeout data to consume
+                var maxProcessedTime = dataReadLogDao.getMaxProcessedMicrosecondTime(sid);
+                dataRange = dataReadLogDao.selectTop1TimeoutData(
+                    sid, maxProcessedTime * timeoutTolerance);
             }
+
+            if (Objects.nonNull(dataRange)) {
+                dataRange.setConsumerId(consumerId);
+                dataReadLogDao.updateToAssigned(dataRange);
+            }
+            return dataRange;
+        } finally {
+            sessionLock.unlock();
         }
-        // Whether to process serially under the same consumer,
-        // if serial is true, unassigned the previous unprocessed data
-        if (request.isSerial()) {
-            dataReadLogDao.updateUnProcessedToUnAssigned(consumerId);
+
+    }
+
+    @Transactional(propagation = REQUIRES_NEW)
+    void handleConsumerData(String consumerId, boolean isSerial, List<DataIndexDesc> processedData, Session session) {
+        var sid = session.getId();
+        var lock = new KeyLock<>(consumerId);
+        try {
+            lock.lock();
+            // update processed data
+            if (CollectionUtils.isNotEmpty(processedData)) {
+                for (DataIndexDesc indexDesc : processedData) {
+                    dataReadLogDao.updateToProcessed(
+                            sid, consumerId, indexDesc.getStart(), indexDesc.getEnd());
+                }
+                // Whether to process serially under the same consumer,
+                // if serial is true, unassigned the previous unprocessed data
+                if (isSerial) {
+                    dataReadLogDao.updateUnProcessedToUnAssigned(sid, consumerId);
+                }
+            }
+        } finally {
+            lock.unlock();
         }
+
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/bo/DataReadLog.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/bo/DataReadLog.java
@@ -26,7 +26,7 @@ import lombok.Data;
 public class DataReadLog {
 
     private Long id;
-    private String sessionId;
+    private Long sessionId;
     private String consumerId;
     private String start;
     @Builder.Default

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/converter/SessionConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/converter/SessionConverter.java
@@ -29,6 +29,7 @@ public class SessionConverter implements Convertor<Session, SessionEntity> {
     public SessionEntity convert(Session session) throws ConvertException {
         return SessionEntity.builder()
             .id(session.getId())
+            .sessionId(session.getSessionId())
             .batchSize(session.getBatchSize())
             .datasetName(session.getDatasetName())
             .datasetVersion(session.getDatasetVersion())
@@ -45,6 +46,7 @@ public class SessionConverter implements Convertor<Session, SessionEntity> {
     public Session revert(SessionEntity session) throws ConvertException {
         return Session.builder()
             .id(session.getId())
+            .sessionId(session.getSessionId())
             .batchSize(session.getBatchSize())
             .datasetName(session.getDatasetName())
             .datasetVersion(session.getDatasetVersion())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/dao/DataReadLogDao.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/dao/DataReadLogDao.java
@@ -53,26 +53,26 @@ public class DataReadLogDao {
         return mapper.updateToAssigned(converter.convert(dataReadLog)) > 0;
     }
 
-    public boolean updateToProcessed(String sessionId, String consumerId, String start, String end) {
-        return mapper.updateToProcessed(sessionId, consumerId, start, end,
+    public boolean updateToProcessed(Long sid, String consumerId, String start, String end) {
+        return mapper.updateToProcessed(sid, consumerId, start, end,
                 Status.DataStatus.PROCESSED.name()) > 0;
     }
 
-    public boolean updateUnProcessedToUnAssigned(String consumerId) {
-        return mapper.updateToUnAssigned(consumerId, Status.DataStatus.UNPROCESSED.name()) > 0;
+    public boolean updateUnProcessedToUnAssigned(Long sid, String consumerId) {
+        return mapper.updateToUnAssigned(sid, consumerId, Status.DataStatus.UNPROCESSED.name()) > 0;
     }
 
-    public DataReadLog selectTop1UnAssignedData(String sessionId) {
-        var entity = mapper.selectTop1UnAssigned(sessionId, Status.DataStatus.UNPROCESSED.name());
+    public DataReadLog selectTop1UnAssignedData(Long sid) {
+        var entity = mapper.selectTop1UnAssigned(sid, Status.DataStatus.UNPROCESSED.name());
         return entity == null ? null : converter.revert(entity);
     }
 
-    public DataReadLog selectTop1TimeoutData(String sessionId, long secondTimeout) {
-        var entity = mapper.selectTop1TimeoutData(sessionId, Status.DataStatus.UNPROCESSED.name(), secondTimeout);
+    public DataReadLog selectTop1TimeoutData(Long sid, long secondTimeout) {
+        var entity = mapper.selectTop1TimeoutData(sid, Status.DataStatus.UNPROCESSED.name(), secondTimeout);
         return entity == null ? null : converter.revert(entity);
     }
 
-    public long getMaxProcessedMicrosecondTime(String sessionId) {
-        return mapper.selectMaxProcessedMicrosecondTime(sessionId, Status.DataStatus.PROCESSED.name());
+    public long getMaxProcessedMicrosecondTime(Long sid) {
+        return mapper.selectMaxProcessedMicrosecondTime(sid, Status.DataStatus.PROCESSED.name());
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/dao/SessionDao.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/dao/SessionDao.java
@@ -34,11 +34,14 @@ public class SessionDao {
     }
 
     public boolean insert(Session session) {
-        return mapper.insert(converter.convert(session)) > 0;
+        var entity = converter.convert(session);
+        var rows = mapper.insert(entity);
+        session.setId(entity.getId());
+        return rows > 0;
     }
 
-    public Session selectById(String sessionId) {
-        var entity = mapper.selectById(sessionId);
+    public Session selectOne(String sessionId, String datasetName, String datasetVersion) {
+        var entity = mapper.selectOne(sessionId, datasetName, datasetVersion);
         return entity != null ? converter.revert(entity) : null;
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/mapper/SessionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/mapper/SessionMapper.java
@@ -28,19 +28,20 @@ public interface SessionMapper {
 
     @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
     @Insert("INSERT into dataset_read_session ("
-            + "id, batch_size, dataset_name, dataset_version, table_name, "
+            + "session_id, batch_size, dataset_name, dataset_version, table_name, "
             + "start, start_inclusive, end, end_inclusive) "
             + "VALUES("
-            + "#{id}, #{batchSize}, #{datasetName}, #{datasetVersion}, #{tableName}, "
+            + "#{sessionId}, #{batchSize}, #{datasetName}, #{datasetVersion}, #{tableName}, "
             + "#{start}, #{startInclusive}, #{end}, #{endInclusive}) "
             )
     int insert(SessionEntity session);
 
-    @Select("SELECT * from dataset_read_session WHERE id=#{id}")
-    SessionEntity selectById(String id);
+    @Select("SELECT * from dataset_read_session "
+            + "WHERE session_id=#{sessionId} and dataset_name=#{datasetName} and dataset_version=#{datasetVersion}")
+    SessionEntity selectOne(String sessionId, String datasetName, String datasetVersion);
 
     @Select("SELECT * from dataset_read_session WHERE id=#{id} FOR UPDATE")
-    SessionEntity selectForUpdate(String id);
+    SessionEntity selectForUpdate(Long id);
 
     @Select("SELECT * from dataset_read_session")
     List<SessionEntity> select();

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/po/DataReadLogEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/po/DataReadLogEntity.java
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DataReadLogEntity {
     private Long id;
-    private String sessionId;
+    private Long sessionId;
     private String consumerId;
 
     private String start;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/po/SessionEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/po/SessionEntity.java
@@ -28,7 +28,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SessionEntity {
-    private String id;
+    private Long id;
+    private String sessionId;
     private int batchSize;
     private String datasetName;
     private String datasetVersion;

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
@@ -175,12 +175,16 @@ public class K8sTaskScheduler implements SwTaskScheduler {
         Map<String, String> coreContainerEnvs = new HashMap<>();
         coreContainerEnvs.put("SW_TASK_STEP", task.getStep().getName());
         coreContainerEnvs.put("DATASET_CONSUMPTION_BATCH_SIZE", String.valueOf(datasetLoadBatchSize));
-        // TODO: support multi dataset uris
-        // oss env
-        List<DataSet> dataSets = swJob.getDataSets();
-        DataSet dataSet = dataSets.get(0);
-        coreContainerEnvs.put("SW_DATASET_URI", String.format(FORMATTER_URI_DATASET, instanceUri,
-                swJob.getProject().getName(), dataSet.getName(), dataSet.getVersion()));
+        // support multi dataset uris
+        var datasetUri = swJob.getDataSets().stream()
+                    .map(dataSet -> String.format(
+                            FORMATTER_URI_DATASET,
+                            instanceUri,
+                            swJob.getProject().getName(),
+                            dataSet.getName(),
+                            dataSet.getVersion())
+                    ).collect(Collectors.joining(" "));
+        coreContainerEnvs.put("SW_DATASET_URI", datasetUri);
         coreContainerEnvs.put("SW_TASK_INDEX", String.valueOf(task.getTaskRequest().getIndex()));
         coreContainerEnvs.put("SW_TASK_NUM", String.valueOf(task.getTaskRequest().getTotal()));
         coreContainerEnvs.put("SW_EVALUATION_VERSION", swJob.getUuid());

--- a/server/controller/src/main/resources/db/migration/V00031__Mod_dataset_reader.sql
+++ b/server/controller/src/main/resources/db/migration/V00031__Mod_dataset_reader.sql
@@ -13,29 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+TRUNCATE TABLE dataset_read_session;
+ALTER TABLE dataset_read_session MODIFY COLUMN id BIGINT auto_increment NOT NULL COMMENT 'PK';
+ALTER TABLE dataset_read_session ADD session_id varchar(255) NOT NULL;
+ALTER TABLE dataset_read_session ADD CONSTRAINT dataset_read_session_UN UNIQUE KEY (session_id,dataset_name,dataset_version);
 
-package ai.starwhale.mlops.domain.dataset.dataloader.bo;
-
-import java.util.Date;
-import lombok.Builder;
-import lombok.Data;
-
-@Data
-@Builder
-public class Session {
-    private Long id;
-    private String sessionId;
-    private int batchSize;
-    private String tableName;
-    private String datasetName;
-    private String datasetVersion;
-
-    private String start;
-    @Builder.Default
-    private boolean startInclusive = true;
-    private String end;
-    private boolean endInclusive;
-
-    @Builder.Default
-    private Date createdTime = new Date(-1);
-}
+TRUNCATE TABLE dataset_read_log;
+ALTER TABLE dataset_read_log DROP KEY session_readrange;
+ALTER TABLE dataset_read_log MODIFY COLUMN session_id BIGINT NOT NULL;
+ALTER TABLE dataset_read_log ADD CONSTRAINT dataset_read_log_UK UNIQUE KEY (session_id,`start`,`end`);


### PR DESCRIPTION
## Description

1. sever: Support multi datasets, the model's relation are as below:
session -> consumer -> dataset
     1        :         n         :       m
2. client: In order to ensure the uniqueness of data under multiple datasets, add uri as prefix for data id/index
![image](https://user-images.githubusercontent.com/24869618/202372816-ae49d79c-69fc-4ba4-9294-f9962f1e72e9.png)

4. client: add multi dataset parm for the cmd  "swcli eval run" and "swcli model eval" 


## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
