### PR TITLE
chore(ci): disable useless git lfs config

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -159,8 +159,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          lfs: true
 
       - name: Setup python
         uses: actions/setup-python@v3

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,11 @@ build/
 
 # User Test Data
 example/.idea/
-example/mnist/data
+example/mnist/data/
 example/mnist/runtime.yaml
-example/mnist/sw_output
+example/mnist/sw_output/
 example/mnist/test/task_volume
+example/mnist/models/
 example/cifar10/data/
 example/cifar10/models/
 example/PennFudanPed/data/


### PR DESCRIPTION
## Description
- related pr: https://github.com/star-whale/starwhale/pull/1552
- `mnist/models/mnist.pth` file has already been removed, so the client e2e test can disable git lfs to reduce github's network brandwith.

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
