### PR TITLE
deps(client): client/sdk supports python3.11

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -93,6 +93,11 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+        exclude:
+          # https://github.com/pytorch/pytorch/issues/86566
+          # pytorch does not release python 3.11 wheel package for macosx os yet.
+          - os: macos-latest
+            python-version: "3.11"
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -100,7 +105,7 @@ jobs:
 
     needs:
       - filter
-    if: ${{ (github.event_name == 'pull_request' && needs.filter.outputs.client == 'true') || github.event_name == 'push' }}
+    if: ${{(github.event_name == 'pull_request' && needs.filter.outputs.client == 'true') || github.event_name == 'push'}}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -37,7 +37,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-
+          - "3.11"
     needs:
       - filter
     if: ${{ (github.event_name == 'pull_request' && needs.filter.outputs.client == 'true') || github.event_name == 'push' }}
@@ -89,6 +89,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         os:
           - macos-latest
           - ubuntu-latest
@@ -149,6 +150,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -69,6 +69,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/client/setup.py
+++ b/client/setup.py
@@ -22,7 +22,7 @@ install_requires = [
     "commonmark>=0.9.1",
     "textual==0.1.18",
     "jsonlines==3.0.0",
-    "boto3==1.21.0",
+    "boto3==1.26.22",
     "scikit-learn>=0.20.0",
     # Python 3.11 needs dill >= 0.3.6
     "dill>=0.3.6",

--- a/client/setup.py
+++ b/client/setup.py
@@ -22,7 +22,8 @@ install_requires = [
     "commonmark>=0.9.1",
     "textual==0.1.18",
     "jsonlines==3.0.0",
-    "boto3==1.26.22",
+    # botocore(>=1.29.14) fixed the cgi deprecation warning which has been updated in the boto3 1.26.14 version
+    "boto3>=1.26.14",
     "scikit-learn>=0.20.0",
     # Python 3.11 needs dill >= 0.3.6
     "dill>=0.3.6",

--- a/client/setup.py
+++ b/client/setup.py
@@ -24,7 +24,8 @@ install_requires = [
     "jsonlines==3.0.0",
     "boto3==1.21.0",
     "scikit-learn>=0.20.0",
-    "dill==0.3.5.1",
+    # Python 3.11 needs dill >= 0.3.6
+    "dill>=0.3.6",
     "packaging>=21.3",
     "pyarrow>=8.0.0",
     "Jinja2>=3.1.2",
@@ -76,7 +77,7 @@ setup(
       sw = starwhale.cli:cli
       starwhale = starwhale.cli:cli
       """,
-    python_requires=">=3.7, <3.11",
+    python_requires=">=3.7, <=3.11",
     scripts=[
         "scripts/sw-docker-entrypoint",
     ],
@@ -91,6 +92,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -1436,7 +1436,7 @@ class TableWriter(threading.Thread):
         self._queue_run_exceptions: List[Exception] = []
         self._run_exceptions_limits = max(run_exceptions_limits, 0)
 
-        self.setDaemon(True)
+        self.daemon = True
         atexit.register(self.close)
         self.start()
 

--- a/client/starwhale/api/_impl/dataset/builder.py
+++ b/client/starwhale/api/_impl/dataset/builder.py
@@ -569,7 +569,7 @@ class RowWriter(threading.Thread):
 
         self._run_exception: t.Optional[Exception] = None
 
-        self.setDaemon(True)
+        self.daemon = True
         self._builder: t.Optional[BaseBuildExecutor] = None
         if append and append_from_version:
             _cls = create_generic_cls_by_mode(append_with_swds_bin, self.__iter__)

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -121,7 +121,7 @@ _list: t.Callable[[_t_mixed_str_list], t.List[str]] = (
 
 _SUPPORT_CUDA = ["11.3", "11.4", "11.5", "11.6", "11.7"]
 _SUPPORT_CUDNN = {"8": {"support_cuda_versions": ["11.3", "11.4", "11.5", "11.6"]}}
-_SUPPORT_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+_SUPPORT_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 
 class DockerEnv(ASDictMixin):

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -1541,7 +1541,7 @@ class TestRowWriter(BaseTestCase):
         rw._builder = None
         rw.update(DataRow(index=3, data=Binary(b"test"), annotations={"label": 3}))
         assert rw._builder is not None
-        assert rw.isDaemon()
+        assert rw.daemon
         assert isinstance(rw._builder, SWDSBinBuildExecutor)
         assert m_make_swds.call_count == 1
 


### PR DESCRIPTION
## Description
- depend pr: https://github.com/star-whale/starwhale/pull/1588
- upgrade deps:
  - boto3: 
     -  version: `1.21.0` -> `1.26.0`
     -  reason: botocore/utils.py:15: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
  - dill
     -  version: `0.3.5.1` -> `0.3.6`
     -  reason: dill==0.3.5.1 does not work for python3.11.
- **known issue**: https://github.com/pytorch/pytorch/issues/86566 , so we skip client ut for macosx system in the python 3.11.

## Modules
- [x] Client
- [x] Python-SDK


## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
