### PR TITLE
chore(docker): install the correct starwhale version when startup

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -56,16 +56,29 @@ set_pip_cache() {
     python3 -m pip cache dir || true
 }
 
-set_python() {
-    _MANIFEST_RUNTIME=$(swcli -o json runtime info ${SW_RUNTIME_VERSION} | jq -r '.config["environment"]["python"]') || exit 1
+set_py_and_sw() {
+    _MANIFEST_RUNTIME=$(swcli -o json runtime info ${SW_RUNTIME_VERSION} | jq -r ".config.environment.python") || exit 1
     _RUNTIME="python${_MANIFEST_RUNTIME}"
 
-    echo "**** DETECT RUNTIME: ${_RUNTIME}"
+    ORIGIN_SW_VER=$(swcli --version)
+    DETECTED_SW_VER=$(swcli -o json runtime info ${SW_RUNTIME_VERSION} | jq -r ".config.environment.lock.starwhale_version") || exit 1
+    DETECTED_SW_VER=${DETECTED_SW_VER:-$ORIGIN_SW_VER}
 
+    echo "**** DETECT RUNTIME: python version: ${_RUNTIME}, starwhale version: ${DETECTED_SW_VER}"
+
+    # default python version
+    PY_VER="python3.8"
     if [ "$_RUNTIME" = "python3.7" ] || [ "$_RUNTIME" = "python3.9" ] || [ "$_RUNTIME" = "python3.10" ] ; then
-        _update_python_alter "$_RUNTIME"
-    else
-        _update_python_alter "python3.8"
+        PY_VER="$_RUNTIME"
+    fi
+    _update_python_alter "$PY_VER"
+
+    if [ "$PY_VER" != "$_RUNTIME" ] || [ "$DETECTED_SW_VER" != "$ORIGIN_SW_VER" ]; then
+        # ignore the editable dev version
+        if [ "$DETECTED_SW_VER" != "0.0.0.dev0" ]; then
+          # install starwhale for current python
+          python3 -m pip install "starwhale==${DETECTED_SW_VER}" || exit 1
+        fi
     fi
 }
 
@@ -109,7 +122,7 @@ eval_task_prepare(){
         # only remote
         pull_model_and_runtime
     fi
-    set_python
+    set_py_and_sw
     set_pip_cache
 }
 

--- a/client/starwhale/cli/__init__.py
+++ b/client/starwhale/cli/__init__.py
@@ -21,7 +21,7 @@ from .completion import completion_cmd
 
 def create_sw_cli() -> click.core.Group:
     @click.group(cls=AliasedGroup)
-    @click.version_option(version=STARWHALE_VERSION)
+    @click.version_option(version=STARWHALE_VERSION, message="%(version)s")
     @click.option(
         "-v",
         "--verbose",


### PR DESCRIPTION
## Description

Part of #1603

Install the right starwhale cli before execute the real job

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
