### PR TITLE
fix(ci): make test of dataset stable

### DIFF
--- a/client/starwhale/utils/fs.py
+++ b/client/starwhale/utils/fs.py
@@ -45,7 +45,11 @@ def ensure_file(
     os.chmod(path, mode)
 
 
-def empty_dir(p: t.Union[str, Path]) -> None:
+def empty_dir(
+    p: t.Union[str, Path],
+    ignore_errors: bool = False,
+    onerror: t.Optional[t.Callable] = None,
+) -> None:
     if not p:
         return
 
@@ -55,7 +59,7 @@ def empty_dir(p: t.Union[str, Path]) -> None:
 
     def _self_empty() -> None:
         if path.is_dir():
-            shutil.rmtree(str(path.resolve()))
+            shutil.rmtree(str(path.resolve()), ignore_errors, onerror)
         else:
             path.unlink()
 

--- a/client/tests/sdk/test_base.py
+++ b/client/tests/sdk/test_base.py
@@ -24,7 +24,8 @@ class BaseTestCase(unittest.TestCase):
         self.mock_atexit.start()
 
     def tearDown(self) -> None:
-        empty_dir(self.local_storage)
+        # use ignore_errors = True to prevent errors like "Directory not empty" caused by missing close action in test
+        empty_dir(self.local_storage, ignore_errors=True)
         os.environ.pop(ENV_SW_CLI_CONFIG, "")
         os.environ.pop(ENV_SW_LOCAL_STORAGE, "")
 

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -42,6 +42,7 @@ class TestDatasetSDK(BaseTestCase):
                     )
                 )
             ds.commit()
+            ds.close()
         return ds.uri
 
     def _init_simple_dataset_with_str_id(self) -> URI:
@@ -55,6 +56,7 @@ class TestDatasetSDK(BaseTestCase):
                     )
                 )
             ds.commit()
+            ds.close()
         return ds.uri
 
     def test_create_from_empty(self) -> None:

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -42,7 +42,6 @@ class TestDatasetSDK(BaseTestCase):
                     )
                 )
             ds.commit()
-            ds.close()
         return ds.uri
 
     def _init_simple_dataset_with_str_id(self) -> URI:
@@ -56,7 +55,6 @@ class TestDatasetSDK(BaseTestCase):
                     )
                 )
             ds.commit()
-            ds.close()
         return ds.uri
 
     def test_create_from_empty(self) -> None:


### PR DESCRIPTION
## Description

Fix

```FAILED tests/sdk/test_dataset_sdk.py::TestDatasetSDK::test_forbid_handler - OSError: [Errno 39] Directory not empty: '/tmp/sw-test-mock-k6gce_c_' ```
 [link](https://github.com/star-whale/starwhale/actions/runs/3644683518/jobs/6154166653)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
