### PR TITLE
bug(sdk): fix dataset create cache issue from existed dataset 

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -61,12 +61,12 @@ ci-isort:
 .POHNY: ut
 ut:
 	echo "ut"
-	python -m pytest tests -vvrfEsx --cov-config=.coveragerc --cov=starwhale --cov-report=xml:coverage.xml --cov-report=term-missing
+	python -m pytest tests -vvrfEsxl --cov-config=.coveragerc --cov=starwhale --cov-report=xml:coverage.xml --cov-report=term-missing
 
 .POHNY: fast-ut
 fast-ut:
 	echo "fast ut"
-	python -m pytest tests -vvrfEsx --cov-config=.coveragerc --cov=starwhale --cov-report=xml:coverage.xml --cov-report=term-missing -n auto --dist=loadscope
+	python -m pytest tests -vvrfEsxl --cov-config=.coveragerc --cov=starwhale --cov-report=xml:coverage.xml --cov-report=term-missing -n auto --dist=loadscope
 
 .POHNY: all-check
 all-check: ci-format-checker ci-lint ci-mypy ci-isort fast-ut

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -285,6 +285,7 @@ class TabularDataset:
             _row.data_origin = DataOriginType.INHERIT
             self.put(_row)
 
+        self.flush()
         return last_append_seq_id, rows_cnt
 
     @classmethod


### PR DESCRIPTION
## Description
- add flush for fork_dataset to finish datastore dump
- local test: repeat 100 times for test_create_from_existed
  -  ![Screenshot from 2022-12-08 19-12-17](https://user-images.githubusercontent.com/590748/206432716-2aaeb5f2-9342-4e9d-819f-f8e98e9402a4.png)

## Modules
- [x] Python-SDK


## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
