### PR TITLE
feat(model): split model file from tar  to dir

### DIFF
--- a/client/starwhale/base/cloud.py
+++ b/client/starwhale/base/cloud.py
@@ -60,7 +60,6 @@ class CloudRequestMixed:
                 if progress:
                     progress.update(task_id, total=total, advance=len(chunk))
                 f.write(chunk)
-
         if progress:
             # TODO: remove the hack code when api support content-length header
             progress.update(task_id, total=1, completed=1)
@@ -92,10 +91,8 @@ class CloudRequestMixed:
             # default chunk is 8192 Bytes
             _encoder._read = _encoder.read  # type: ignore
             _encoder.read = lambda size: _encoder._read(_UPLOAD_CHUNK_SIZE)  # type: ignore
-
             _headers["Content-Type"] = _encoder.content_type
             _monitor = MultipartEncoderMonitor(_encoder, callback=_progress_bar)
-
             return self.do_http_request(  # type: ignore
                 url_path,
                 instance_uri=instance_uri,

--- a/client/starwhale/consts/__init__.py
+++ b/client/starwhale/consts/__init__.py
@@ -1,4 +1,6 @@
 import pathlib
+from enum import Enum, unique
+from dataclasses import dataclass
 
 # TODO: use str path, not Path Class
 HOMEDIR = pathlib.Path.home()
@@ -116,8 +118,27 @@ class SWDSSubFileType:
     META = "swds_meta"
 
 
+@unique
+class FileType(Enum):
+    MANIFEST = "MANIFEST"
+    SRC = "SRC"
+    SRC_TAR = "SRC_TAR"
+    MODEL = "MODEL"
+    DATA = "DATA"
+
+
+@dataclass
+class FileDesc:
+    path: pathlib.Path
+    name: str
+    size: int
+    file_type: FileType
+    signature: str = ""
+
+
 SWDS_DATA_FNAME_FMT = "data_ubyte_{index}.%s" % SWDSSubFileType.BIN
 ARCHIVED_SWDS_META_FNAME = "archive.%s" % SWDSSubFileType.META
+SWMP_SRC_FNAME = "src.tar"
 
 CURRENT_FNAME = "current"
 

--- a/client/starwhale/core/dataset/copy.py
+++ b/client/starwhale/core/dataset/copy.py
@@ -1,22 +1,91 @@
+import os
+from typing import List, Iterator, Optional
 from pathlib import Path
 
 from rich.progress import Progress
 
-from starwhale.utils import console
-from starwhale.consts import STANDALONE_INSTANCE
+from starwhale.utils import console, load_yaml, NoSupportError
+from starwhale.consts import (
+    FileDesc,
+    FileType,
+    STANDALONE_INSTANCE,
+    DEFAULT_MANIFEST_NAME,
+    ARCHIVED_SWDS_META_FNAME,
+)
+from starwhale.utils.fs import ensure_dir
 from starwhale.base.bundle_copy import BundleCopy
 
+from .store import DatasetStorage
 from .tabular import TabularDataset
 
 
 class DatasetCopy(BundleCopy):
+    def upload_files(self, workdir: Path) -> Iterator[FileDesc]:
+        _manifest = load_yaml(workdir / DEFAULT_MANIFEST_NAME)
+        for _k in _manifest["signature"]:
+            _size, _, _hash = _k.split(":")
+            # TODO: head object by hash name at first
+            _path = workdir / "data" / _hash[: DatasetStorage.short_sign_cnt]
+            yield FileDesc(
+                path=_path,
+                name=os.path.basename(_path),
+                size=_size,
+                file_type=FileType.DATA,
+                signature=_hash,
+            )
+
+        _meta_names = [ARCHIVED_SWDS_META_FNAME]
+
+        for _n in _meta_names:
+            _path = workdir / _n
+
+            yield FileDesc(
+                path=_path,
+                name=os.path.basename(_path),
+                size=_path.stat().st_size,
+                file_type=FileType.SRC_TAR,
+                signature="",
+            )
+
+    def download_files(self, workdir: Path) -> Iterator[FileDesc]:
+        ensure_dir(workdir / "data")
+        _manifest = load_yaml(workdir / DEFAULT_MANIFEST_NAME)
+        for _k in _manifest.get("signature", []):
+            # TODO: parallel download
+            _size, _algo, _hash = _k.split(":")
+            if _algo != DatasetStorage.object_hash_algo:
+                raise NoSupportError(f"download file hash algorithm {_algo}")
+
+            _dest = DatasetStorage._get_object_store_path(_hash)
+
+            yield FileDesc(
+                path=_dest,
+                signature=_hash,
+                size=_size,
+                name=_hash[: DatasetStorage.short_sign_cnt],
+                file_type=FileType.DATA,
+            )
+
+            Path(workdir / "data" / _hash[: DatasetStorage.short_sign_cnt]).symlink_to(
+                _dest
+            )
+
+        for _f in (ARCHIVED_SWDS_META_FNAME,):
+            yield FileDesc(
+                path=workdir / _f,
+                signature="",
+                size=0,
+                name=_f,
+                file_type=FileType.SRC_TAR,
+            )
+
     def _do_ubd_blobs(
         self,
         progress: Progress,
         workdir: Path,
         upload_id: str,
         url_path: str,
-        add_data_uri_header: bool = False,
+        existed_files: Optional[List] = None,
     ) -> None:
         with TabularDataset(
             name=self.bundle_name,
@@ -36,9 +105,7 @@ class DatasetCopy(BundleCopy):
             for row in local.scan():
                 remote.put(row)
 
-        super()._do_ubd_blobs(
-            progress, workdir, upload_id, url_path, add_data_uri_header
-        )
+        super()._do_ubd_blobs(progress, workdir, upload_id, url_path, existed_files)
 
     def _do_download_bundle_dir(self, progress: Progress) -> None:
 

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -154,20 +154,6 @@ def _recover(model: str, force: bool) -> None:
     ModelTermView(model).recover(force)
 
 
-@model_cmd.command(
-    "extract", help="[ONLY Standalone]Extract local model bundle tar file into workdir"
-)
-@click.argument("model")
-@click.option("-f", "--force", is_flag=True, help="Force to extract model bundle")
-@click.option(
-    "--target-dir",
-    default="",
-    help="Extract target dir.if omitted, swcli will use starwhale default workdir",
-)
-def _extract(model: str, force: bool, target_dir: str) -> None:
-    ModelTermView(model).extract(force, target_dir)
-
-
 @model_cmd.command("eval")
 @click.argument("target")
 @click.option(

--- a/client/starwhale/core/model/copy.py
+++ b/client/starwhale/core/model/copy.py
@@ -1,0 +1,70 @@
+import os
+from typing import Iterator
+from pathlib import Path
+
+from starwhale.utils import load_yaml
+from starwhale.consts import FileDesc, FileType, SWMP_SRC_FNAME, DEFAULT_MANIFEST_NAME
+from starwhale.utils.fs import extract_tar
+from starwhale.base.bundle_copy import BundleCopy
+
+
+class ModelCopy(BundleCopy):
+    def upload_files(self, workdir: Path) -> Iterator[FileDesc]:
+        _manifest = load_yaml(workdir / DEFAULT_MANIFEST_NAME)
+        for _m in _manifest.get("resources", []):
+            if _m["type"] != FileType.MODEL.name:
+                continue
+            _path = workdir / _m["path"]
+            yield FileDesc(
+                path=_path,
+                name=_m["name"],
+                size=_path.stat().st_size,
+                file_type=FileType.MODEL,
+                signature=_m["signature"],
+            )
+
+        _meta_names = [SWMP_SRC_FNAME]
+
+        for _n in _meta_names:
+            _path = workdir / _n
+            yield FileDesc(
+                path=_path,
+                name=os.path.basename(_path),
+                size=_path.stat().st_size,
+                file_type=FileType.SRC_TAR,
+                signature="",
+            )
+
+    def download_files(self, workdir: Path) -> Iterator[FileDesc]:
+        _manifest = load_yaml(workdir / DEFAULT_MANIFEST_NAME)
+        for _f in (SWMP_SRC_FNAME,):
+            yield FileDesc(
+                path=workdir / _f,
+                signature="",
+                size=0,
+                name=_f,
+                file_type=FileType.SRC_TAR,
+            )
+            extract_tar(
+                tar_path=workdir / SWMP_SRC_FNAME,
+                dest_dir=workdir / "src",
+                force=False,
+            )
+        # this must after src download
+        for _m in _manifest.get("resources", []):
+            if _m["type"] != FileType.MODEL.name:
+                continue
+            _sign = _m["signature"]
+            _dest = workdir / _m["path"]
+
+            yield FileDesc(
+                path=_dest,
+                signature=_sign,
+                size=0,
+                name=_m["name"],
+                file_type=FileType.MODEL,
+            )
+            # TODO use unified storage
+            # Path(workdir / _m["path"]).symlink_to(
+            #     _dest # the unify dir
+            # )

--- a/client/starwhale/core/model/store.py
+++ b/client/starwhale/core/model/store.py
@@ -1,7 +1,7 @@
 import typing as t
 from pathlib import Path
 
-from starwhale.consts import DEFAULT_MANIFEST_NAME
+from starwhale.consts import VERSION_PREFIX_CNT, DEFAULT_MANIFEST_NAME
 from starwhale.base.type import URIType, BundleType
 from starwhale.base.store import BaseStorage
 
@@ -19,8 +19,12 @@ class ModelStorage(BaseStorage):
         return URIType.MODEL
 
     @property
+    def src_dir_name(self) -> str:
+        return "src"
+
+    @property
     def src_dir(self) -> Path:
-        return self.snapshot_workdir / "src"
+        return self.snapshot_workdir / self.src_dir_name
 
     @property
     def recover_loc(self) -> Path:
@@ -32,4 +36,13 @@ class ModelStorage(BaseStorage):
 
     @property
     def snapshot_workdir(self) -> Path:
-        return self._get_snapshot_workdir_for_bundle()
+        if self.building:
+            return self.tmp_dir
+        version = self.uri.object.version
+        return (
+            self.project_dir
+            / URIType.MODEL
+            / self.uri.object.name
+            / version[:VERSION_PREFIX_CNT]
+            / f"{version}{BundleType.MODEL}"
+        )

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -41,12 +41,6 @@ class ModelTermView(BaseTermView):
             title="Model History List", history=self.model.history(), fullname=fullname
         )
 
-    @BaseTermView._only_standalone
-    def extract(self, force: bool = False, target_dir: str = "") -> None:
-        console.print(":oncoming_police_car: try to extract ...")
-        path = self.model.extract(force, target_dir)
-        console.print(f":clap: extracted @ {path.resolve()} :tada:")
-
     @classmethod
     @BaseTermView._only_standalone
     def eval(

--- a/client/tests/core/test_executor.py
+++ b/client/tests/core/test_executor.py
@@ -43,14 +43,7 @@ class StandaloneEvalExecutor(TestCase):
             / "gn"
             / "gnstmntggi4t111111111111.swmp"
         )
-        model_workdir_path = (
-            project_dir
-            / "workdir"
-            / URIType.MODEL
-            / "mnist"
-            / "gn"
-            / "gnstmntggi4t111111111111"
-        )
+
         dataset_bundle_path = (
             project_dir
             / URIType.DATASET
@@ -74,16 +67,14 @@ class StandaloneEvalExecutor(TestCase):
             / "ga4doztfg4yw11111111111111"
         )
 
-        ensure_dir(model_bundle_path.parent)
-        ensure_file(model_bundle_path, " ")
-        ensure_dir(model_workdir_path)
-        ensure_file(model_workdir_path / DEFAULT_MANIFEST_NAME, "{}")
-        ensure_dir(model_workdir_path / "src")
-        ensure_file(model_workdir_path / "src" / DefaultYAMLName.MODEL, _model_yaml)
-        ensure_dir(model_workdir_path / "src" / "models")
-        ensure_dir(model_workdir_path / "src" / "config")
-        ensure_file(model_workdir_path / "src" / "models" / "mnist_cnn.pt", " ")
-        ensure_file(model_workdir_path / "src" / "config" / "hyperparam.json", " ")
+        ensure_dir(model_bundle_path)
+        ensure_file(model_bundle_path / DEFAULT_MANIFEST_NAME, "{}")
+        ensure_dir(model_bundle_path / "src")
+        ensure_file(model_bundle_path / "src" / DefaultYAMLName.MODEL, _model_yaml)
+        ensure_dir(model_bundle_path / "src" / "models")
+        ensure_dir(model_bundle_path / "src" / "config")
+        ensure_file(model_bundle_path / "src" / "models" / "mnist_cnn.pt", " ")
+        ensure_file(model_bundle_path / "src" / "config" / "hyperparam.json", " ")
 
         ensure_dir(dataset_bundle_path)
         ensure_file(dataset_bundle_path / DEFAULT_MANIFEST_NAME, _dataset_manifest)

--- a/docs/docs/reference/cli/basic.md
+++ b/docs/docs/reference/cli/basic.md
@@ -26,7 +26,7 @@ swcli [OPTIONS] COMMAND [ARGS]...
 |-------|-----------|
 |dataset|Dataset management, build/info/list/copy/tag/render-fuse...|
 |runtime|Runtime management, create/build/copy/activate/restore...|
-|model|Model management, build/copy/ppl/cmp/eval/extract...|
+|model|Model management, build/copy/ppl/cmp/eval...|
 |project|Project management, for standalone and cloud instances|
 |instance|Instance management, login and select standalone or cloud instance|
 |job|Job management, create/list/info/compare evaluation job|

--- a/docs/docs/reference/cli/model.md
+++ b/docs/docs/reference/cli/model.md
@@ -29,7 +29,6 @@ swcli model [OPTIONS] COMMAND [ARGS]...
   |history|✅|✅|
   |info|✅|✅|
   |tag|✅|❌|
-  |extract|✅|❌|
   |copy|✅|✅|
 
 ## Build a model
@@ -275,29 +274,6 @@ swcli model recover [OPTIONS] MODEL
     ```bash
     ❯ swcli model recover mnist/version/hbtdenjxgm4ggnrtmftdgyjzm43tioi
     👏 do successfully
-    ```
-
-## Extract model bundle
-
-```bash
-swcli model extract [OPTIONS] MODEL
-```
-
-- This command extracts the bundled model to target dir. When you copy a model from a remote cloud instance to the local standalone instance, you can extract it and then do some operations, such as updating the code and rebuilding the model.
-- The `MODEL` argument uses the `Model URI` format, which must include the `/version/{version id}` part.
-- Options:
-
-    |Option|Alias Option|Required|Type|Default|Description|
-    |------|--------|-------|-----------|-----|-----------|
-    |`--force`|`-f`|❌|Boolean|False|Force to extract model|
-    |`--target-dir`||❌|String|Starwhale default model workdir|Extract target dir|
-
-- Example:
-
-    ```bash
-    ❯ swcli model extract mnist/version/latest --force
-    🚔 try to extract ...
-    👏 extracted @ /home/liutianwei/.cache/starwhale/self/workdir/model/mnist/gb/gbstgnlgheydqnrtmftdgyjzpe4tezy 🎉
     ```
 
 ## Copy a model

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/guides/model.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/guides/model.md
@@ -42,7 +42,6 @@ title: Starwhale Model-模型包
   - `swcli model build`
 - 分发与复原阶段
   - `swcli model copy`
-  - `swcli model extract`
 - 运行阶段
   - `swcli model eval`
   - `swcli model serve`

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/cli/model.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/cli/model.md
@@ -19,7 +19,6 @@ model包含如下子命令：
 |build||✅|❌|
 |copy|cp|✅|✅|
 |eval||✅|❌|
-|extract||✅|❌|
 |history||✅|✅|
 |info||✅|✅|
 |list|ls|✅|✅|
@@ -82,20 +81,7 @@ swcli model eval [OPTIONS] TARGET
 
 ![model-eval.gif](../../img/model-eval.gif)
 
-## 5. 解压模型包文件
-
-```bash
-swcli model extract [OPTIONS] MODEL
-```
-
-`model extract` 命令可以解压Starwhale Model的 `swmp` 格式文件，查看原始模型包内容，目前**该命令只能在standalone instance下执行**。`MODEL` 参数为Model URI，其他参数如下：
-
-|参数|参数别名|必要性|类型|默认值|说明|
-|------|--------|-------|-----------|-----|-----------|
-|`--force`|`-f`|❌|Boolean|False|若曾经在target-dir目录中extract过，设定该参数后，会强制在target-dir目录覆盖旧的内容|
-|`--target-dir`||❌|String|Model URI对应的snapshot_workdir目录|解压模型包后存储相关内容的目录|
-
-## 6. 查看模型包历史版本
+## 5. 查看模型包历史版本
 
 ```bash
 swcli model history [OPTIONS] MODEL
@@ -107,7 +93,7 @@ swcli model history [OPTIONS] MODEL
 |------|--------|-------|-----------|-----|-----------|
 |`--fullname`||❌|Boolean|False|显示完整的版本信息，默认只显示版本号的前12位。|
 
-## 7. 查看模型包详细信息
+## 6. 查看模型包详细信息
 
 ```bash
 swcli model info [OPTIONS] MODEL
@@ -119,7 +105,7 @@ swcli model info [OPTIONS] MODEL
 |------|--------|-------|-----------|-----|-----------|
 |`--fullname`||❌|Boolean|False|显示完整的版本信息，默认只显示版本号的前12位。|
 
-## 8. 展示模型包列表
+## 7. 展示模型包列表
 
 ```bash
 swcli model list [OPTIONS]
@@ -135,7 +121,7 @@ swcli model list [OPTIONS]
 |`--page`||❌|Integer|1|Cloud Instance中分页显示中page序号。|
 |`--size`||❌|Integer|20|Cloud Instance中分页显示中每页数量。|
 
-## 9. 删除模型包
+## 8. 删除模型包
 
 ```bash
 swcli model remove [OPTIONS] MODEL
@@ -147,7 +133,7 @@ swcli model remove [OPTIONS] MODEL
 |------|--------|-------|-----------|-----|-----------|
 |`--force`|`-f`|❌|Boolean|False|强制删除，不可恢复|
 
-## 10. 恢复软删除的模型包
+## 9. 恢复软删除的模型包
 
 ```bash
 swcli model recover [OPTIONS] MODEL
@@ -159,7 +145,7 @@ swcli model recover [OPTIONS] MODEL
 |------|--------|-------|-----------|-----|-----------|
 |`--force`|`-f`|❌|Boolean|False|强制恢复，处理类似恢复版本冲突的情况。|
 
-## 11. 标记模型包
+## 10. 标记模型包
 
 ```bash
 swcli model tag [OPTIONS] MODEL [TAGS]...

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
@@ -26,8 +26,8 @@ import ai.starwhale.mlops.api.protocol.dataset.DatasetVo;
 import ai.starwhale.mlops.api.protocol.dataset.RevertDatasetRequest;
 import ai.starwhale.mlops.api.protocol.dataset.dataloader.DataConsumptionRequest;
 import ai.starwhale.mlops.api.protocol.dataset.dataloader.DataIndexDesc;
-import ai.starwhale.mlops.api.protocol.dataset.upload.UploadRequest;
-import ai.starwhale.mlops.api.protocol.dataset.upload.UploadResult;
+import ai.starwhale.mlops.api.protocol.dataset.upload.DatasetUploadRequest;
+import ai.starwhale.mlops.api.protocol.upload.UploadResult;
 import com.github.pagehelper.PageInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -229,7 +229,7 @@ public interface DatasetApi {
             @PathVariable(name = "datasetName") String datasetName,
             @PathVariable(name = "versionName") String versionName,
             @Parameter(description = "file detail") @RequestPart(value = "file", required = false) MultipartFile dsFile,
-            UploadRequest uploadRequest);
+            DatasetUploadRequest uploadRequest);
 
     @Operation(summary = "Pull Dataset files",
             description = "Pull Dataset files part by part. ")

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
@@ -25,8 +25,8 @@ import ai.starwhale.mlops.api.protocol.dataset.DatasetVo;
 import ai.starwhale.mlops.api.protocol.dataset.RevertDatasetRequest;
 import ai.starwhale.mlops.api.protocol.dataset.dataloader.DataConsumptionRequest;
 import ai.starwhale.mlops.api.protocol.dataset.dataloader.DataIndexDesc;
-import ai.starwhale.mlops.api.protocol.dataset.upload.UploadRequest;
-import ai.starwhale.mlops.api.protocol.dataset.upload.UploadResult;
+import ai.starwhale.mlops.api.protocol.dataset.upload.DatasetUploadRequest;
+import ai.starwhale.mlops.api.protocol.upload.UploadResult;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.PageParams;
 import ai.starwhale.mlops.common.TagAction;
@@ -172,7 +172,7 @@ public class DatasetController implements DatasetApi {
     @Override
     public ResponseEntity<ResponseMessage<UploadResult>> uploadDs(String uploadId, String uri,
             String projectUrl, String datasetUrl, String versionUrl,
-            MultipartFile dsFile, UploadRequest uploadRequest) {
+            MultipartFile dsFile, DatasetUploadRequest uploadRequest) {
         uploadRequest.setProject(projectUrl);
         uploadRequest.setSwds(datasetUrl + ":" + versionUrl);
         switch (uploadRequest.getPhase()) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ModelApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ModelApi.java
@@ -19,9 +19,10 @@ package ai.starwhale.mlops.api;
 import static ai.starwhale.mlops.domain.bundle.BundleManager.BUNDLE_NAME_REGEX;
 
 import ai.starwhale.mlops.api.protocol.ResponseMessage;
-import ai.starwhale.mlops.api.protocol.model.ClientModelRequest;
+import ai.starwhale.mlops.api.protocol.model.FileType;
 import ai.starwhale.mlops.api.protocol.model.ModelInfoVo;
 import ai.starwhale.mlops.api.protocol.model.ModelTagRequest;
+import ai.starwhale.mlops.api.protocol.model.ModelUploadRequest;
 import ai.starwhale.mlops.api.protocol.model.ModelVersionVo;
 import ai.starwhale.mlops.api.protocol.model.ModelVo;
 import ai.starwhale.mlops.api.protocol.model.RevertModelVersionRequest;
@@ -47,6 +48,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -273,10 +275,12 @@ public interface ModelApi {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})
     @PostMapping(
             value = "/project/{projectUrl}/model/{modelName}/version/{versionName}/file",
-            produces = {"application/json"},
-            consumes = {"multipart/form-data"})
+            produces = {"application/json"})
     @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
-    ResponseEntity<ResponseMessage<String>> upload(
+    ResponseEntity<ResponseMessage<Object>> upload(
+            @RequestHeader(name = "X-SW-UPLOAD-TYPE", required = false) FileType fileType,
+            @RequestHeader(name = "X-SW-UPLOAD-OBJECT-HASH", required = false) String signature,
+            @RequestHeader(name = "X-SW-UPLOAD-ID", required = false) Long uploadId,
             @Parameter(
                     in = ParameterIn.PATH,
                     description = "Project url",
@@ -288,8 +292,8 @@ public interface ModelApi {
             @PathVariable("modelName") String modelName,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @PathVariable("versionName") String versionName,
-            @Parameter(description = "file detail") @RequestPart(value = "file") MultipartFile file,
-            ClientModelRequest uploadRequest);
+            @Parameter(description = "file detail") @RequestPart(value = "file", required = false) MultipartFile file,
+            ModelUploadRequest uploadRequest);
 
     @Operation(summary = "Pull file of a model version",
             description = "Create a new version of the model. ")
@@ -299,6 +303,9 @@ public interface ModelApi {
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
     void pull(
+            @RequestHeader(name = "X-SW-DOWNLOAD-TYPE", required = false) FileType fileType,
+            @RequestHeader(name = "X-SW-DOWNLOAD-OBJECT-NAME", required = false) String name,
+            @RequestHeader(name = "X-SW-DOWNLOAD-OBJECT-HASH", required = false) String signature,
             @PathVariable("projectUrl") String projectUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @Pattern(regexp = BUNDLE_NAME_REGEX, message = "Model name is not invalid.")

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/upload/DatasetUploadRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/upload/DatasetUploadRequest.java
@@ -14,49 +14,25 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.api.protocol.model;
+package ai.starwhale.mlops.api.protocol.dataset.upload;
 
+import ai.starwhale.mlops.api.protocol.upload.UploadRequest;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.validation.annotation.Validated;
 
-/**
- * request protocol of client
- */
+@Validated
 @Data
-public class ClientModelRequest {
-
-    static final String SEPERATOR = ":";
-
-    /**
-     * LATEST is not allowed in upload phase
-     */
-    static final String VERSION_LATEST = "LATEST";
-
-    /**
-     * in formation of name:version
-     */
-    String swmp;
-
-    String project;
-
-    String force;
-
-    String manifest;
+@EqualsAndHashCode(callSuper = true)
+public class DatasetUploadRequest extends UploadRequest {
+    String swds;
 
     public String name() {
-        return swmp.split(SEPERATOR)[0];
+        return swds.split(SEPARATOR)[0];
     }
 
     public String version() {
-        return swmp.split(SEPERATOR)[1];
+        return swds.split(SEPARATOR)[1];
     }
 
-    static final String FORCE = "1";
-
-    public boolean force() {
-        return FORCE.equals(force);
-    }
-
-    public String getProject() {
-        return null == project ? "" : project;
-    }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/model/FileType.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/model/FileType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.model;
+
+public enum FileType {
+    MANIFEST, SRC_TAR, MODEL, DATA
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/model/ModelUploadRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/model/ModelUploadRequest.java
@@ -14,40 +14,36 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.api.protocol.dataset.upload;
+package ai.starwhale.mlops.api.protocol.model;
 
-import javax.validation.constraints.NotNull;
+import ai.starwhale.mlops.api.protocol.upload.UploadRequest;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.springframework.validation.annotation.Validated;
 
+/**
+ * request protocol of client
+ */
 @Validated
 @Data
-public class UploadRequest {
+@EqualsAndHashCode(callSuper = true)
+public class ModelUploadRequest extends UploadRequest {
 
-    static final String SEPARATOR = ":";
+    /**
+     * LATEST is not allowed in upload phase
+     */
+    static final String VERSION_LATEST = "LATEST";
 
-    String swds;
-    @NotNull
-    UploadPhase phase;
-    String force;
-    String project;
-
-    static final String FORCE = "1";
-
-    public boolean force() {
-        return FORCE.equals(force);
-    }
-
-    public String getProject() {
-        return null == project ? "" : project;
-    }
+    /**
+     * in formation of name:version
+     */
+    String swmp;
 
     public String name() {
-        return swds.split(SEPARATOR)[0];
+        return swmp.split(SEPARATOR)[0];
     }
 
     public String version() {
-        return swds.split(SEPARATOR)[1];
+        return swmp.split(SEPARATOR)[1];
     }
-
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/model/ModelUploadResult.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/model/ModelUploadResult.java
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.api.protocol.dataset.upload;
+package ai.starwhale.mlops.api.protocol.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import ai.starwhale.mlops.api.protocol.upload.UploadResult;
+import java.util.Set;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
-public class UploadHeader {
-
-    @JsonProperty("X-SW-UPLOAD-ID")
-    String uploadId;
-    @JsonProperty("Authorization")
-    String token;
-
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ModelUploadResult extends UploadResult {
+    private Set<String> existed;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadHeader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadHeader.java
@@ -14,8 +14,17 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.api.protocol.dataset.upload;
+package ai.starwhale.mlops.api.protocol.upload;
 
-public enum UploadPhase {
-    MANIFEST, BLOB, END, CANCEL
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class UploadHeader {
+
+    @JsonProperty("X-SW-UPLOAD-ID")
+    String uploadId;
+    @JsonProperty("Authorization")
+    String token;
+
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadPhase.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadPhase.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.upload;
+
+public enum UploadPhase {
+    MANIFEST, BLOB, END, CANCEL
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.upload;
+
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@Data
+public abstract class UploadRequest {
+
+    protected static final String SEPARATOR = ":";
+
+    @NotNull
+    UploadPhase phase;
+    String force;
+    String project;
+
+    static final String FORCE = "1";
+
+    public boolean force() {
+        return FORCE.equals(force);
+    }
+
+    public String getProject() {
+        return null == project ? "" : project;
+    }
+
+    public abstract String name();
+
+    public abstract String version();
+
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadResult.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadResult.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.upload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UploadResult {
+
+    @JsonProperty("upload_id")
+    String uploadId;
+
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/upload/DatasetUploader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/upload/DatasetUploader.java
@@ -16,7 +16,7 @@
 
 package ai.starwhale.mlops.domain.dataset.upload;
 
-import ai.starwhale.mlops.api.protocol.dataset.upload.UploadRequest;
+import ai.starwhale.mlops.api.protocol.dataset.upload.DatasetUploadRequest;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.VersionAliasConverter;
 import ai.starwhale.mlops.domain.bundle.BundleManager;
@@ -212,7 +212,7 @@ public class DatasetUploader {
     }
 
     @Transactional
-    public String create(String yamlContent, String fileName, UploadRequest uploadRequest) {
+    public String create(String yamlContent, String fileName, DatasetUploadRequest uploadRequest) {
         Manifest manifest;
         try {
             manifest = yamlMapper.readValue(yamlContent, Manifest.class);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/bo/MetaInfo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/bo/MetaInfo.java
@@ -14,19 +14,35 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.api.protocol.dataset.upload;
+package ai.starwhale.mlops.domain.model.bo;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
+@Builder
 @NoArgsConstructor
-public class UploadResult {
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MetaInfo {
 
-    @JsonProperty("upload_id")
-    String uploadId;
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class FileDesc {
+        String path;
+        String name;
+        String signature;
+        @JsonProperty("duplicate_check")
+        boolean duplicateCheck;
+    }
+
+    List<FileDesc> resources;
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/mapper/ModelVersionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/mapper/ModelVersionMapper.java
@@ -34,7 +34,7 @@ import org.apache.ibatis.jdbc.SQL;
 public interface ModelVersionMapper {
 
     String COLUMNS = "id, version_order, model_id, owner_id, version_name, version_tag, version_meta,"
-            + " storage_path, manifest, created_time, modified_time, eval_jobs";
+            + " storage_path, manifest, created_time, modified_time, eval_jobs, status";
 
     @SelectProvider(value = ModelVersionProvider.class, method = "listSql")
     List<ModelVersionEntity> list(@Param("modelId") Long modelId,
@@ -68,6 +68,9 @@ public interface ModelVersionMapper {
             + " #{storagePath}, #{manifest}, #{evalJobs})")
     @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
     int insert(ModelVersionEntity version);
+
+    @Update("update model_version set status = #{status} where id = #{id}")
+    int updateStatus(@Param("id") Long id, @Param("status") Integer status);
 
     @UpdateProvider(value = ModelVersionProvider.class, method = "updateSql")
     int update(ModelVersionEntity version);
@@ -126,7 +129,16 @@ public interface ModelVersionMapper {
                     if (StrUtil.isNotEmpty(version.getVersionTag())) {
                         SET("version_tag = #{versionTag}");
                     }
-                    WHERE("where id = #{id}");
+                    if (StrUtil.isNotEmpty(version.getEvalJobs())) {
+                        SET("eval_jobs=#{evalJobs}");
+                    }
+                    if (StrUtil.isNotEmpty(version.getManifest())) {
+                        SET("manifest=#{manifest}");
+                    }
+                    if (Objects.nonNull(version.getStatus())) {
+                        SET("status=#{status}");
+                    }
+                    WHERE("id = #{id}");
                 }
             }.toString();
         }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/po/ModelVersionEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/po/ModelVersionEntity.java
@@ -31,6 +31,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class ModelVersionEntity extends BaseEntity implements BundleVersionEntity {
 
+    public static final Integer STATUS_AVAILABLE = 1;
+    public static final Integer STATUS_UN_AVAILABLE = 0;
+
     private Long id;
 
     private Long modelId;
@@ -52,6 +55,11 @@ public class ModelVersionEntity extends BaseEntity implements BundleVersionEntit
     private String manifest;
 
     private String evalJobs;
+
+    /**
+     * 0 - unavailable 1 - available
+     */
+    private Integer status = STATUS_UN_AVAILABLE;
 
     @Override
     public String getName() {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/storage/StoragePathCoordinator.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/storage/StoragePathCoordinator.java
@@ -88,6 +88,11 @@ public class StoragePathCoordinator {
         return allocateBundlePath(projectName, BUNDLE_MODEL, modelName, modelVersion);
     }
 
+    public String allocateCommonModelPoolPath(String projectName, String signature) {
+        return String.format(STORAGE_PATH_FORMATTER_MODEL_POOL,
+                prefix, projectName, BUNDLE_MODEL, signature);
+    }
+
     public String allocateRuntimePath(String projectName, String runtimeName,
             String runtimeVersion) {
         checkKeyWord(runtimeVersion, ValidSubject.RUNTIME);
@@ -101,6 +106,7 @@ public class StoragePathCoordinator {
      * {prefix}/project/{projectName}/{bundleType}/{bundleName}/version/{bundleVersion}
      */
     static final String STORAGE_PATH_FORMATTER_BUNDLE = "%s/project/%s/%s/%s/version/%s";
+    static final String STORAGE_PATH_FORMATTER_MODEL_POOL = "%s/project/%s/%s/%s";
 
     public String allocateBundlePath(String projectName, String bundleName,
             String bundleVersion, String bundleType) {

--- a/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_005__add_model_status.sql
+++ b/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_005__add_model_status.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE `model_version` ADD status TINYINT UNSIGNED DEFAULT 0 NOT NULL;
+UPDATE `model_version` set status = 1 where status is null or status = 0;

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/DatasetControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/DatasetControllerTest.java
@@ -40,8 +40,8 @@ import ai.starwhale.mlops.api.protocol.dataset.DatasetTagRequest;
 import ai.starwhale.mlops.api.protocol.dataset.DatasetVersionVo;
 import ai.starwhale.mlops.api.protocol.dataset.DatasetVo;
 import ai.starwhale.mlops.api.protocol.dataset.RevertDatasetRequest;
-import ai.starwhale.mlops.api.protocol.dataset.upload.UploadPhase;
-import ai.starwhale.mlops.api.protocol.dataset.upload.UploadRequest;
+import ai.starwhale.mlops.api.protocol.dataset.upload.DatasetUploadRequest;
+import ai.starwhale.mlops.api.protocol.upload.UploadPhase;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.PageParams;
 import ai.starwhale.mlops.domain.dataset.DatasetService;
@@ -184,15 +184,15 @@ public class DatasetControllerTest {
     public void testUploadDs() {
         MultipartFile file = new MockMultipartFile("dsFile", "originalName", null,
                 "file_content".getBytes());
-        given(datasetUploader.create(anyString(), anyString(), any(UploadRequest.class)))
+        given(datasetUploader.create(anyString(), anyString(), any(DatasetUploadRequest.class)))
                 .willAnswer((Answer<String>) invocation -> {
                     String yamlContent = invocation.getArgument(0);
                     String fileName = invocation.getArgument(1);
-                    UploadRequest request = invocation.getArgument(2);
+                    DatasetUploadRequest request = invocation.getArgument(2);
                     return String.format("%s-%s-%s-%s",
                             yamlContent, fileName, request.getProject(), request.getSwds());
                 });
-        UploadRequest uploadRequest = new UploadRequest();
+        DatasetUploadRequest uploadRequest = new DatasetUploadRequest();
         uploadRequest.setPhase(UploadPhase.MANIFEST);
         var resp = controller.uploadDs("upload1", "", "p1", "d1", "v1", file, uploadRequest);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetUploaderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetUploaderTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.starwhale.mlops.JobMockHolder;
-import ai.starwhale.mlops.api.protocol.dataset.upload.UploadRequest;
+import ai.starwhale.mlops.api.protocol.dataset.upload.DatasetUploadRequest;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.VersionAliasConverter;
 import ai.starwhale.mlops.configuration.json.ObjectMapperConfig;
@@ -103,7 +103,7 @@ public class DatasetUploaderTest {
                 hotJobHolder, projectManager, dataStoreTableNameHelper, indexWriter, datasetDao, idConvertor,
                 versionAliasConvertor);
 
-        UploadRequest uploadRequest = new UploadRequest();
+        DatasetUploadRequest uploadRequest = new DatasetUploadRequest();
         String dsName = "testds3";
         String dsVersionId = "mizwkzrqgqzdemjwmrtdmmjummzxczi3";
         uploadRequest.setSwds(dsName + ":" + dsVersionId);


### PR DESCRIPTION
## Description
the features are：
1. change swmp type from one tar to dir
2. remove cmd:'swcli model extract'
3. support duplicate validation for model file
4. refactor bundle_copy

the model build and copy flow is:
1. build: (_manifest.yaml, src.tar, models)
2. copy from local to remote: ①upload manifest(generate base record, validate models) and response is{'upload_id':**, 'existed':['model signature', ...]};  ②upload src.tar ③ upload models which not exists at cloud
3. copy from remote to local: ①download manifest ②download src.tar and extract it ③ download models

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
