### PR TITLE
feat(dataset): sign data uris in batch

### DIFF
--- a/client/starwhale/api/_impl/dataset/builder.py
+++ b/client/starwhale/api/_impl/dataset/builder.py
@@ -238,7 +238,7 @@ class SWDSBinBuildExecutor(BaseBuildExecutor):
             self.tabular_dataset.put(
                 TabularDatasetRow(
                     id=idx,
-                    data_uri=str(fno),
+                    data_uri=Link(str(fno)),
                     data_format=self.data_format_type,
                     object_store_type=ObjectStoreType.LOCAL,
                     data_offset=_bin_section.raw_data_offset,
@@ -411,7 +411,7 @@ class UserRawBuildExecutor(BaseBuildExecutor):
             self.tabular_dataset.put(
                 TabularDatasetRow(
                     id=idx,
-                    data_uri=data_uri,
+                    data_uri=Link(data_uri),
                     data_format=self.data_format_type,
                     object_store_type=object_store_type,
                     data_offset=row_data.offset,

--- a/client/starwhale/api/_impl/dataset/builder.py
+++ b/client/starwhale/api/_impl/dataset/builder.py
@@ -238,7 +238,7 @@ class SWDSBinBuildExecutor(BaseBuildExecutor):
             self.tabular_dataset.put(
                 TabularDatasetRow(
                     id=idx,
-                    data_uri=Link(str(fno)),
+                    data_link=Link(str(fno)),
                     data_format=self.data_format_type,
                     object_store_type=ObjectStoreType.LOCAL,
                     data_offset=_bin_section.raw_data_offset,
@@ -317,11 +317,11 @@ class SWDSBinBuildExecutor(BaseBuildExecutor):
 
         # TODO: tune performance scan after put in a second
         for row in self.tabular_dataset.scan():
-            if row.data_uri.uri not in map_fno_sign:
+            if row.data_link.uri not in map_fno_sign:
                 continue
 
             self.tabular_dataset.update(
-                row_id=row.id, data_uri=Link(map_fno_sign[row.data_uri.uri])
+                row_id=row.id, data_link=Link(map_fno_sign[row.data_link.uri])
             )
 
 
@@ -411,7 +411,7 @@ class UserRawBuildExecutor(BaseBuildExecutor):
             self.tabular_dataset.put(
                 TabularDatasetRow(
                     id=idx,
-                    data_uri=Link(data_uri),
+                    data_link=Link(data_uri),
                     data_format=self.data_format_type,
                     object_store_type=object_store_type,
                     data_offset=row_data.offset,

--- a/client/starwhale/api/_impl/dataset/builder.py
+++ b/client/starwhale/api/_impl/dataset/builder.py
@@ -317,11 +317,11 @@ class SWDSBinBuildExecutor(BaseBuildExecutor):
 
         # TODO: tune performance scan after put in a second
         for row in self.tabular_dataset.scan():
-            if row.data_uri not in map_fno_sign:
+            if row.data_uri.uri not in map_fno_sign:
                 continue
 
             self.tabular_dataset.update(
-                row_id=row.id, data_uri=map_fno_sign[row.data_uri]
+                row_id=row.id, data_uri=Link(map_fno_sign[row.data_uri.uri])
             )
 
 

--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -115,15 +115,15 @@ class DataLoader(metaclass=ABCMeta):
                     CloudRequestMixed()
                     .do_http_request(
                         f"/project/{self.dataset_uri.project}/{self.dataset_uri.object.typ}/{self.dataset_uri.object.name}/version/{self.dataset_uri.object.version}/sign-links",
-                        method=HTTPMethod.GET,
+                        method=HTTPMethod.POST,
                         instance_uri=self.dataset_uri,
                         params={
-                            "uris": uris,
                             "expTimeMillis": int(
-                                os.environ.get("SW_MODEL_UNIT_TIME", "60000")
+                                os.environ.get("SW_MODEL_PROCESS_UNIT_TIME_MILLIS", "60000")
                             )
                             * self.session_consumption.batch_size,  # type: ignore
                         },
+                        json=uris,
                         use_raise=True,
                     )
                     .json()

--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -119,7 +119,9 @@ class DataLoader(metaclass=ABCMeta):
                         instance_uri=self.dataset_uri,
                         params={
                             "expTimeMillis": int(
-                                os.environ.get("SW_MODEL_PROCESS_UNIT_TIME_MILLIS", "60000")
+                                os.environ.get(
+                                    "SW_MODEL_PROCESS_UNIT_TIME_MILLIS", "60000"
+                                )
                             )
                             * self.session_consumption.batch_size,  # type: ignore
                         },

--- a/client/starwhale/core/dataset/store.py
+++ b/client/starwhale/core/dataset/store.py
@@ -14,9 +14,9 @@ import boto3
 import requests
 from loguru import logger
 from botocore.client import Config as S3Config
+from starwhale.core.dataset.type import Link
 from typing_extensions import Protocol
 
-from starwhale import Link
 from starwhale.consts import (
     HTTPMethod,
     SWDSBackendType,
@@ -295,15 +295,14 @@ class ObjectStore:
         return f"ObjectStored:{self.backend}, bucket:{self.bucket}, key_prefix:{self.key_prefix}"
 
     @classmethod
-    def from_data_link_uri(cls, data_uri: str, auth_name: str) -> ObjectStore:
-        data_uri = data_uri.strip()
+    def from_data_link_uri(cls, data_uri: Link, auth_name: str) -> ObjectStore:
         if not data_uri:
             raise FieldTypeOrValueError("data_uri is empty")
 
         # TODO: support other uri type
-        if data_uri.startswith("s3://"):
+        if data_uri.uri.startswith("s3://"):
             backend = SWDSBackendType.S3
-            conn = S3Connection.from_uri(data_uri, auth_name)
+            conn = S3Connection.from_uri(data_uri.uri, auth_name)
             bucket = conn.bucket
         else:
             backend = SWDSBackendType.LocalFS

--- a/client/starwhale/core/dataset/store.py
+++ b/client/starwhale/core/dataset/store.py
@@ -270,7 +270,7 @@ class ObjectStore:
     def __init__(
         self,
         backend: str,
-        bucket: str,
+        bucket: str = "",
         dataset_uri: URI = URI(""),
         key_prefix: str = "",
         **kw: t.Any,

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -240,6 +240,21 @@ class TabularDataset:
                 _d[k] = v(_d[k])
             yield TabularDatasetRow.from_datastore(**_d)
 
+    def scan_btch(
+        self,
+        start: t.Optional[t.Any] = None,
+        end: t.Optional[t.Any] = None,
+        batch_size: int = 32,
+    ) -> t.Generator[TabularDatasetRow, None, None]:
+        batch = []
+        for r in self.scan(start, end):
+            batch.append(r)
+            if len(batch) % batch_size == 0:
+                yield batch
+                batch = []
+        if len(batch):
+            yield batch
+
     def close(self) -> None:
         self._ds_wrapper.close()
 

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -49,7 +49,7 @@ class TabularDatasetRow(ASDictMixin):
     def __init__(
         self,
         id: t.Union[str, int],
-        data_uri: Link,
+        data_link: Link,
         data_format: DataFormatType = DataFormatType.SWDS_BIN,
         object_store_type: ObjectStoreType = ObjectStoreType.LOCAL,
         data_offset: int = 0,
@@ -61,7 +61,7 @@ class TabularDatasetRow(ASDictMixin):
         **kw: t.Union[str, int, float],
     ) -> None:
         self.id = id
-        self.data_uri = data_uri
+        self.data_link = data_link
         self.data_format = data_format
         self.data_offset = data_offset
         self.data_size = data_size
@@ -79,7 +79,7 @@ class TabularDatasetRow(ASDictMixin):
     def from_datastore(
         cls,
         id: t.Union[str, int],
-        data_uri: Link,
+        data_link: Link,
         data_format: str = DataFormatType.SWDS_BIN.value,
         object_store_type: str = ObjectStoreType.LOCAL.value,
         data_offset: int = 0,
@@ -100,7 +100,7 @@ class TabularDatasetRow(ASDictMixin):
 
         return cls(
             id=id,
-            data_uri=data_uri,
+            data_link=data_link,
             data_format=DataFormatType(data_format),
             object_store_type=ObjectStoreType(object_store_type),
             data_offset=data_offset,
@@ -132,8 +132,8 @@ class TabularDatasetRow(ASDictMixin):
 
         # TODO: add annotation items type check
 
-        if not self.data_uri:
-            raise FieldTypeOrValueError("no raw_data_uri field")
+        if not self.data_link:
+            raise FieldTypeOrValueError("no raw_data_link field")
 
         if not isinstance(self.data_format, DataFormatType):
             raise NoSupportError(f"data format: {self.data_format}")
@@ -145,11 +145,11 @@ class TabularDatasetRow(ASDictMixin):
             raise NoSupportError(f"object store {self.object_store_type}")
 
     def __str__(self) -> str:
-        return f"row-{self.id}, data-{self.data_uri}, origin-[{self.data_origin}]"
+        return f"row-{self.id}, data-{self.data_link}, origin-[{self.data_origin}]"
 
     def __repr__(self) -> str:
         return (
-            f"row-{self.id}, data-{self.data_uri}(offset:{self.data_offset}, size:{self.data_size},"
+            f"row-{self.id}, data-{self.data_link}(offset:{self.data_offset}, size:{self.data_size},"
             f"format:{self.data_format}, meta type:{self.data_type}), "
             f"origin-[{self.data_origin}], object store-{self.object_store_type}"
         )
@@ -157,7 +157,7 @@ class TabularDatasetRow(ASDictMixin):
     def asdict(self, ignore_keys: t.Optional[t.List[str]] = None) -> t.Dict:
         d = super().asdict(
             ignore_keys=ignore_keys
-            or ["annotations", "extra_kw", "data_type", "data_uri"]
+            or ["annotations", "extra_kw", "data_type", "data_link"]
         )
         d.update(_do_asdict_convert(self.extra_kw))
         for k, v in self.annotations.items():
@@ -166,7 +166,7 @@ class TabularDatasetRow(ASDictMixin):
         d["data_type"] = json.dumps(
             _do_asdict_convert(self.data_type), separators=(",", ":")
         )
-        d["data_uri"] = self.data_uri
+        d["data_link"] = self.data_link
         return d
 
 
@@ -245,7 +245,7 @@ class TabularDataset:
                 _d[k] = v(_d[k])
             yield TabularDatasetRow.from_datastore(**_d)
 
-    def scan_btch(
+    def scan_batch(
         self,
         start: t.Optional[t.Any] = None,
         end: t.Optional[t.Any] = None,
@@ -257,7 +257,7 @@ class TabularDataset:
             if len(batch) % batch_size == 0:
                 yield batch
                 batch = []
-        if len(batch):
+        if batch:
             yield batch
 
     def close(self) -> None:

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -13,9 +13,9 @@ from collections import defaultdict
 
 import requests
 from loguru import logger
+from starwhale.core.dataset.type import Link
 from typing_extensions import Protocol
 
-from starwhale import Link
 from starwhale.utils import validate_obj_name
 from starwhale.consts import ENV_POD_NAME, VERSION_PREFIX_CNT, STANDALONE_INSTANCE
 from starwhale.base.uri import URI
@@ -156,7 +156,7 @@ class TabularDatasetRow(ASDictMixin):
 
     def asdict(self, ignore_keys: t.Optional[t.List[str]] = None) -> t.Dict:
         d = super().asdict(
-            ignore_keys=ignore_keys or ["annotations", "extra_kw", "data_type"]
+            ignore_keys=ignore_keys or ["annotations", "extra_kw", "data_type", "data_uri"]
         )
         d.update(_do_asdict_convert(self.extra_kw))
         for k, v in self.annotations.items():
@@ -165,6 +165,7 @@ class TabularDatasetRow(ASDictMixin):
         d["data_type"] = json.dumps(
             _do_asdict_convert(self.data_type), separators=(",", ":")
         )
+        d["data_uri"] = self.data_uri
         return d
 
 

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -323,6 +323,8 @@ class _RunEnvType(Enum):
 
 
 class TabularDatasetSessionConsumption(Protocol):
+    batch_size: int
+
     def get_scan_range(
         self, processed_keys: t.Optional[t.List[t.Tuple[t.Any, t.Any]]] = None
     ) -> t.Optional[t.Tuple[t.Any, t.Any]]:

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -15,6 +15,7 @@ import requests
 from loguru import logger
 from typing_extensions import Protocol
 
+from starwhale import Link
 from starwhale.utils import validate_obj_name
 from starwhale.consts import ENV_POD_NAME, VERSION_PREFIX_CNT, STANDALONE_INSTANCE
 from starwhale.base.uri import URI
@@ -48,7 +49,7 @@ class TabularDatasetRow(ASDictMixin):
     def __init__(
         self,
         id: t.Union[str, int],
-        data_uri: str,
+        data_uri: Link,
         data_format: DataFormatType = DataFormatType.SWDS_BIN,
         object_store_type: ObjectStoreType = ObjectStoreType.LOCAL,
         data_offset: int = 0,
@@ -60,7 +61,7 @@ class TabularDatasetRow(ASDictMixin):
         **kw: t.Union[str, int, float],
     ) -> None:
         self.id = id
-        self.data_uri = data_uri.strip()
+        self.data_uri = data_uri
         self.data_format = data_format
         self.data_offset = data_offset
         self.data_size = data_size
@@ -78,7 +79,7 @@ class TabularDatasetRow(ASDictMixin):
     def from_datastore(
         cls,
         id: t.Union[str, int],
-        data_uri: str,
+        data_uri: Link,
         data_format: str = DataFormatType.SWDS_BIN.value,
         object_store_type: str = ObjectStoreType.LOCAL.value,
         data_offset: int = 0,

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -554,7 +554,8 @@ class Link(ASDictMixin, SwObject):
 
         auth_name = self.auth.name if self.auth else ""
         if dataset_uri.instance_type == InstanceType.CLOUD:
-            store = ObjectStore.to_signed_http_backend(dataset_uri, auth_name)
+            key_compose = self, 0, 0
+            store = ObjectStore.to_signed_http_backend(dataset_uri)
         else:
             r = urlparse(self.uri)
             if r.scheme:

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -23,9 +23,8 @@ from starwhale.utils.fs import FilePosition
 from starwhale.base.type import URIType, InstanceType
 from starwhale.base.mixin import ASDictMixin
 from starwhale.utils.error import NoSupportError, FieldTypeOrValueError
+from starwhale.utils.retry import http_retry
 from starwhale.api._impl.data_store import SwObject
-
-from ...utils.retry import http_retry
 
 D_FILE_VOLUME_SIZE = 64 * 1024 * 1024  # 64MB
 D_ALIGNMENT_SIZE = 4 * 1024  # 4k for page cache

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -515,8 +515,7 @@ class Link(ASDictMixin, SwObject):
 
     @local_fs_uri.setter
     def local_fs_uri(self, value: str) -> None:
-        self._local_fs_uri = value\
-
+        self._local_fs_uri = value
 
     @property
     def signed_uri(self) -> str:
@@ -545,6 +544,7 @@ class Link(ASDictMixin, SwObject):
     @http_retry
     def to_bytes(self, dataset_uri: t.Union[str, URI]) -> bytes:
         from .store import ObjectStore
+
         if self.signed_uri:
             r = requests.get(self.signed_uri, timeout=10)
             return r.content
@@ -557,14 +557,21 @@ class Link(ASDictMixin, SwObject):
             key_compose = self, 0, 0
             store = ObjectStore.to_signed_http_backend(dataset_uri)
         else:
-            r = urlparse(self.uri)
-            if r.scheme:
-                key_compose = Link(self.local_fs_uri) if self.local_fs_uri else self, 0, 0
+            _up = urlparse(self.uri)
+            if _up.scheme:
+                key_compose = (
+                    Link(self.local_fs_uri) if self.local_fs_uri else self,
+                    0,
+                    0,
+                )
                 store = ObjectStore.from_data_link_uri(key_compose[0], auth_name)
             else:
-                key_compose = Link(self.local_fs_uri) if self.local_fs_uri else self, 0, -2
+                key_compose = (
+                    Link(self.local_fs_uri) if self.local_fs_uri else self,
+                    0,
+                    -2,
+                )
                 store = ObjectStore.from_dataset_uri(dataset_uri)
-
 
         return store.backend._make_file(store.bucket, key_compose).read(-1)
 

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -8,6 +8,7 @@ from abc import ABCMeta
 from enum import Enum, unique
 from pathlib import Path
 from functools import partial
+from urllib.parse import urlparse
 
 import requests
 
@@ -24,7 +25,6 @@ from starwhale.base.mixin import ASDictMixin
 from starwhale.utils.error import NoSupportError, FieldTypeOrValueError
 from starwhale.api._impl.data_store import SwObject
 
-from .store import ObjectStore
 from ...utils.retry import http_retry
 
 D_FILE_VOLUME_SIZE = 64 * 1024 * 1024  # 64MB
@@ -544,6 +544,7 @@ class Link(ASDictMixin, SwObject):
 
     @http_retry
     def to_bytes(self, dataset_uri: t.Union[str, URI]) -> bytes:
+        from .store import ObjectStore
         if self.signed_uri:
             r = requests.get(self.signed_uri, timeout=10)
             return r.content
@@ -555,8 +556,15 @@ class Link(ASDictMixin, SwObject):
         if dataset_uri.instance_type == InstanceType.CLOUD:
             store = ObjectStore.to_signed_http_backend(dataset_uri, auth_name)
         else:
-            store = ObjectStore.from_data_link_uri(self.uri, auth_name)
-        key_compose = Link(self.local_fs_uri) or self, 0, 0
+            r = urlparse(self.uri)
+            if r.scheme:
+                key_compose = Link(self.local_fs_uri) if self.local_fs_uri else self, 0, 0
+                store = ObjectStore.from_data_link_uri(key_compose[0], auth_name)
+            else:
+                key_compose = Link(self.local_fs_uri) if self.local_fs_uri else self, 0, -2
+                store = ObjectStore.from_dataset_uri(dataset_uri)
+
+
         return store.backend._make_file(store.bucket, key_compose).read(-1)
 
 

--- a/client/starwhale/core/dataset/view.py
+++ b/client/starwhale/core/dataset/view.py
@@ -107,9 +107,9 @@ class DatasetTermView(BaseTermView):
 
         def _str_row(row: t.Dict) -> str:
             data_uri = (
-                row["data_uri"][:SHORT_VERSION_CNT]
+                row["data_link"].uri[:SHORT_VERSION_CNT]
                 if row["object_store_type"] == "local"
-                else row["data_uri"]
+                else row["data_link"].uri
             )
             return f"{row['id']}:offset-{row['data_offset']}:size-{row['data_size']}:uri-{data_uri}"
 

--- a/client/tests/core/test_dataset_store.py
+++ b/client/tests/core/test_dataset_store.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock
 
 from starwhale import URI, URIType
 from starwhale.utils.error import NoSupportError, FieldTypeOrValueError
+from starwhale.core.dataset.type import Link
 from starwhale.core.dataset.store import (
     S3Connection,
     S3StorageBackend,
@@ -35,7 +36,7 @@ class TestDatasetBackend(TestCase):
             expected_type=URIType.DATASET,
         )
         backend = SignedUrlBackend(dataset_uri)
-        file = backend._make_file("", ("a", 0, -1))
+        file = backend._make_file("", (Link("a"), 0, -1))
         self.assertEqual(file.read(-1), _content)
 
     @patch("os.environ", {})
@@ -101,7 +102,7 @@ class TestDatasetBackend(TestCase):
         assert conn.bucket == "users"
 
     def test_s3_backend(self) -> None:
-        uri = "s3://username:password@127.0.0.1:8000/bucket/key"
+        uri = Link("s3://username:password@127.0.0.1:8000/bucket/key")
         conn = S3Connection.from_uri("s3://username:password@127.0.0.1:8000/bucket/key")
         backend = S3StorageBackend(conn)
         s3_file: S3BufferedFileLike = backend._make_file("bucket", (uri, 0, -1))  # type: ignore
@@ -109,5 +110,5 @@ class TestDatasetBackend(TestCase):
         assert s3_file.start == 0
         assert s3_file.end == -1
 
-        s3_file: S3BufferedFileLike = backend._make_file("bucket", ("/path/key2", 0, -1))  # type: ignore
+        s3_file: S3BufferedFileLike = backend._make_file("bucket", (Link("/path/key2"), 0, -1))  # type: ignore
         assert s3_file.key == "path/key2"

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -1224,20 +1224,20 @@ class TestTabularDataset(TestCase):
     def test_tabular_dataset(self, m_ds_wrapper: MagicMock) -> None:
         m_ds_wrapper.return_value.scan.return_value = [
             TabularDatasetRow(
-                id="path/1",
+                id=Link(uri="path/1"),
                 data_uri="abcdef",
                 data_format=DataFormatType.SWDS_BIN,
                 annotations={"a": 1, "b": {"c": 1}},
                 _append_seq_id=0,
             ).asdict(),
             TabularDatasetRow(
-                id="path/2",
+                id=Link(uri="path/2"),
                 data_uri="abcefg",
                 annotations={"a": 2, "b": {"c": 2}},
                 _append_seq_id=1,
             ).asdict(),
             TabularDatasetRow(
-                id="path/3",
+                id=Link(uri="path/3"),
                 data_uri="abcefg",
                 annotations={"a": 2, "b": {"c": 2}},
                 _append_seq_id=2,
@@ -1263,25 +1263,25 @@ class TestTabularDataset(TestCase):
             TabularDataset("a123", "", "")
 
     def test_row(self) -> None:
-        s_row = TabularDatasetRow(id=0, data_uri="abcdef", annotations={"a": 1})
+        s_row = TabularDatasetRow(id=0, data_uri=Link("abcdef"), annotations={"a": 1})
         data_type = {"type": "image", "shape": [1, 2, 3]}
         u_row = TabularDatasetRow(
             id="path/1",
-            data_uri="abcdef",
+            data_uri=Link("abcdef"),
             data_format=DataFormatType.USER_RAW,
             data_type=data_type,
             annotations={"a": 1, "b": {"c": 1}},
         )
         l_row = TabularDatasetRow(
             id="path/1",
-            data_uri="s3://a/b/c",
+            data_uri=Link("s3://a/b/c"),
             data_format=DataFormatType.USER_RAW,
             object_store_type=ObjectStoreType.REMOTE,
             annotations={"a": 1},
         )
         s2_row = TabularDatasetRow(
             id=0,
-            data_uri="abcdef",
+            data_uri=Link("abcdef"),
             data_origin=DataOriginType.INHERIT,
             annotations={"a": 1},
         )
@@ -1308,25 +1308,25 @@ class TestTabularDataset(TestCase):
         assert l_row.asdict()["id"] == "path/1"
 
         with self.assertRaises(FieldTypeOrValueError):
-            TabularDatasetRow(id="", data_uri="")
+            TabularDatasetRow(id="", data_uri=Link(""))
 
         with self.assertRaises(FieldTypeOrValueError):
-            TabularDatasetRow(id=1.1, data_uri="")  # type: ignore
+            TabularDatasetRow(id=1.1, data_uri=Link(""))  # type: ignore
 
         with self.assertRaises(FieldTypeOrValueError):
-            TabularDatasetRow(id="1", data_uri="", annotations=[])  # type: ignore
+            TabularDatasetRow(id="1", data_uri=Link(""), annotations=[])  # type: ignore
 
         with self.assertRaises(FieldTypeOrValueError):
-            TabularDatasetRow(id=1, data_uri="")
+            TabularDatasetRow(id=1, data_uri=Link(""))
 
         with self.assertRaises(NoSupportError):
-            TabularDatasetRow(id="1", data_uri="123", annotations={"a": 1}, data_format="1")  # type: ignore
+            TabularDatasetRow(id="1", data_uri=Link("123"), annotations={"a": 1}, data_format="1")  # type: ignore
 
         with self.assertRaises(NoSupportError):
-            TabularDatasetRow(id="1", data_uri="123", annotations={"a": 1}, data_origin="1")  # type: ignore
+            TabularDatasetRow(id="1", data_uri=Link("123"), annotations={"a": 1}, data_origin="1")  # type: ignore
 
         with self.assertRaises(NoSupportError):
-            TabularDatasetRow(id="1", data_uri="123", annotations={"a": 1}, object_store_type="1")  # type: ignore
+            TabularDatasetRow(id="1", data_uri=Link("123"), annotations={"a": 1}, object_store_type="1")  # type: ignore
 
         for r in (s_row, u_row, l_row):
             copy_r = TabularDatasetRow.from_datastore(**r.asdict())

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -315,7 +315,7 @@ class TestDatasetCopy(BaseTestCase):
                     "columnTypes": [
                         {"type": "STRING", "name": "id"},
                         {
-                            "name": "data_uri",
+                            "name": "data_link",
                             "type": "OBJECT",
                             "pythonType": "starwhale.core.dataset.type.Link",
                             "attributes": [
@@ -355,7 +355,7 @@ class TestDatasetCopy(BaseTestCase):
                     "records": [
                         {
                             "id": "idx-0",
-                            "data_uri": {
+                            "data_link": {
                                 "_local_fs_uri": "",
                                 "_signed_uri": "",
                                 "offset": "0",
@@ -427,7 +427,7 @@ class TestDatasetCopy(BaseTestCase):
         meta_list = list(tdb.scan())
         assert len(meta_list) == 1
         assert meta_list[0].id == "idx-0"
-        assert meta_list[0].data_uri.uri == "111"
+        assert meta_list[0].data_link.uri == "111"
         bbox = meta_list[0].annotations["bbox"]
         assert isinstance(bbox, BoundingBox)
         assert bbox.x == 2 and bbox.y == 2
@@ -642,7 +642,7 @@ class TestDatasetBuildExecutor(BaseTestCase):
         meta = list(tdb.scan(start=0, end=1))[0]
         assert meta.id == 0
         assert meta.data_offset == 16
-        assert meta.data_uri.uri == self.data_file_sign
+        assert meta.data_link.uri == self.data_file_sign
         link: Link = meta.annotations["link"]
         assert link.uri == str(_mnist_label_path)
         assert link.local_fs_uri == self.label_file_sign
@@ -733,7 +733,7 @@ class TestDatasetBuildExecutor(BaseTestCase):
         assert meta.id == 0
         assert meta.data_offset == 32
         assert meta.extra_kw["_swds_bin_offset"] == 0
-        assert meta.data_uri.uri in data_files_sign
+        assert meta.data_link.uri in data_files_sign
         assert meta.data_type["type"] == ArtifactType.Image.value
         assert meta.data_type["mime_type"] == MIMEType.GRAYSCALE.value
         assert meta.data_type["shape"] == [28, 28, 1]
@@ -996,9 +996,13 @@ class TestDatasetType(TestCase):
         )
 
         rm.request(
-            HTTPMethod.GET,
-            "http://127.0.0.1:8081/api/v1/project/test/dataset/mnist/version/latest/sign-link",
-            json={"data": "http://127.0.0.1:9001/signed_url"},
+            HTTPMethod.POST,
+            "http://127.0.0.1:8081/api/v1/project/test/dataset/mnist/version/latest/sign-links?expTimeMillis=60000",
+            json={
+                "data": {
+                    "s3://minioadmin:minioadmin@10.131.0.1:9000/users/path/to/file": "http://127.0.0.1:9001/signed_url"
+                }
+            },
         )
 
         raw_content = b"123"
@@ -1277,20 +1281,20 @@ class TestTabularDataset(TestCase):
         m_ds_wrapper.return_value.scan.return_value = [
             TabularDatasetRow(
                 id="path/1",
-                data_uri=Link("abcdef"),
+                data_link=Link("abcdef"),
                 data_format=DataFormatType.SWDS_BIN,
                 annotations={"a": 1, "b": {"c": 1}},
                 _append_seq_id=0,
             ).asdict(),
             TabularDatasetRow(
                 id="path/2",
-                data_uri=Link(uri="abcefg"),
+                data_link=Link(uri="abcefg"),
                 annotations={"a": 2, "b": {"c": 2}},
                 _append_seq_id=1,
             ).asdict(),
             TabularDatasetRow(
                 id="path/3",
-                data_uri=Link(uri="abcefg"),
+                data_link=Link(uri="abcefg"),
                 annotations={"a": 2, "b": {"c": 2}},
                 _append_seq_id=2,
             ).asdict(),
@@ -1315,25 +1319,25 @@ class TestTabularDataset(TestCase):
             TabularDataset("a123", "", "")
 
     def test_row(self) -> None:
-        s_row = TabularDatasetRow(id=0, data_uri=Link("abcdef"), annotations={"a": 1})
+        s_row = TabularDatasetRow(id=0, data_link=Link("abcdef"), annotations={"a": 1})
         data_type = {"type": "image", "shape": [1, 2, 3]}
         u_row = TabularDatasetRow(
             id="path/1",
-            data_uri=Link("abcdef"),
+            data_link=Link("abcdef"),
             data_format=DataFormatType.USER_RAW,
             data_type=data_type,
             annotations={"a": 1, "b": {"c": 1}},
         )
         l_row = TabularDatasetRow(
             id="path/1",
-            data_uri=Link("s3://a/b/c"),
+            data_link=Link("s3://a/b/c"),
             data_format=DataFormatType.USER_RAW,
             object_store_type=ObjectStoreType.REMOTE,
             annotations={"a": 1},
         )
         s2_row = TabularDatasetRow(
             id=0,
-            data_uri=Link("abcdef"),
+            data_link=Link("abcdef"),
             data_origin=DataOriginType.INHERIT,
             annotations={"a": 1},
         )
@@ -1342,7 +1346,7 @@ class TestTabularDataset(TestCase):
         assert s_row != u_row
         assert s_row.asdict() == {
             "id": 0,
-            "data_uri": Link("abcdef"),
+            "data_link": Link("abcdef"),
             "data_format": "swds_bin",
             "data_offset": 0,
             "data_size": 0,
@@ -1360,25 +1364,25 @@ class TestTabularDataset(TestCase):
         assert l_row.asdict()["id"] == "path/1"
 
         with self.assertRaises(FieldTypeOrValueError):
-            TabularDatasetRow(id="", data_uri=Link(""))
+            TabularDatasetRow(id="", data_link=Link(""))
 
         with self.assertRaises(FieldTypeOrValueError):
-            TabularDatasetRow(id=1.1, data_uri=Link(""))  # type: ignore
+            TabularDatasetRow(id=1.1, data_link=Link(""))  # type: ignore
 
         with self.assertRaises(FieldTypeOrValueError):
-            TabularDatasetRow(id="1", data_uri=Link(""), annotations=[])  # type: ignore
+            TabularDatasetRow(id="1", data_link=Link(""), annotations=[])  # type: ignore
 
         with self.assertRaises(FieldTypeOrValueError):
-            TabularDatasetRow(id=1, data_uri=Link(""))
+            TabularDatasetRow(id=1, data_link=Link(""))
 
         with self.assertRaises(NoSupportError):
-            TabularDatasetRow(id="1", data_uri=Link("123"), annotations={"a": 1}, data_format="1")  # type: ignore
+            TabularDatasetRow(id="1", data_link=Link("123"), annotations={"a": 1}, data_format="1")  # type: ignore
 
         with self.assertRaises(NoSupportError):
-            TabularDatasetRow(id="1", data_uri=Link("123"), annotations={"a": 1}, data_origin="1")  # type: ignore
+            TabularDatasetRow(id="1", data_link=Link("123"), annotations={"a": 1}, data_origin="1")  # type: ignore
 
         with self.assertRaises(NoSupportError):
-            TabularDatasetRow(id="1", data_uri=Link("123"), annotations={"a": 1}, object_store_type="1")  # type: ignore
+            TabularDatasetRow(id="1", data_link=Link("123"), annotations={"a": 1}, object_store_type="1")  # type: ignore
 
         for r in (s_row, u_row, l_row):
             copy_r = TabularDatasetRow.from_datastore(**r.asdict())

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -314,7 +314,22 @@ class TestDatasetCopy(BaseTestCase):
                 "data": {
                     "columnTypes": [
                         {"type": "STRING", "name": "id"},
-                        {"type": "STRING", "name": "data_uri"},
+                        {
+                            "name": "data_uri",
+                            "type": "OBJECT",
+                            "pythonType": "starwhale.core.dataset.type.Link",
+                            "attributes": [
+                                {"name": "_local_fs_uri", "type": "STRING"},
+                                {"name": "_signed_uri", "type": "STRING"},
+                                {"name": "offset", "type": "INT64"},
+                                {"name": "size", "type": "INT64"},
+                                {"name": "auth", "type": "UNKNOWN"},
+                                {"name": "with_local_fs_data", "type": "BOOL"},
+                                {"name": "_type", "type": "STRING"},
+                                {"name": "data_type", "type": "UNKNOWN"},
+                                {"name": "uri", "type": "STRING"},
+                            ],
+                        },
                         {"type": "STRING", "name": "data_format"},
                         {"type": "INT64", "name": "data_offset"},
                         {"type": "INT64", "name": "data_size"},
@@ -340,7 +355,17 @@ class TestDatasetCopy(BaseTestCase):
                     "records": [
                         {
                             "id": "idx-0",
-                            "data_uri": "111",
+                            "data_uri": {
+                                "_local_fs_uri": "",
+                                "_signed_uri": "",
+                                "offset": "0",
+                                "size": "1",
+                                "auth": None,
+                                "with_local_fs_data": "false",
+                                "_type": "link",
+                                "data_type": None,
+                                "uri": "111",
+                            },
                             "data_format": "swds_bin",
                             "data_offset": "0000000000000080",
                             "data_size": "0000000000000006",
@@ -402,7 +427,7 @@ class TestDatasetCopy(BaseTestCase):
         meta_list = list(tdb.scan())
         assert len(meta_list) == 1
         assert meta_list[0].id == "idx-0"
-        assert meta_list[0].data_uri == "111"
+        assert meta_list[0].data_uri.uri == "111"
         bbox = meta_list[0].annotations["bbox"]
         assert isinstance(bbox, BoundingBox)
         assert bbox.x == 2 and bbox.y == 2
@@ -617,7 +642,7 @@ class TestDatasetBuildExecutor(BaseTestCase):
         meta = list(tdb.scan(start=0, end=1))[0]
         assert meta.id == 0
         assert meta.data_offset == 16
-        assert meta.data_uri == self.data_file_sign
+        assert meta.data_uri.uri == self.data_file_sign
         link: Link = meta.annotations["link"]
         assert link.uri == str(_mnist_label_path)
         assert link.local_fs_uri == self.label_file_sign
@@ -708,7 +733,7 @@ class TestDatasetBuildExecutor(BaseTestCase):
         assert meta.id == 0
         assert meta.data_offset == 32
         assert meta.extra_kw["_swds_bin_offset"] == 0
-        assert meta.data_uri in data_files_sign
+        assert meta.data_uri.uri in data_files_sign
         assert meta.data_type["type"] == ArtifactType.Image.value
         assert meta.data_type["mime_type"] == MIMEType.GRAYSCALE.value
         assert meta.data_type["shape"] == [28, 28, 1]
@@ -1251,21 +1276,21 @@ class TestTabularDataset(TestCase):
     def test_tabular_dataset(self, m_ds_wrapper: MagicMock) -> None:
         m_ds_wrapper.return_value.scan.return_value = [
             TabularDatasetRow(
-                id=Link(uri="path/1"),
-                data_uri="abcdef",
+                id="path/1",
+                data_uri=Link("abcdef"),
                 data_format=DataFormatType.SWDS_BIN,
                 annotations={"a": 1, "b": {"c": 1}},
                 _append_seq_id=0,
             ).asdict(),
             TabularDatasetRow(
-                id=Link(uri="path/2"),
-                data_uri="abcefg",
+                id="path/2",
+                data_uri=Link(uri="abcefg"),
                 annotations={"a": 2, "b": {"c": 2}},
                 _append_seq_id=1,
             ).asdict(),
             TabularDatasetRow(
-                id=Link(uri="path/3"),
-                data_uri="abcefg",
+                id="path/3",
+                data_uri=Link(uri="abcefg"),
                 annotations={"a": 2, "b": {"c": 2}},
                 _append_seq_id=2,
             ).asdict(),
@@ -1317,7 +1342,7 @@ class TestTabularDataset(TestCase):
         assert s_row != u_row
         assert s_row.asdict() == {
             "id": 0,
-            "data_uri": "abcdef",
+            "data_uri": Link("abcdef"),
             "data_format": "swds_bin",
             "data_offset": 0,
             "data_size": 0,

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -647,9 +647,15 @@ class TestDataLoader(TestCase):
         loader = get_data_loader(
             dataset_uri, start="a", end="b", session_consumption=tdsc
         )
+        _dict_got = {}
         for idx, data, annotations in loader:
             self.assertEqual(_content, data.fp)
+            _dict_got[annotations["label"].uri] = annotations["label"]._signed_uri
             self.assertEqual(
                 annotations["label"]._signed_uri,
                 _uri_dict.get(annotations["label"].uri),
             )
+        self.assertDictEqual(
+            {"l1": "l1-sign", "l2": "l2-sign", "l3": "l3-sign", "l4": "l4-sign"},
+            _dict_got,
+        )

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -13,7 +13,7 @@ from starwhale.utils.fs import ensure_dir, ensure_file
 from starwhale.base.type import URIType, DataFormatType, DataOriginType, ObjectStoreType
 from starwhale.consts.env import SWEnv
 from starwhale.utils.error import ParameterError
-from starwhale.core.dataset.type import Image, ArtifactType, DatasetSummary, Link
+from starwhale.core.dataset.type import Link, Image, ArtifactType, DatasetSummary
 from starwhale.core.dataset.store import (
     DatasetStorage,
     SignedUrlBackend,
@@ -196,7 +196,9 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=Link(f"s3://127.0.0.1:9000/starwhale/project/2/dataset/11/{version}"),
+                data_uri=Link(
+                    f"s3://127.0.0.1:9000/starwhale/project/2/dataset/11/{version}"
+                ),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 0},
@@ -211,7 +213,9 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=1,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=Link(f"s3://127.0.0.1:19000/starwhale/project/2/dataset/11/{version}"),
+                data_uri=Link(
+                    f"s3://127.0.0.1:19000/starwhale/project/2/dataset/11/{version}"
+                ),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 1},
@@ -226,7 +230,9 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=2,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=Link(f"s3://127.0.0.1/starwhale/project/2/dataset/11/{version}"),
+                data_uri=Link(
+                    f"s3://127.0.0.1/starwhale/project/2/dataset/11/{version}"
+                ),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 1},
@@ -241,7 +247,9 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=3,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=Link(f"s3://username:password@127.0.0.1:29000/starwhale/project/2/dataset/11/{version}"),
+                data_uri=Link(
+                    f"s3://username:password@127.0.0.1:29000/starwhale/project/2/dataset/11/{version}"
+                ),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 1},

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -84,7 +84,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id="path/0",
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=Link(fname),
+                data_link=Link(fname),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 0},
@@ -196,7 +196,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=Link(
+                data_link=Link(
                     f"s3://127.0.0.1:9000/starwhale/project/2/dataset/11/{version}"
                 ),
                 data_offset=16,
@@ -213,7 +213,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=1,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=Link(
+                data_link=Link(
                     f"s3://127.0.0.1:19000/starwhale/project/2/dataset/11/{version}"
                 ),
                 data_offset=16,
@@ -230,7 +230,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=2,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=Link(
+                data_link=Link(
                     f"s3://127.0.0.1/starwhale/project/2/dataset/11/{version}"
                 ),
                 data_offset=16,
@@ -247,7 +247,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=3,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=Link(
+                data_link=Link(
                     f"s3://username:password@127.0.0.1:29000/starwhale/project/2/dataset/11/{version}"
                 ),
                 data_offset=16,
@@ -355,7 +355,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=Link(fname),
+                data_link=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,
@@ -454,7 +454,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=Link(fname),
+                data_link=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,
@@ -471,7 +471,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=1,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=Link(fname),
+                data_link=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,
@@ -521,7 +521,7 @@ class TestDataLoader(TestCase):
 
     @patch.dict(os.environ, {"SW_TOKEN": "a", "SW_POD_NAME": "b"})
     @patch("starwhale.core.dataset.model.CloudDataset.summary")
-    @patch("starwhale.api._impl.dataset.loader.TabularDataset.scan_btch")
+    @patch("starwhale.api._impl.dataset.loader.TabularDataset.scan_batch")
     @patch("requests.get")
     @patch("requests.request")
     @patch("starwhale.core.dataset.tabular.TabularDatasetSessionConsumption")
@@ -559,7 +559,7 @@ class TestDataLoader(TestCase):
                 TabularDatasetRow(
                     id=0,
                     object_store_type=ObjectStoreType.LOCAL,
-                    data_uri=Link("l11"),
+                    data_link=Link("l11"),
                     data_offset=32,
                     data_size=784,
                     _swds_bin_offset=0,
@@ -576,7 +576,7 @@ class TestDataLoader(TestCase):
                 TabularDatasetRow(
                     id=1,
                     object_store_type=ObjectStoreType.LOCAL,
-                    data_uri=Link("l12"),
+                    data_link=Link("l12"),
                     data_offset=32,
                     data_size=784,
                     _swds_bin_offset=0,
@@ -595,7 +595,7 @@ class TestDataLoader(TestCase):
                 TabularDatasetRow(
                     id=2,
                     object_store_type=ObjectStoreType.LOCAL,
-                    data_uri=Link("l13"),
+                    data_link=Link("l13"),
                     data_offset=32,
                     data_size=784,
                     _swds_bin_offset=0,
@@ -612,7 +612,7 @@ class TestDataLoader(TestCase):
                 TabularDatasetRow(
                     id=3,
                     object_store_type=ObjectStoreType.LOCAL,
-                    data_uri=Link("l14"),
+                    data_link=Link("l14"),
                     data_offset=32,
                     data_size=784,
                     _swds_bin_offset=0,

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -13,7 +13,7 @@ from starwhale.utils.fs import ensure_dir, ensure_file
 from starwhale.base.type import URIType, DataFormatType, DataOriginType, ObjectStoreType
 from starwhale.consts.env import SWEnv
 from starwhale.utils.error import ParameterError
-from starwhale.core.dataset.type import Image, ArtifactType, DatasetSummary
+from starwhale.core.dataset.type import Image, ArtifactType, DatasetSummary, Link
 from starwhale.core.dataset.store import (
     DatasetStorage,
     SignedUrlBackend,
@@ -84,7 +84,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id="path/0",
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=fname,
+                data_uri=Link(fname),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 0},
@@ -196,7 +196,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=f"s3://127.0.0.1:9000/starwhale/project/2/dataset/11/{version}",
+                data_uri=Link(f"s3://127.0.0.1:9000/starwhale/project/2/dataset/11/{version}"),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 0},
@@ -211,7 +211,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=1,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=f"s3://127.0.0.1:19000/starwhale/project/2/dataset/11/{version}",
+                data_uri=Link(f"s3://127.0.0.1:19000/starwhale/project/2/dataset/11/{version}"),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 1},
@@ -226,7 +226,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=2,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=f"s3://127.0.0.1/starwhale/project/2/dataset/11/{version}",
+                data_uri=Link(f"s3://127.0.0.1/starwhale/project/2/dataset/11/{version}"),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 1},
@@ -241,7 +241,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=3,
                 object_store_type=ObjectStoreType.REMOTE,
-                data_uri=f"s3://username:password@127.0.0.1:29000/starwhale/project/2/dataset/11/{version}",
+                data_uri=Link(f"s3://username:password@127.0.0.1:29000/starwhale/project/2/dataset/11/{version}"),
                 data_offset=16,
                 data_size=784,
                 annotations={"label": 1},
@@ -347,7 +347,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=fname,
+                data_uri=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,
@@ -446,7 +446,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=fname,
+                data_uri=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,
@@ -463,7 +463,7 @@ class TestDataLoader(TestCase):
             TabularDatasetRow(
                 id=1,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=fname,
+                data_uri=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,

--- a/client/tests/sdk/test_model.py
+++ b/client/tests/sdk/test_model.py
@@ -22,7 +22,7 @@ from starwhale.base.type import (
 )
 from starwhale.api._impl.job import context_holder
 from starwhale.core.eval.store import EvaluationStorage
-from starwhale.core.dataset.type import MIMEType, ArtifactType, DatasetSummary
+from starwhale.core.dataset.type import MIMEType, ArtifactType, DatasetSummary, Link
 from starwhale.core.dataset.store import DatasetStorage
 from starwhale.core.dataset.tabular import TabularDatasetRow
 from starwhale.api._impl.dataset.loader import UserRawDataLoader
@@ -176,7 +176,7 @@ class TestModelPipelineHandler(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=fname,
+                data_uri=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,
@@ -263,7 +263,7 @@ class TestModelPipelineHandler(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=fname,
+                data_uri=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,

--- a/client/tests/sdk/test_model.py
+++ b/client/tests/sdk/test_model.py
@@ -22,7 +22,7 @@ from starwhale.base.type import (
 )
 from starwhale.api._impl.job import context_holder
 from starwhale.core.eval.store import EvaluationStorage
-from starwhale.core.dataset.type import MIMEType, ArtifactType, DatasetSummary, Link
+from starwhale.core.dataset.type import Link, MIMEType, ArtifactType, DatasetSummary
 from starwhale.core.dataset.store import DatasetStorage
 from starwhale.core.dataset.tabular import TabularDatasetRow
 from starwhale.api._impl.dataset.loader import UserRawDataLoader

--- a/client/tests/sdk/test_model.py
+++ b/client/tests/sdk/test_model.py
@@ -176,7 +176,7 @@ class TestModelPipelineHandler(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=Link(fname),
+                data_link=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,
@@ -263,7 +263,7 @@ class TestModelPipelineHandler(TestCase):
             TabularDatasetRow(
                 id=0,
                 object_store_type=ObjectStoreType.LOCAL,
-                data_uri=Link(fname),
+                data_link=Link(fname),
                 data_offset=32,
                 data_size=784,
                 _swds_bin_offset=0,

--- a/console/src/domain/dataset/sdk.ts
+++ b/console/src/domain/dataset/sdk.ts
@@ -85,7 +85,7 @@ export class DatasetObject {
         this.src = data?.src ?? 0
         this.size = Number(data?.data_size ?? 0)
         this.offset = Number(data?.data_offset ?? 0)
-        this.uri = data?.data_uri?.uri ?? ''
+        this.uri = data?.data_link?.uri ?? ''
         this.id = data?.id ?? ''
         this.mimeType = ''
         this.type = ''

--- a/console/src/domain/dataset/sdk.ts
+++ b/console/src/domain/dataset/sdk.ts
@@ -85,7 +85,7 @@ export class DatasetObject {
         this.src = data?.src ?? 0
         this.size = Number(data?.data_size ?? 0)
         this.offset = Number(data?.data_offset ?? 0)
-        this.uri = data?.data_uri ?? ''
+        this.uri = data?.data_uri?.uri ?? ''
         this.id = data?.id ?? ''
         this.mimeType = ''
         this.type = ''

--- a/example/datasets/coco/dataset.py
+++ b/example/datasets/coco/dataset.py
@@ -31,6 +31,7 @@ def seg_dict_2_object(sg: dict):
     sg["bbox_view"] = BoundingBox(x=x, y=y, width=w, height=h)
     return SegInfo(sg)
 
+
 def do_iter_item():
     with (DATA_DIR / "annotations" / "panoptic_val2017.json").open("r") as f:
         index = json.load(f)
@@ -43,21 +44,23 @@ def do_iter_item():
             msk_f_name = anno["file_name"]
             msk_f_pth = DATA_DIR / "annotations" / "panoptic_val2017" / msk_f_name
             segs_info = anno["segments_info"]
-            anno["segments_info"] = [seg_dict_2_object(sg) for sg in segs_info]
+            for sg in segs_info:
+                x, y, w, h = sg["bbox"]
+                sg["bbox_view"] = BoundingBox(x=x, y=y, width=w, height=h)
 
-            anno["mask"] = Link(
+            yield Link(
+                uri=str(img_pth.absolute()),
+                data_type=Image(display_name=img_name, shape=img_shape),
+                with_local_fs_data=True,
+            ), {"mask": Link(
                 auth=None,
                 with_local_fs_data=True,
                 data_type=Image(
                     display_name=msk_f_name, shape=img_shape, mime_type=MIMEType.PNG
                 ),
                 uri=str(msk_f_pth.absolute()),
-            )
-            yield Link(
-                uri=str(img_pth.absolute()),
-                data_type=Image(display_name=img_name, shape=img_shape),
-                with_local_fs_data=True,
-            ), anno
+            )}
+
 
 PATH_ROOT = "dataset/coco/extracted"
 _ak = os.environ.get("SW_S3_AK", "starwhale")
@@ -104,19 +107,20 @@ def do_iter_item_from_remote():
         img_shape = (img_meta["height"], img_meta["width"])
         msk_f_name = anno["file_name"]
         segs_info = anno["segments_info"]
-        anno["segments_info"] = [seg_dict_2_object(sg) for sg in segs_info]
+        for sg in segs_info:
+            x, y, w, h = sg["bbox"]
+            sg["bbox_view"] = BoundingBox(x=x, y=y, width=w, height=h)
 
-        anno["mask"] = Link(
+        yield Link(
+            auth=_auth,
+            uri=f"s3://{RUI_ROOT}/val2017/{img_name}",
+            data_type=Image(display_name=img_name, shape=img_shape),
+            with_local_fs_data=False,
+        ), {"mask": Link(
             auth=_auth,
             with_local_fs_data=False,
             data_type=Image(
                 display_name=msk_f_name, shape=img_shape, mime_type=MIMEType.PNG
             ),
             uri=f"s3://{RUI_ROOT}/annotations/panoptic_val2017/{msk_f_name}",
-        )
-        yield Link(
-            auth=_auth,
-            uri=f"s3://{RUI_ROOT}/val2017/{img_name}",
-            data_type=Image(display_name=img_name, shape=img_shape),
-            with_local_fs_data=False,
-        ), anno
+        )}

--- a/example/datasets/coco/dataset.py
+++ b/example/datasets/coco/dataset.py
@@ -7,29 +7,9 @@ from botocore.client import Config as S3Config
 
 from starwhale import Link, Image, MIMEType, S3LinkAuth, BoundingBox  # noqa: F401
 from starwhale.core.dataset.store import S3Connection, S3StorageBackend  # noqa: F401
-from starwhale.api._impl.data_store import SwObject
 
 ROOT_DIR = Path(__file__).parent
 DATA_DIR = ROOT_DIR / "data"
-
-
-class SegInfo(SwObject):
-    def __init__(
-        self,
-        sg: dict,
-    ) -> None:
-        self.id = sg.get("id")
-        self.category_id = sg.get("category_id")
-        self.iscrowd = sg.get("iscrowd")
-        self.bbox = sg.get("bbox")
-        self.area = sg.get("area")
-        self.bbox_view = sg.get("bbox_view")
-
-
-def seg_dict_2_object(sg: dict):
-    x, y, w, h = sg["bbox"]
-    sg["bbox_view"] = BoundingBox(x=x, y=y, width=w, height=h)
-    return SegInfo(sg)
 
 
 def do_iter_item():

--- a/example/datasets/coco/dataset.py
+++ b/example/datasets/coco/dataset.py
@@ -7,10 +7,29 @@ from botocore.client import Config as S3Config
 
 from starwhale import Link, Image, MIMEType, S3LinkAuth, BoundingBox  # noqa: F401
 from starwhale.core.dataset.store import S3Connection, S3StorageBackend  # noqa: F401
+from starwhale.api._impl.data_store import SwObject
 
 ROOT_DIR = Path(__file__).parent
 DATA_DIR = ROOT_DIR / "data"
 
+
+class SegInfo(SwObject):
+    def __init__(
+        self,
+        sg: dict,
+    ) -> None:
+        self.id = sg.get("id")
+        self.category_id = sg.get('category_id')
+        self.iscrowd = sg.get('iscrowd')
+        self.bbox = sg.get('bbox')
+        self.area = sg.get('area')
+        self.bbox_view = sg.get('bbox_view')
+
+
+def seg_dict_2_object(sg: dict):
+    x, y, w, h = sg["bbox"]
+    sg["bbox_view"] = BoundingBox(x=x, y=y, width=w, height=h)
+    return SegInfo(sg)
 
 def do_iter_item():
     with (DATA_DIR / "annotations" / "panoptic_val2017.json").open("r") as f:
@@ -24,9 +43,7 @@ def do_iter_item():
             msk_f_name = anno["file_name"]
             msk_f_pth = DATA_DIR / "annotations" / "panoptic_val2017" / msk_f_name
             segs_info = anno["segments_info"]
-            for sg in segs_info:
-                x, y, w, h = sg["bbox"]
-                sg["bbox_view"] = BoundingBox(x=x, y=y, width=w, height=h)
+            anno["segments_info"] = [seg_dict_2_object(sg) for sg in segs_info]
 
             anno["mask"] = Link(
                 auth=None,
@@ -42,17 +59,17 @@ def do_iter_item():
                 with_local_fs_data=True,
             ), anno
 
-
 PATH_ROOT = "dataset/coco/extracted"
 _ak = os.environ.get("SW_S3_AK", "starwhale")
 _sk = os.environ.get("SW_S3_SK", "starwhale")
-_endpoint = os.environ.get("SW_S3_EDP", "http://10.131.0.1:9000")
+_host_p = os.environ.get("SW_S3_HOST", "10.131.0.1:9000")
+_endpoint = os.environ.get("SW_S3_EDP", f"http://{_host_p}")
 _region = os.environ.get("SW_S3_REGION", "local")
 _auth = S3LinkAuth(
     name="SW_S3", access_key=_ak, secret=_sk, endpoint=_endpoint, region=_region
 )
 _bucket = "users"
-RUI_ROOT = f"{_bucket}/{PATH_ROOT}"
+RUI_ROOT = f"{_host_p}/{_bucket}/{PATH_ROOT}"
 
 
 def do_iter_item_from_remote():
@@ -87,12 +104,10 @@ def do_iter_item_from_remote():
         img_shape = (img_meta["height"], img_meta["width"])
         msk_f_name = anno["file_name"]
         segs_info = anno["segments_info"]
-        for sg in segs_info:
-            x, y, w, h = sg["bbox"]
-            sg["bbox_view"] = BoundingBox(x=x, y=y, width=w, height=h)
+        anno["segments_info"] = [seg_dict_2_object(sg) for sg in segs_info]
 
         anno["mask"] = Link(
-            auth=None,
+            auth=_auth,
             with_local_fs_data=False,
             data_type=Image(
                 display_name=msk_f_name, shape=img_shape, mime_type=MIMEType.PNG

--- a/example/datasets/coco/dataset.py
+++ b/example/datasets/coco/dataset.py
@@ -19,11 +19,11 @@ class SegInfo(SwObject):
         sg: dict,
     ) -> None:
         self.id = sg.get("id")
-        self.category_id = sg.get('category_id')
-        self.iscrowd = sg.get('iscrowd')
-        self.bbox = sg.get('bbox')
-        self.area = sg.get('area')
-        self.bbox_view = sg.get('bbox_view')
+        self.category_id = sg.get("category_id")
+        self.iscrowd = sg.get("iscrowd")
+        self.bbox = sg.get("bbox")
+        self.area = sg.get("area")
+        self.bbox_view = sg.get("bbox_view")
 
 
 def seg_dict_2_object(sg: dict):
@@ -52,14 +52,16 @@ def do_iter_item():
                 uri=str(img_pth.absolute()),
                 data_type=Image(display_name=img_name, shape=img_shape),
                 with_local_fs_data=True,
-            ), {"mask": Link(
-                auth=None,
-                with_local_fs_data=True,
-                data_type=Image(
-                    display_name=msk_f_name, shape=img_shape, mime_type=MIMEType.PNG
-                ),
-                uri=str(msk_f_pth.absolute()),
-            )}
+            ), {
+                "mask": Link(
+                    auth=None,
+                    with_local_fs_data=True,
+                    data_type=Image(
+                        display_name=msk_f_name, shape=img_shape, mime_type=MIMEType.PNG
+                    ),
+                    uri=str(msk_f_pth.absolute()),
+                )
+            }
 
 
 PATH_ROOT = "dataset/coco/extracted"
@@ -116,11 +118,13 @@ def do_iter_item_from_remote():
             uri=f"s3://{RUI_ROOT}/val2017/{img_name}",
             data_type=Image(display_name=img_name, shape=img_shape),
             with_local_fs_data=False,
-        ), {"mask": Link(
-            auth=_auth,
-            with_local_fs_data=False,
-            data_type=Image(
-                display_name=msk_f_name, shape=img_shape, mime_type=MIMEType.PNG
-            ),
-            uri=f"s3://{RUI_ROOT}/annotations/panoptic_val2017/{msk_f_name}",
-        )}
+        ), {
+            "mask": Link(
+                auth=_auth,
+                with_local_fs_data=False,
+                data_type=Image(
+                    display_name=msk_f_name, shape=img_shape, mime_type=MIMEType.PNG
+                ),
+                uri=f"s3://{RUI_ROOT}/annotations/panoptic_val2017/{msk_f_name}",
+            )
+        }

--- a/example/datasets/coco/example.py
+++ b/example/datasets/coco/example.py
@@ -40,9 +40,7 @@ def link():
     uri = URI("coco-link/version/latest", expected_type=URIType.DATASET)
     for idx, data, annotations in get_data_loader(uri, 0, 1):
         with PILImage.open(io.BytesIO(data.fp)) as img, PILImage.open(
-            io.BytesIO(
-                annotations["mask"].to_bytes(uri)
-            )
+            io.BytesIO(annotations["mask"].to_bytes(uri))
         ).convert("RGBA") as msk:
             # for seg in annotations["segments_info"]:
             #     draw_bbox(img, seg.bbox_view)
@@ -54,15 +52,18 @@ def link():
 
 def link_remote():
     os.environ["SW_POD_NAME"] = "pod-1"
-    uri = URI("http://localhost:8082/project/starwhale/dataset/coco-link/version/ge3taobuge3gkobzhbtdkzbrgb4ds4q",
-              expected_type=URIType.DATASET)
-    for idx, data, annotations in get_data_loader(uri, session_consumption=get_dataset_consumption(uri, session_id="1",
-                                                                                                   batch_size=10,
-                                                                                                   instance_uri="http://localhost:8082")):
+    uri = URI(
+        "http://localhost:8082/project/starwhale/dataset/coco-link/version/ge3taobuge3gkobzhbtdkzbrgb4ds4q",
+        expected_type=URIType.DATASET,
+    )
+    for idx, data, annotations in get_data_loader(
+        uri,
+        session_consumption=get_dataset_consumption(
+            uri, session_id="1", batch_size=10, instance_uri="http://localhost:8082"
+        ),
+    ):
         with PILImage.open(io.BytesIO(data.fp)) as img, PILImage.open(
-            io.BytesIO(
-                annotations["mask"].to_bytes(uri)
-            )
+            io.BytesIO(annotations["mask"].to_bytes(uri))
         ).convert("RGBA") as msk:
             # for seg in annotations["segments_info"]:
             #     draw_bbox(img, seg.bbox_view)

--- a/example/datasets/coco/example.py
+++ b/example/datasets/coco/example.py
@@ -1,22 +1,19 @@
 import io
-import os
-from urllib.parse import urlparse
 
 from PIL import Image as PILImage
 from PIL import ImageDraw
 
 from starwhale import URI, URIType, get_data_loader
-from starwhale.core.dataset.store import S3Connection, S3StorageBackend
 
 
 def draw_bbox(img, bbox_view_):
     bbox1 = ImageDraw.Draw(img)
     bbox1.rectangle(
         [
-            (bbox_view_["x"], bbox_view_["y"]),
+            (bbox_view_.x, bbox_view_.y),
             (
-                bbox_view_["x"] + bbox_view_["width"],
-                bbox_view_["y"] + bbox_view_["height"],
+                bbox_view_.x + bbox_view_.width,
+                bbox_view_.y + bbox_view_.height,
             ),
         ],
         fill=None,
@@ -28,36 +25,26 @@ def raw():
     uri = URI("coco-raw/version/latest", expected_type=URIType.DATASET)
     for idx, data, annotations in get_data_loader(uri, 0, 1):
         with PILImage.open(io.BytesIO(data.fp)) as img, PILImage.open(
-            annotations["mask"]["uri"]
+            io.BytesIO(annotations["mask"].to_bytes(uri))
         ).convert("RGBA") as msk:
             for seg in annotations["segments_info"]:
-                draw_bbox(img, seg["bbox_view"])
+                draw_bbox(img, seg.bbox_view)
 
             msk.putalpha(127)
             img.paste(msk, (0, 0), mask=msk)
             img.show()
 
 
-_ak = os.environ.get("SW_S3_AK", "starwhale")
-_sk = os.environ.get("SW_S3_SK", "starwhale")
-_endpoint = os.environ.get("SW_S3_EDP", "http://10.131.0.1:9000")
-_region = os.environ.get("SW_S3_REGION", "local")
-_bucket = "users"
-
-
 def link():
-    s3 = S3StorageBackend(S3Connection(_endpoint, _ak, _sk, _region, _bucket))
     uri = URI("coco-link/version/latest", expected_type=URIType.DATASET)
     for idx, data, annotations in get_data_loader(uri, 0, 1):
         with PILImage.open(io.BytesIO(data.fp)) as img, PILImage.open(
             io.BytesIO(
-                s3._make_file(_bucket, urlparse(annotations["mask"]["uri"]).path).read(
-                    -1
-                )
+                annotations["mask"].to_bytes(uri)
             )
         ).convert("RGBA") as msk:
             for seg in annotations["segments_info"]:
-                draw_bbox(img, seg["bbox_view"])
+                draw_bbox(img, seg.bbox_view)
 
             msk.putalpha(127)
             img.paste(msk, (0, 0), mask=msk)
@@ -65,4 +52,4 @@ def link():
 
 
 if __name__ == "__main__":
-    raw()
+    link()

--- a/example/datasets/coco/example.py
+++ b/example/datasets/coco/example.py
@@ -1,9 +1,10 @@
 import io
+import os
 
 from PIL import Image as PILImage
 from PIL import ImageDraw
 
-from starwhale import URI, URIType, get_data_loader
+from starwhale import URI, URIType, get_data_loader, get_dataset_consumption
 
 
 def draw_bbox(img, bbox_view_):
@@ -27,8 +28,8 @@ def raw():
         with PILImage.open(io.BytesIO(data.fp)) as img, PILImage.open(
             io.BytesIO(annotations["mask"].to_bytes(uri))
         ).convert("RGBA") as msk:
-            for seg in annotations["segments_info"]:
-                draw_bbox(img, seg.bbox_view)
+            # for seg in annotations["segments_info"]:
+            #     draw_bbox(img, seg.bbox_view)
 
             msk.putalpha(127)
             img.paste(msk, (0, 0), mask=msk)
@@ -43,8 +44,28 @@ def link():
                 annotations["mask"].to_bytes(uri)
             )
         ).convert("RGBA") as msk:
-            for seg in annotations["segments_info"]:
-                draw_bbox(img, seg.bbox_view)
+            # for seg in annotations["segments_info"]:
+            #     draw_bbox(img, seg.bbox_view)
+
+            msk.putalpha(127)
+            img.paste(msk, (0, 0), mask=msk)
+            img.show()
+
+
+def link_remote():
+    os.environ["SW_POD_NAME"] = "pod-1"
+    uri = URI("http://localhost:8082/project/starwhale/dataset/coco-link/version/ge3taobuge3gkobzhbtdkzbrgb4ds4q",
+              expected_type=URIType.DATASET)
+    for idx, data, annotations in get_data_loader(uri, session_consumption=get_dataset_consumption(uri, session_id="1",
+                                                                                                   batch_size=10,
+                                                                                                   instance_uri="http://localhost:8082")):
+        with PILImage.open(io.BytesIO(data.fp)) as img, PILImage.open(
+            io.BytesIO(
+                annotations["mask"].to_bytes(uri)
+            )
+        ).convert("RGBA") as msk:
+            # for seg in annotations["segments_info"]:
+            #     draw_bbox(img, seg.bbox_view)
 
             msk.putalpha(127)
             img.paste(msk, (0, 0), mask=msk)
@@ -52,4 +73,4 @@ def link():
 
 
 if __name__ == "__main__":
-    link()
+    link_remote()

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
@@ -37,6 +37,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import java.util.Set;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
@@ -279,6 +281,21 @@ public interface DatasetApi {
             @Parameter(name = "expTimeMillis", description = "the link will be expired after expTimeMillis")
             @RequestParam(name = "expTimeMillis", required = false) Long expTimeMillis);
 
+
+    @Operation(summary = "Sign SWDS uris to get a batch of temporarily accessible links",
+            description = "Sign SWDS uris to get a batch of temporarily accessible links")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})
+    @GetMapping(
+            value = "/project/{projectName}/dataset/{datasetName}/version/{version}/sign-links",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER', 'GUEST')")
+    ResponseEntity<ResponseMessage<Map>> signLinks(@PathVariable(name = "projectName") String projectUrl,
+            @PathVariable(name = "datasetName") String datasetUrl,
+            @PathVariable(name = "version") String versionUrl,
+            @Parameter(name = "uris", description = "a batch of uris")
+            @RequestParam(name = "uris", required = true) Set<String> uris,
+            @Parameter(name = "expTimeMillis", description = "the link will be expired after expTimeMillis")
+            @RequestParam(name = "expTimeMillis", required = false) Long expTimeMillis);
 
     @Operation(summary = "Set the tag of the dataset version")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
@@ -265,22 +265,6 @@ public interface DatasetApi {
             @RequestParam(name = "size", required = false) Long size,
             HttpServletResponse httpResponse);
 
-    @Operation(summary = "Sign SWDS uri to get a temporarily accessible link",
-            description = "Sign SWDS uri to get a temporarily accessible link")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})
-    @GetMapping(
-            value = "/project/{projectName}/dataset/{datasetName}/version/{version}/sign-link",
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER', 'GUEST')")
-    ResponseEntity<ResponseMessage<String>> signLink(
-            @PathVariable(name = "projectName") String projectUrl,
-            @PathVariable(name = "datasetName") String datasetUrl,
-            @PathVariable(name = "version") String versionUrl,
-            @Parameter(name = "uri", description = "uri of the link")
-            @RequestParam(name = "uri", required = true) String uri,
-            @Parameter(name = "expTimeMillis", description = "the link will be expired after expTimeMillis")
-            @RequestParam(name = "expTimeMillis", required = false) Long expTimeMillis);
-
 
     @Operation(summary = "Sign SWDS uris to get a batch of temporarily accessible links",
             description = "Sign SWDS uris to get a batch of temporarily accessible links")

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
@@ -285,15 +285,14 @@ public interface DatasetApi {
     @Operation(summary = "Sign SWDS uris to get a batch of temporarily accessible links",
             description = "Sign SWDS uris to get a batch of temporarily accessible links")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})
-    @GetMapping(
+    @PostMapping(
             value = "/project/{projectName}/dataset/{datasetName}/version/{version}/sign-links",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER', 'GUEST')")
     ResponseEntity<ResponseMessage<Map>> signLinks(@PathVariable(name = "projectName") String projectUrl,
             @PathVariable(name = "datasetName") String datasetUrl,
             @PathVariable(name = "version") String versionUrl,
-            @Parameter(name = "uris", description = "a batch of uris")
-            @RequestParam(name = "uris", required = true) Set<String> uris,
+            @RequestBody Set<String> uris,
             @Parameter(name = "expTimeMillis", description = "the link will be expired after expTimeMillis")
             @RequestParam(name = "expTimeMillis", required = false) Long expTimeMillis);
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
@@ -49,6 +49,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.servlet.ServletOutputStream;
@@ -242,6 +244,14 @@ public class DatasetController implements DatasetApi {
         DatasetVersionEntity datasetVersionEntity = datasetService.query(projectUrl, datasetUrl, versionUrl);
         return ResponseEntity.ok(Code.success.asResponse(
                 datasetService.signLink(datasetVersionEntity.getId(), uri, expTimeMillis)));
+    }
+
+    @Override
+    public ResponseEntity<ResponseMessage<Map>> signLinks(String projectUrl, String datasetUrl, String versionUrl,
+            Set<String> uris, Long expTimeMillis) {
+        DatasetVersionEntity datasetVersionEntity = datasetService.query(projectUrl, datasetUrl, versionUrl);
+        return ResponseEntity.ok(Code.success.asResponse(
+                datasetService.signLinks(datasetVersionEntity.getId(), uris, expTimeMillis)));
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
@@ -239,14 +239,6 @@ public class DatasetController implements DatasetApi {
     }
 
     @Override
-    public ResponseEntity<ResponseMessage<String>> signLink(String projectUrl, String datasetUrl, String versionUrl,
-            String uri, Long expTimeMillis) {
-        DatasetVersionEntity datasetVersionEntity = datasetService.query(projectUrl, datasetUrl, versionUrl);
-        return ResponseEntity.ok(Code.success.asResponse(
-                datasetService.signLink(datasetVersionEntity.getId(), uri, expTimeMillis)));
-    }
-
-    @Override
     public ResponseEntity<ResponseMessage<Map>> signLinks(String projectUrl, String datasetUrl, String versionUrl,
             Set<String> uris, Long expTimeMillis) {
         DatasetVersionEntity datasetVersionEntity = datasetService.query(projectUrl, datasetUrl, versionUrl);

--- a/server/controller/src/main/java/ai/starwhale/mlops/configuration/RequestLoggingConfig.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/configuration/RequestLoggingConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+
+@Configuration
+public class RequestLoggingConfig {
+
+    @Bean
+    public CommonsRequestLoggingFilter requestLoggingFilter() {
+        CommonsRequestLoggingFilter loggingFilter = new CommonsRequestLoggingFilter();
+        loggingFilter.setIncludeClientInfo(true);
+        loggingFilter.setIncludeQueryString(true);
+        loggingFilter.setIncludePayload(true);
+        loggingFilter.setIncludeHeaders(false);
+        return loggingFilter;
+    }
+
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/DatasetService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/DatasetService.java
@@ -63,7 +63,9 @@ import com.github.pagehelper.PageInfo;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -317,5 +319,15 @@ public class DatasetService {
 
     public String signLink(Long id, String uri, Long expTimeMillis) {
         return dsFileGetter.linkOf(id, uri, expTimeMillis);
+    }
+
+    public Map<String, String> signLinks(Long id, Set<String> uris, Long expTimeMillis) {
+        return uris.stream().collect(Collectors.toMap(u -> u, u -> {
+            try {
+                return signLink(id, u, expTimeMillis);
+            } catch (Exception e) {
+                return "";
+            }
+        }));
     }
 }

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -96,3 +96,4 @@ logging:
   level:
     root: info
     ai.starwhale.mlops: debug
+    org.springframework.web.filter.CommonsRequestLoggingFilter: ${SW_REQUEST_LOG_LEVEL:DEBUG}

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/DatasetControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/DatasetControllerTest.java
@@ -54,7 +54,9 @@ import ai.starwhale.mlops.exception.api.StarwhaleApiException;
 import com.github.pagehelper.PageInfo;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
@@ -355,14 +357,15 @@ public class DatasetControllerTest {
     }
 
     @Test
-    public void testSignLink() {
+    public void testSignLinks() {
         String pj = "pj";
         String ds = "ds";
         String v = "v";
         String uri = "uri";
         when(datasetService.query(pj, ds, v)).thenReturn(DatasetVersionEntity.builder().id(1L).build());
         String signUrl = "sign-url";
-        when(datasetService.signLink(1L, uri, 100L)).thenReturn(signUrl);
-        Assertions.assertEquals(signUrl, controller.signLink(pj, ds, v, uri, 100L).getBody().getData());
+        when(datasetService.signLinks(1L, Set.of(uri), 100L)).thenReturn(Map.of(uri, signUrl));
+        Assertions.assertEquals(Map.of(uri, signUrl),
+                controller.signLinks(pj, ds, v, Set.of(uri), 100L).getBody().getData());
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
@@ -64,10 +65,13 @@ import ai.starwhale.mlops.domain.user.bo.User;
 import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.exception.api.StarwhaleApiException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Setter;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -385,7 +389,21 @@ public class DatasetServiceTest {
                 .willReturn("link");
 
         var res = dsFileGetter.linkOf(1L, "", 1L);
-        assertThat(dsFileGetter.linkOf(1L, "", 1L), is("link"));
+        assertThat(service.signLink(1L, "", 1L), is("link"));
+    }
+
+    @Test
+    public void testLinksOf() {
+        given(dsFileGetter.linkOf(same(1L), eq("a"), anyLong()))
+                .willReturn("link1");
+
+        given(dsFileGetter.linkOf(same(1L), eq("b"), anyLong()))
+                .willReturn("link2");
+        given(dsFileGetter.linkOf(same(1L), eq("x"), anyLong()))
+                .willThrow(SwValidationException.class);
+
+        Assertions.assertEquals(Map.of("a", "link1", "b", "link2", "x", ""),
+                service.signLinks(1L, Set.of("a", "b", "x"), 1L));
     }
 
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/objectstore/DsFileGetterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/objectstore/DsFileGetterTest.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import ai.starwhale.mlops.datastore.ColumnTypeScalar;
 import ai.starwhale.mlops.domain.dataset.mapper.DatasetVersionMapper;
 import ai.starwhale.mlops.domain.dataset.po.DatasetVersionEntity;
 import ai.starwhale.mlops.storage.LengthAbleInputStream;


### PR DESCRIPTION
## Description
- add batch uri sign api in server
- add logger for server request
- change `data_uri` column type to `Link` and change UI related api call
- yield batch rows when scan datastore
- travel all `Link`s in datastore row including annotations
- batch sign uri and add `signed_uri` to `Link`
- change coco example


#### verification
http://batch-sign-20221116.pre.intra.starwhale.ai/projects/3/evaluations/3/actions
http://batch-sign-20221116.pre.intra.starwhale.ai/projects/3/evaluations/4/results
**sign-links log**
![image](https://user-images.githubusercontent.com/89630947/202146484-46f30f15-2b05-4ebb-a76d-3a1f0240ba91.png)


## Modules
- [x] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
