### PR TITLE
enhance(sdk): tune get http file performance with buffer

### DIFF
--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -169,11 +169,11 @@ class DataLoader(metaclass=ABCMeta):
             # TODO: tune performance by fetch in batch
             _store = self._get_store(row)
             _key_compose = self._get_key_compose(row, _store)
-            _file = _store.backend._make_file(_store.bucket, _key_compose)
-            for data_content, _ in self._do_iter_data(_file, row):
-                data = BaseArtifact.reflect(data_content, row.data_type)
-                # TODO: refactor annotation origin type
-                yield row.id, data, row.annotations
+            with _store.backend._make_file(_store.bucket, _key_compose) as _file:
+                for data_content, _ in self._do_iter_data(_file, row):
+                    data = BaseArtifact.reflect(data_content, row.data_type)
+                    # TODO: refactor annotation origin type
+                    yield row.id, data, row.annotations
 
     @abstractmethod
     def _do_iter_data(

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -596,7 +596,8 @@ class Link(ASDictMixin, SwObject):
                 )
                 store = ObjectStore.from_dataset_uri(dataset_uri)
 
-        return store.backend._make_file(store.bucket, key_compose).read(-1)
+        with store.backend._make_file(store.bucket, key_compose) as f:
+            return f.read(-1)  # type: ignore
 
 
 class DatasetSummary(ASDictMixin):

--- a/client/tests/core/test_dataset_store.py
+++ b/client/tests/core/test_dataset_store.py
@@ -1,43 +1,51 @@
 import os
-from http import HTTPStatus
+import string
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
+
+from requests_mock import Mocker
 
 from starwhale import URI, URIType
 from starwhale.utils.error import NoSupportError, FieldTypeOrValueError
 from starwhale.core.dataset.type import Link
 from starwhale.core.dataset.store import (
+    BytesBuffer,
     S3Connection,
     S3StorageBackend,
     SignedUrlBackend,
     S3BufferedFileLike,
+    HttpBufferedFileLike,
 )
 
 
 class TestDatasetBackend(TestCase):
-    @patch("requests.get")
-    @patch("requests.request")
+    @Mocker()
     def test_signed_url_backend(
         self,
-        m_request: MagicMock,
-        m_get: MagicMock,
+        rm: Mocker,
     ):
-        m_request.return_value = MagicMock(
-            **{"status_code": HTTPStatus.OK, "data": "a"}
+        signed_url = "http://minio-io/path/to/signed/file"
+        raw_content = string.ascii_lowercase.encode()
+        data_uri = "12345678abcdefg"
+        req_signed_url = rm.post(
+            "http://127.0.0.1:1234/api/v1/project/self/dataset/mnist/version/1122334455667788/sign-links",
+            json={"data": {data_uri: signed_url}},
         )
-        _content = b"abcd"
-        m_get.return_value = MagicMock(
-            **{
-                "content": _content,
-            }
+        req_file_download = rm.get(
+            signed_url,
+            content=raw_content,
         )
+
         dataset_uri = URI(
             "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788",
             expected_type=URIType.DATASET,
         )
-        backend = SignedUrlBackend(dataset_uri)
-        file = backend._make_file("", (Link("a"), 0, -1))
-        self.assertEqual(file.read(-1), _content)
+        obj = SignedUrlBackend(dataset_uri)._make_file("", (Link(data_uri), 0, -1))
+        assert obj.read(1) == b"a"
+        assert obj.read(-1) == raw_content[1:]
+        assert req_signed_url.call_count == 1
+        assert req_file_download.call_count == 1
+        obj.close()
 
     @patch("os.environ", {})
     def test_s3_conn_from_uri(self) -> None:
@@ -107,8 +115,127 @@ class TestDatasetBackend(TestCase):
         backend = S3StorageBackend(conn)
         s3_file: S3BufferedFileLike = backend._make_file("bucket", (uri, 0, -1))  # type: ignore
         assert s3_file.key == "key"
-        assert s3_file.start == 0
+        assert s3_file._current_s3_start == 0
         assert s3_file.end == -1
+        s3_file.close()
 
-        s3_file: S3BufferedFileLike = backend._make_file("bucket", (Link("/path/key2"), 0, -1))  # type: ignore
-        assert s3_file.key == "path/key2"
+        with backend._make_file("bucket", (Link("/path/key2"), 0, -1)) as s3_file:
+            assert s3_file.key == "path/key2"
+
+
+class TestBytesBuffer(TestCase):
+    def setUp(self) -> None:
+        self.content = string.ascii_letters.encode()
+        self.content_iter = iter(
+            [self.content[i : i + 10] for i in range(0, len(self.content), 10)]
+        )
+
+    def test_read(self) -> None:
+        buf = BytesBuffer(10)
+        buf.write_from_iter(self.content_iter)
+        assert len(buf) == 10
+        assert buf.read(1) == b"a"
+        assert buf.read(1) == b"b"
+        assert buf.read() == b"cdefghij"
+        assert buf.read(1) == b""
+        assert buf.read() == b""
+        assert len(buf) == 0
+
+        wrote_size = buf.write_from_iter(self.content_iter)
+        assert wrote_size == 10
+
+        assert buf.read(2) == b"kl"
+        assert buf.read(2) == b"mn"
+        assert len(buf) == 6
+        assert buf.read(-1) == b"opqrst"
+
+    def test_read_zero(self) -> None:
+        buf = BytesBuffer(0)
+        assert buf.read() == b""
+        assert buf.read(1) == b""
+        assert buf.read(-1) == b""
+
+    def test_read_exhausted_buffer(self) -> None:
+        buf = BytesBuffer(10)
+        buf.write_from_iter([b"abcd"])
+        assert len(buf) == 4
+        assert buf.read(-1) == b"abcd"
+        assert buf.read(-1) == b""
+        assert buf.read() == b""
+
+    def test_write(self) -> None:
+        buf = BytesBuffer(10)
+        buf.write_from_iter(self.content_iter)
+        assert len(buf) == 10
+        buf.write_from_iter(self.content_iter)
+        assert len(buf) == 20
+        assert buf.read(1) == b"a"
+        assert len(buf) == 19
+        buf.write_from_iter(self.content_iter)
+        assert len(buf) == 29
+        assert buf.read(1) == b"b"
+        buf.write_from_iter(self.content_iter)
+        assert buf.read(1) == b"c"
+
+    def test_close(self) -> None:
+        buf = BytesBuffer(10)
+        buf.close()
+        assert len(buf._buffer) == 0
+
+        buf = BytesBuffer(10)
+        buf.write_from_iter(self.content_iter)
+        assert len(buf._buffer) == 10
+        buf.close()
+        assert len(buf._buffer) == 0
+        # close twice test
+        buf.close()
+
+
+class TestBufferedFile(TestCase):
+    @Mocker()
+    def test_http_read(self, rm: Mocker) -> None:
+        url = "http://1.1.1.1/path/to/file"
+        mock_req = rm.get(
+            url,
+            content=string.ascii_lowercase.encode(),
+        )
+
+        buffer_size_tests = [1, 10, 26, 100]
+        for size in buffer_size_tests:
+            rm.reset_mock()
+            obj = HttpBufferedFileLike(url=url, buffer_size=size, headers={"k": "v"})
+            assert mock_req.call_count == 1
+            assert obj.read(0) == b""
+            assert obj.read(1) == b"a"
+            assert obj.read(1) == b"b"
+            assert obj.read(-1) == string.ascii_lowercase.encode()[2:]
+            assert obj.read(1) == b""
+            obj.close()
+
+        with HttpBufferedFileLike(url=url, buffer_size=10, headers={"k": "v"}) as f:
+            assert f.read(-1) == string.ascii_lowercase.encode()
+            assert f.read(100) == b""
+
+    def test_s3_read(self) -> None:
+        content = string.ascii_lowercase.encode()
+        s3 = MagicMock(
+            **{
+                "Object.return_value": MagicMock(
+                    **{
+                        "get.return_value": {
+                            "Body": MagicMock(**{"read.return_value": content}),
+                            "ContentLength": len(content),
+                        }
+                    }
+                )
+            }
+        )
+
+        obj = S3BufferedFileLike(s3, "bucket", "key", 0, 100)
+        assert obj.read(0) == b""
+        assert obj.read(1) == b"a"
+        assert obj.read(3) == b"bcd"
+        assert obj.read(-1) == content[4:] + content
+
+        with S3BufferedFileLike(s3, "bucket", "key", 0, 10) as f:
+            assert f.read(100) == content

--- a/example/datasets/test_annotations/dataset.py
+++ b/example/datasets/test_annotations/dataset.py
@@ -69,7 +69,7 @@ def _load_dataset(uri):
     print("-" * 20)
     print(uri)
     for idx, data, annotations in get_data_loader(uri, "idx-0", "idx-2"):
-        print(f"---->[{idx}] {data}")
+        print(f"---->[{idx}] {data} data-length:{len(data.to_bytes())}")
         ats = "\n".join(
             [f"\t{k}-{v}-{type(v)}-{_get_type(v)}" for k, v in annotations.items()]
         )


### PR DESCRIPTION
## Description
- fix unclosed issue for _make_file
- support HttpBufferedFileLike same as `S3BufferedFileLike`
- tune HTTP get file with timeout, stream and buffered.

## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
