### PR TITLE
bug: fix E2E fail occasionally with s3 client creation error

### DIFF
--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -121,6 +121,7 @@ class DataLoader(metaclass=ABCMeta):
             else:
                 _store = ObjectStore.from_dataset_uri(self.dataset_uri)
 
+        self.logger.info(f"new store backend created for key {_k}")
         self._stores[_k] = _store
         return _store
 


### PR DESCRIPTION
## Description
E2E failed with error occasionally:
![image](https://user-images.githubusercontent.com/89630947/206389200-1f7fbcf1-a2c2-4831-ae89-7416ca7492e7.png)

## reproduce

1. make a model who has 20 tasks
2. restart your computer
3. eval it against a link type dataset locally
4. the same error occurs

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
