### PR TITLE
fix(docker): yq in entrypoint can not find after global py version changes

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -78,7 +78,8 @@ pre_check() {
 }
 
 set_python() {
-    _MANIFEST_RUNTIME=$(yq -r .environment.python ${SWRT_DIR}/_manifest.yaml) || exit 1
+	# yq only installed for py3.8
+    _MANIFEST_RUNTIME=$(python3.8 yq -r .environment.python ${SWRT_DIR}/_manifest.yaml) || exit 1
     _RUNTIME="python${_MANIFEST_RUNTIME}"
 
     echo "**** DETECT RUNTIME: ${_RUNTIME}"


### PR DESCRIPTION
## Description
`yq` in entrypoint can not find after global py version changes

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
