### PR TITLE
chore(ci): upgrade mypy, prevent numpy lint error in python ver 3.10.7+

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -36,7 +36,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10.6" # https://github.com/python/mypy/issues/13627
+          - "3.10"
 
     needs:
       - filter
@@ -88,7 +88,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10.6" # https://github.com/python/mypy/issues/13627
+          - "3.10"
         os:
           - macos-latest
           - ubuntu-latest
@@ -148,7 +148,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10.6" # https://github.com/python/mypy/issues/13627
+          - "3.10"
     defaults:
       run:
         shell: bash

--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -2,7 +2,7 @@
 black==22.3.0
 jupyter-black==0.3.1
 flake8==4.0.1
-mypy==0.950
+mypy~=0.981
 mypy-extensions==0.4.3
 profimp==0.1.0
 types-PyYAML


### PR DESCRIPTION
## Description

https://github.com/python/mypy/pull/13500

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
