### PR TITLE
feat(controller): support deploying serving model workload

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/JobApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/JobApi.java
@@ -20,6 +20,7 @@ import ai.starwhale.mlops.api.protocol.ResponseMessage;
 import ai.starwhale.mlops.api.protocol.job.JobModifyRequest;
 import ai.starwhale.mlops.api.protocol.job.JobRequest;
 import ai.starwhale.mlops.api.protocol.job.JobVo;
+import ai.starwhale.mlops.api.protocol.job.ModelServingRequest;
 import ai.starwhale.mlops.api.protocol.task.TaskVo;
 import ai.starwhale.mlops.domain.dag.bo.Graph;
 import com.github.pagehelper.PageInfo;
@@ -266,4 +267,18 @@ public interface JobApi {
     ResponseEntity<ResponseMessage<String>> recoverJob(
             @Valid @PathVariable("projectUrl") String projectUrl,
             @Valid @PathVariable("jobUrl") String jobUrl);
+
+    @Operation(summary = "Create a new model serving job")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "ok")})
+    @PostMapping(value = "/project/{projectUrl}/serving")
+    @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
+    ResponseEntity<ResponseMessage<String>> createModelServing(
+            @Parameter(
+                    in = ParameterIn.PATH,
+                    description = "Project Url",
+                    schema = @Schema())
+            @PathVariable("projectUrl")
+                    String projectUrl,
+            @Valid @RequestBody ModelServingRequest request);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/ModelServingRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/ModelServingRequest.java
@@ -24,26 +24,18 @@ import org.springframework.validation.annotation.Validated;
 
 @Data
 @Validated
-public class JobRequest implements Serializable {
-
+public class ModelServingRequest implements Serializable {
     @NotNull
     @JsonProperty("modelVersionUrl")
     private String modelVersionUrl;
 
     @NotNull
-    @JsonProperty("datasetVersionUrls")
-    private String datasetVersionUrls;
-
-    @NotNull
     @JsonProperty("runtimeVersionUrl")
     private String runtimeVersionUrl;
-
-    @JsonProperty("comment")
-    private String comment;
 
     @JsonProperty("resourcePool")
     private String resourcePool;
 
-    @JsonProperty("stepSpecOverWrites")
-    private String stepSpecOverWrites;
+    @JsonProperty("ttlInSeconds")
+    private long ttlInSeconds;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/configuration/security/ModelServingTokenValidator.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/configuration/security/ModelServingTokenValidator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.configuration.security;
+
+import ai.starwhale.mlops.common.util.JwtTokenUtil;
+import ai.starwhale.mlops.domain.job.mapper.ModelServingMapper;
+import ai.starwhale.mlops.domain.user.bo.User;
+import ai.starwhale.mlops.exception.SwValidationException;
+import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
+import io.jsonwebtoken.Claims;
+import java.util.Date;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ModelServingTokenValidator implements JwtClaimValidator {
+    private static final String CLAIM_KEY = "model-serving-id";
+    private final JwtTokenUtil jwtTokenUtil;
+    private final ModelServingMapper modelServingMapper;
+
+    public ModelServingTokenValidator(JwtTokenUtil jwtTokenUtil, ModelServingMapper modelServingMapper) {
+        this.jwtTokenUtil = jwtTokenUtil;
+        this.modelServingMapper = modelServingMapper;
+    }
+
+    public String getToken(User owner, Long modelServingId) {
+        String jwtToken = jwtTokenUtil.generateAccessToken(owner, Map.of(CLAIM_KEY, modelServingId));
+        return String.format("Bearer %s", jwtToken);
+    }
+
+    @Override
+    public void validClaims(Claims claims) throws SwValidationException {
+        var val = claims.get(CLAIM_KEY);
+        if (null == val) {
+            return;
+        }
+        long id;
+        try {
+            id = ((Number) val).longValue();
+        } catch (ClassCastException e) {
+            throw new SwValidationException(ValidSubject.USER, "invalid id for model serving");
+        }
+        var m = modelServingMapper.find(id);
+        if (m == null) {
+            throw new SwValidationException(ValidSubject.USER, "can not find model serving by id");
+        }
+        if (m.getFinishedTime() != null && m.getFinishedTime().before(new Date())) {
+            throw new SwValidationException(ValidSubject.USER, "token is expired");
+        }
+        if (m.getIsDeleted() != null && m.getIsDeleted() != 0) {
+            throw new SwValidationException(ValidSubject.USER, "model serving task is deleted");
+        }
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.job;
+
+import ai.starwhale.mlops.common.DockerImage;
+import ai.starwhale.mlops.configuration.RunTimeProperties;
+import ai.starwhale.mlops.configuration.security.ModelServingTokenValidator;
+import ai.starwhale.mlops.domain.job.mapper.ModelServingMapper;
+import ai.starwhale.mlops.domain.job.po.ModelServingEntity;
+import ai.starwhale.mlops.domain.job.status.JobStatus;
+import ai.starwhale.mlops.domain.model.ModelDao;
+import ai.starwhale.mlops.domain.model.mapper.ModelMapper;
+import ai.starwhale.mlops.domain.model.mapper.ModelVersionMapper;
+import ai.starwhale.mlops.domain.model.po.ModelVersionEntity;
+import ai.starwhale.mlops.domain.project.ProjectManager;
+import ai.starwhale.mlops.domain.runtime.RuntimeDao;
+import ai.starwhale.mlops.domain.runtime.mapper.RuntimeMapper;
+import ai.starwhale.mlops.domain.runtime.mapper.RuntimeVersionMapper;
+import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
+import ai.starwhale.mlops.domain.system.SystemSettingService;
+import ai.starwhale.mlops.domain.user.UserService;
+import ai.starwhale.mlops.domain.user.bo.User;
+import ai.starwhale.mlops.exception.SwProcessException;
+import ai.starwhale.mlops.schedule.k8s.K8sClient;
+import ai.starwhale.mlops.schedule.k8s.K8sJobTemplate;
+import io.kubernetes.client.custom.IntOrString;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.openapi.models.V1ServicePort;
+import io.kubernetes.client.openapi.models.V1ServiceSpec;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ModelServingService {
+    private final ModelServingMapper modelServingMapper;
+    private final UserService userService;
+    private final ProjectManager projectManager;
+    private final ModelDao modelDao;
+    private final RuntimeDao runtimeDao;
+    private final K8sClient k8sClient;
+    private final K8sJobTemplate k8sJobTemplate;
+    private final RuntimeMapper runtimeMapper;
+    private final RuntimeVersionMapper runtimeVersionMapper;
+    private final ModelMapper modelMapper;
+    private final ModelVersionMapper modelVersionMapper;
+    private final SystemSettingService systemSettingService;
+    private final String instanceUri;
+    private final RunTimeProperties runTimeProperties;
+    private final ModelServingTokenValidator modelServingTokenValidator;
+
+
+    public ModelServingService(
+            ModelServingMapper modelServingMapper,
+            RuntimeDao runtimeDao,
+            ProjectManager projectManager,
+            ModelDao modelDao,
+            UserService userService,
+            K8sClient k8sClient,
+            K8sJobTemplate k8sJobTemplate,
+            RuntimeMapper runtimeMapper,
+            RuntimeVersionMapper runtimeVersionMapper,
+            ModelMapper modelMapper,
+            ModelVersionMapper modelVersionMapper,
+            SystemSettingService systemSettingService,
+            RunTimeProperties runTimeProperties,
+            @Value("${sw.instance-uri}") String instanceUri,
+            ModelServingTokenValidator modelServingTokenValidator
+    ) {
+        this.modelServingMapper = modelServingMapper;
+        this.runtimeDao = runtimeDao;
+        this.projectManager = projectManager;
+        this.modelDao = modelDao;
+        this.userService = userService;
+        this.k8sClient = k8sClient;
+        this.k8sJobTemplate = k8sJobTemplate;
+        this.runtimeMapper = runtimeMapper;
+        this.runtimeVersionMapper = runtimeVersionMapper;
+        this.modelMapper = modelMapper;
+        this.modelVersionMapper = modelVersionMapper;
+        this.systemSettingService = systemSettingService;
+        this.runTimeProperties = runTimeProperties;
+        this.instanceUri = instanceUri;
+        this.modelServingTokenValidator = modelServingTokenValidator;
+    }
+
+    public Long create(
+            String projectUrl,
+            String modelVersionUrl,
+            String runtimeVersionUrl,
+            String resourcePool,
+            long ttlInSeconds
+    ) {
+        User user = userService.currentUserDetail();
+        Long projectId = projectManager.getProjectId(projectUrl);
+        Long runtimeVersionId = runtimeDao.getRuntimeVersionId(runtimeVersionUrl, null);
+        Long modelVersionId = modelDao.getModelVersionId(modelVersionUrl, null);
+
+        // TODO move the deployment logic into the scheduler
+        var runtime = runtimeVersionMapper.find(runtimeVersionId);
+        var model = modelVersionMapper.find(modelVersionId);
+
+        var entity = ModelServingEntity.builder()
+                .ownerId(user.getId())
+                .runtimeVersionId(runtimeVersionId)
+                .projectId(projectId)
+                .modelVersionId(modelVersionId)
+                .finishedTime(new Date(System.currentTimeMillis() + ttlInSeconds * 1000))
+                .jobStatus(JobStatus.CREATED)
+                .resourcePool(resourcePool)
+                .build();
+
+        modelServingMapper.add(entity);
+        log.info("Model serving job has been created. ID={}", entity.getId());
+
+        try {
+            deploy(runtime, model, projectId.toString(), user, entity.getId());
+        } catch (ApiException e) {
+            log.error(e.getResponseBody(), e);
+            throw new SwProcessException(SwProcessException.ErrorType.SYSTEM, e.getResponseBody(), e);
+        }
+
+        return entity.getId();
+    }
+
+    private void deploy(RuntimeVersionEntity runtime, ModelVersionEntity model, String project, User owner, long id)
+            throws ApiException {
+        // TODO: refactor image generation
+        var image = runtime.getImage();
+        if (systemSettingService.getSystemSetting() != null
+                && systemSettingService.getSystemSetting().getDockerSetting() != null
+                && systemSettingService.getSystemSetting().getDockerSetting().getRegistry() != null
+        ) {
+            image = new DockerImage(image)
+                    .resolve(systemSettingService.getSystemSetting().getDockerSetting().getRegistry());
+        }
+
+        var name = String.format("model-serving-%d", id);
+
+        var rt = runtimeMapper.find(runtime.getRuntimeId());
+        var md = modelMapper.find(model.getModelId());
+
+        var envs = Map.of(
+                "SW_RUNTIME_VERSION", String.format("%s/version/%s", rt.getRuntimeName(), runtime.getId()),
+                "SW_MODEL_VERSION", String.format("%s/version/%s", md.getModelName(), model.getId()),
+                "SW_INSTANCE_URI", instanceUri,
+                "SW_TOKEN", modelServingTokenValidator.getToken(owner, id),
+                "SW_PROJECT", project,
+                "SW_PYPI_INDEX_URL", runTimeProperties.getPypi().getIndexUrl(),
+                "SW_PYPI_EXTRA_INDEX_URL", runTimeProperties.getPypi().getExtraIndexUrl(),
+                "SW_PYPI_TRUSTED_HOST", runTimeProperties.getPypi().getTrustedHost()
+        );
+        var ss = k8sJobTemplate.renderModelServingOrch(envs, image, name);
+        k8sClient.deployStatefulSet(ss);
+
+        var svc = new V1Service();
+        var meta = new V1ObjectMeta();
+        meta.name(name);
+        svc.metadata(meta);
+        var spec = new V1ServiceSpec();
+        svc.spec(spec);
+        var selector = Map.of("app", name);
+        spec.selector(selector);
+        var port = new V1ServicePort();
+        port.name("model-serving-port");
+        port.protocol("TCP");
+        port.port(80);
+        port.targetPort(new IntOrString(8080));
+        spec.ports(List.of(port));
+        k8sClient.deployService(svc);
+        // TODO add owner reference for svc
+        // TODO garbage collection when svc fails
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapper.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.job.mapper;
+
+import ai.starwhale.mlops.domain.job.po.ModelServingEntity;
+import java.util.Arrays;
+import org.apache.commons.text.CaseUtils;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.jdbc.SQL;
+
+@Mapper
+public interface ModelServingMapper {
+    String[] COLUMNS = {
+            "project_id",
+            "model_version_id",
+            "owner_id",
+            "created_time",
+            "finished_time",
+            "job_status",
+            "runtime_version_id",
+            "resource_pool",
+    };
+    String TABLE = "model_serving_info";
+
+    @InsertProvider(value = SqlProviderAdapter.class, method = "insert")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    void add(ModelServingEntity entity);
+
+    @Select("select * from " + TABLE + " where id=#{id}")
+    ModelServingEntity find(long id);
+
+    class SqlProviderAdapter {
+        public String insert() {
+            var values = Arrays.stream(COLUMNS)
+                    .map(i -> "#{" + CaseUtils.toCamelCase(i, false, '_') + "}")
+                    .toArray(String[]::new);
+            return new SQL() {
+                {
+                    INSERT_INTO(TABLE);
+                    INTO_COLUMNS(COLUMNS);
+                    INTO_VALUES(values);
+                }
+            }.toString();
+        }
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/ModelServingEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/ModelServingEntity.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.job.po;
+
+import ai.starwhale.mlops.common.BaseEntity;
+import ai.starwhale.mlops.domain.job.status.JobStatus;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@EqualsAndHashCode
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ModelServingEntity extends BaseEntity {
+    private Long id;
+    private Long projectId;
+    private Long modelVersionId;
+    private Long ownerId;
+    private Date finishedTime;
+    private JobStatus jobStatus;
+    private Long runtimeVersionId;
+    private Integer isDeleted;
+    private String resourcePool;
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
@@ -21,6 +21,7 @@ import io.kubernetes.client.informer.SharedIndexInformer;
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Job;
@@ -30,6 +31,8 @@ import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1NodeList;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.util.CallGeneratorParams;
 import io.kubernetes.client.util.labels.LabelSelector;
 import java.io.IOException;
@@ -52,6 +55,7 @@ public class K8sClient {
     private final ApiClient client;
     private final CoreV1Api coreV1Api;
     private final BatchV1Api batchV1Api;
+    private final AppsV1Api appsV1Api;
 
     private final String ns;
 
@@ -60,11 +64,18 @@ public class K8sClient {
     /**
      * Basic constructor for Kubernetes
      */
-    public K8sClient(ApiClient client, CoreV1Api coreV1Api, BatchV1Api batchV1Api,
-            @Value("${sw.infra.k8s.name-space}") String ns, SharedInformerFactory informerFactory) {
+    public K8sClient(
+            ApiClient client,
+            CoreV1Api coreV1Api,
+            BatchV1Api batchV1Api,
+            AppsV1Api appsV1Api,
+            @Value("${sw.infra.k8s.name-space}") String ns,
+            SharedInformerFactory informerFactory
+    ) {
         this.client = client;
         this.coreV1Api = coreV1Api;
         this.batchV1Api = batchV1Api;
+        this.appsV1Api = appsV1Api;
         this.ns = ns;
         this.informerFactory = informerFactory;
     }
@@ -75,8 +86,16 @@ public class K8sClient {
      * @param job to apply
      * @return submitted job
      */
-    public V1Job deploy(V1Job job) throws ApiException {
+    public V1Job deployJob(V1Job job) throws ApiException {
         return batchV1Api.createNamespacedJob(ns, job, null, null, null, null);
+    }
+
+    public V1StatefulSet deployStatefulSet(V1StatefulSet ss) throws ApiException {
+        return appsV1Api.createNamespacedStatefulSet(ns, ss, null, null, null, null);
+    }
+
+    public V1Service deployService(V1Service svc) throws ApiException {
+        return coreV1Api.createNamespacedService(ns, svc, null, null, null, null);
     }
 
     public void deleteJob(String id) throws ApiException {
@@ -88,7 +107,7 @@ public class K8sClient {
      *
      * @return job list
      */
-    public V1JobList get(String labelSelector) throws ApiException {
+    public V1JobList getJobs(String labelSelector) throws ApiException {
         return batchV1Api.listNamespacedJob(ns, null, null, null, null, labelSelector, null, null, null, 30, null);
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClientConfig.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClientConfig.java
@@ -18,6 +18,7 @@ package ai.starwhale.mlops.schedule.k8s;
 
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.util.Config;
@@ -43,6 +44,11 @@ public class K8sClientConfig {
     @Bean
     public BatchV1Api batchV1Api(ApiClient apiClient) {
         return new BatchV1Api();
+    }
+
+    @Bean
+    public AppsV1Api appsV1Api(ApiClient apiClient) {
+        return new AppsV1Api();
     }
 
     @Bean

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
@@ -138,7 +138,7 @@ public class K8sTaskScheduler implements SwTaskScheduler {
             } catch (ApiException e) {
                 log.debug("try to delete existing k8s job {} before start it, however it doesn't exist", task.getId());
             }
-            k8sClient.deploy(k8sJob);
+            k8sClient.deployJob(k8sJob);
         } catch (ApiException k8sE) {
             log.error(" schedule task failed {}", k8sE.getResponseBody(), k8sE);
             taskFailed(task);

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -33,6 +33,7 @@ sw:
       name-space: ${SW_K8S_NAME_SPACE:default}
       host-path-for-cache: ${SW_K8S_HOST_PATH_FOR_CACHE:}
       job-template-path: ${SW_K8S_JOB_TEMPLATE_PATH:}
+      model-serving-template-path: ${SW_K8S_MODEL_SERVING_TEMPLATE_PATH:}
   storage:
     type: ${SW_STORAGE_TYPE:minio}
     path-prefix: ${SW_STORAGE_PREFIX:starwhale}

--- a/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_006__create_model_serving_info.sql
+++ b/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_006__create_model_serving_info.sql
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE TABLE IF NOT EXISTS `model_serving_info`
+(
+    `id`                 bigint           NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    `project_id`         bigint           NOT NULL,
+    `model_version_id`   bigint           NOT NULL,
+    `owner_id`           bigint           NOT NULL,
+    `created_time`       datetime         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `finished_time`      datetime         NULL     DEFAULT NULL,
+    `job_status`         varchar(50)      NOT NULL,
+    `runtime_version_id` bigint           NOT NULL,
+    `is_deleted`         tinyint UNSIGNED NOT NULL DEFAULT 0,
+    `resource_pool`      varchar(255)     NULL     DEFAULT NULL,
+    PRIMARY KEY (`id`) USING BTREE,
+    INDEX `idx_base_image` (`runtime_version_id`) USING BTREE,
+    INDEX `idx_owner_id` (`owner_id`) USING BTREE,
+    INDEX `idx_swmp_version_id` (`model_version_id`) USING BTREE
+);

--- a/server/controller/src/main/resources/template/model-serving.yaml
+++ b/server/controller/src/main/resources/template/model-serving.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: 'model-serving'
+  labels:
+    owner: starwhale
+spec:
+  selector:
+    matchLabels:
+      app: serve
+  template:
+    metadata:
+      labels:
+        app: serve
+    spec:
+      containers:
+      - name: 'worker'
+        image: 'docker.io/library/busybox'
+        imagePullPolicy: IfNotPresent
+        args:
+        - serve
+        volumeMounts:
+        - mountPath: /root/.cache
+          name: pip-cache
+        - mountPath: /opt/starwhale
+          name: data
+        env:
+        - name: SW_PYPI_INDEX_URL
+          value: https://pypi.doubanio.com/simple/
+        - name: SW_PYPI_TRUSTED_HOST
+          value: pypi.doubanio.com
+        - name: SW_PIP_CACHE_DIR
+          value: /root/.cache/pip
+      volumes:
+      - name: pip-cache
+        hostPath:
+          path: /data
+          type: DirectoryOrCreate
+      - name: data
+        emptyDir: {}

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/JobControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/JobControllerTest.java
@@ -33,11 +33,13 @@ import static org.mockito.Mockito.mock;
 import ai.starwhale.mlops.api.protocol.job.JobModifyRequest;
 import ai.starwhale.mlops.api.protocol.job.JobRequest;
 import ai.starwhale.mlops.api.protocol.job.JobVo;
+import ai.starwhale.mlops.api.protocol.job.ModelServingRequest;
 import ai.starwhale.mlops.api.protocol.task.TaskVo;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.PageParams;
 import ai.starwhale.mlops.domain.dag.DagQuerier;
 import ai.starwhale.mlops.domain.job.JobService;
+import ai.starwhale.mlops.domain.job.ModelServingService;
 import ai.starwhale.mlops.domain.task.TaskService;
 import ai.starwhale.mlops.exception.api.StarwhaleApiException;
 import com.github.pagehelper.Page;
@@ -55,16 +57,20 @@ public class JobControllerTest {
 
     private TaskService taskService;
 
+    private ModelServingService modelServingService;
+
     private DagQuerier dagQuerier;
 
     @BeforeEach
     public void setUp() {
         jobService = mock(JobService.class);
         taskService = mock(TaskService.class);
+        modelServingService = mock(ModelServingService.class);
         dagQuerier = mock(DagQuerier.class);
         controller = new JobController(
                 jobService,
                 taskService,
+                modelServingService,
                 new IdConverter(),
                 dagQuerier
         );
@@ -214,5 +220,18 @@ public class JobControllerTest {
 
         assertThrows(StarwhaleApiException.class,
                 () -> controller.recoverJob("p1", "j2"));
+    }
+
+    @Test
+    public void testCreateModelServing() {
+        given(modelServingService.create("foo", "bar", "baz", "default", 7L)).willReturn(8L);
+        var req = new ModelServingRequest();
+        req.setModelVersionUrl("bar");
+        req.setRuntimeVersionUrl("baz");
+        req.setResourcePool("default");
+        req.setTtlInSeconds(7L);
+        var resp = controller.createModelServing("foo", req);
+        assertThat(resp.getStatusCode(), is(HttpStatus.OK));
+        assertThat(resp.getBody().getData(), is("8"));
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/config/ModelServingTokenValidatorTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/config/ModelServingTokenValidatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.config;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.starwhale.mlops.common.util.JwtTokenUtil;
+import ai.starwhale.mlops.configuration.security.JwtProperties;
+import ai.starwhale.mlops.configuration.security.ModelServingTokenValidator;
+import ai.starwhale.mlops.domain.job.mapper.ModelServingMapper;
+import ai.starwhale.mlops.domain.job.po.ModelServingEntity;
+import ai.starwhale.mlops.domain.user.bo.User;
+import ai.starwhale.mlops.exception.SwValidationException;
+import java.util.Date;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ModelServingTokenValidatorTest {
+    ModelServingTokenValidator modelServingTokenValidator;
+    ModelServingMapper modelServingMapper;
+    JwtTokenUtil jwtTokenUtil;
+    User user;
+
+    @BeforeEach
+    public void setup() {
+        JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setSecret("sw_secret");
+        jwtTokenUtil = new JwtTokenUtil(jwtProperties);
+        modelServingMapper = mock(ModelServingMapper.class);
+        modelServingTokenValidator = new ModelServingTokenValidator(jwtTokenUtil, modelServingMapper);
+        user = User.builder().id(1L).name("starwhale").build();
+    }
+
+    @Test
+    public void testToken() {
+        String token = modelServingTokenValidator.getToken(user, 1L).split(" ")[1];
+        var parsed = jwtTokenUtil.parseJwt(token);
+
+        // not found
+        when(modelServingMapper.find(eq(1L))).thenReturn(null);
+        Assertions.assertThrowsExactly(SwValidationException.class,
+                () -> modelServingTokenValidator.validClaims(parsed));
+
+
+        var entity = ModelServingEntity.builder()
+                .id(1L)
+                .finishedTime(new Date(System.currentTimeMillis() + 1000))
+                .isDeleted(0)
+                .build();
+
+        // valid
+        when(modelServingMapper.find(eq(1L))).thenReturn(entity);
+        modelServingTokenValidator.validClaims(parsed);
+
+        // deleted
+        entity.setIsDeleted(1);
+        when(modelServingMapper.find(eq(1L))).thenReturn(entity);
+        var e = Assertions.assertThrowsExactly(SwValidationException.class,
+                () -> modelServingTokenValidator.validClaims(parsed));
+        Assertions.assertTrue(e.getMessage().contains("deleted"));
+        entity.setIsDeleted(0);
+
+        // expired
+        entity.setFinishedTime(new Date(1));
+        when(modelServingMapper.find(eq(1L))).thenReturn(entity);
+        e = Assertions.assertThrowsExactly(SwValidationException.class,
+                () -> modelServingTokenValidator.validClaims(parsed));
+        Assertions.assertTrue(e.getMessage().contains("expired"));
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.job.mapper;
+
+import ai.starwhale.mlops.domain.MySqlContainerHolder;
+import ai.starwhale.mlops.domain.job.po.ModelServingEntity;
+import ai.starwhale.mlops.domain.job.status.JobStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+
+
+@MybatisTest(properties = {"mybatis.configuration.map-underscore-to-camel-case=true"})
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class ModelServingMapperTest extends MySqlContainerHolder {
+    @Autowired
+    private ModelServingMapper modelServingMapper;
+
+    @Test
+    public void testGetAndSet() {
+        var entity = ModelServingEntity.builder()
+                .modelVersionId(1L)
+                .projectId(2L)
+                .runtimeVersionId(3L)
+                .ownerId(4L)
+                .createUser("foo")
+                .isDeleted(0)
+                .resourcePool("bar")
+                .jobStatus(JobStatus.RUNNING)
+                .build();
+        modelServingMapper.add(entity);
+        var result = modelServingMapper.find(entity.getId());
+        Assertions.assertEquals(entity, result);
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
@@ -28,6 +28,7 @@ import io.kubernetes.client.informer.SharedIndexInformer;
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Job;
@@ -54,6 +55,7 @@ public class K8sClientTest {
     ApiClient client;
     CoreV1Api coreV1Api;
     BatchV1Api batchV1Api;
+    AppsV1Api appsV1Api;
     SharedInformerFactory informerFactory;
     String nameSpace = "nameSpace";
 
@@ -62,14 +64,15 @@ public class K8sClientTest {
         client = mock(ApiClient.class);
         coreV1Api = mock(CoreV1Api.class);
         batchV1Api = mock(BatchV1Api.class);
+        appsV1Api = mock(AppsV1Api.class);
         informerFactory = mock(SharedInformerFactory.class);
-        k8sClient = new K8sClient(client, coreV1Api, batchV1Api, nameSpace, informerFactory);
+        k8sClient = new K8sClient(client, coreV1Api, batchV1Api, appsV1Api, nameSpace, informerFactory);
     }
 
     @Test
     public void testDeploy() throws ApiException {
         V1Job job = new V1Job();
-        k8sClient.deploy(job);
+        k8sClient.deployJob(job);
         verify(batchV1Api).createNamespacedJob(eq(nameSpace), eq(job), any(), eq(null), any(), any());
     }
 
@@ -85,7 +88,7 @@ public class K8sClientTest {
         when(batchV1Api.listNamespacedJob(nameSpace, null, null, null, null, "ls", null, null, null, 30,
                 null)).thenReturn(
                 t);
-        Assertions.assertEquals(t, k8sClient.get("ls"));
+        Assertions.assertEquals(t, k8sClient.getJobs("ls"));
     }
 
     @Test

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
@@ -63,7 +63,7 @@ public class K8sTaskSchedulerTest {
         K8sClient k8sClient = mock(K8sClient.class);
         K8sTaskScheduler scheduler = buildK8sSheduler(k8sClient);
         scheduler.schedule(Set.of(mockTask()));
-        verify(k8sClient).deploy(any());
+        verify(k8sClient).deployJob(any());
     }
 
     @NotNull
@@ -91,7 +91,7 @@ public class K8sTaskSchedulerTest {
     @Test
     public void testException() throws ApiException, IOException {
         K8sClient k8sClient = mock(K8sClient.class);
-        when(k8sClient.deploy(any())).thenThrow(new ApiException());
+        when(k8sClient.deployJob(any())).thenThrow(new ApiException());
         K8sTaskScheduler scheduler = buildK8sSheduler(k8sClient);
         Task task = mockTask();
         scheduler.schedule(Set.of(task));
@@ -103,7 +103,7 @@ public class K8sTaskSchedulerTest {
         var client = mock(K8sClient.class);
 
         var runTimeProperties = new RunTimeProperties("", new Pypi("", "", ""));
-        var k8sJobTemplate = new K8sJobTemplate("", "");
+        var k8sJobTemplate = new K8sJobTemplate("", "", "");
         var scheduler = new K8sTaskScheduler(
                 client,
                 mock(TaskTokenValidator.class),
@@ -124,7 +124,7 @@ public class K8sTaskSchedulerTest {
                 .setRuntimeResources(List.of(new RuntimeResource(ResourceOverwriteSpec.RESOURCE_GPU, 1f, 0f)));
         scheduler.schedule(Set.of(task));
 
-        verify(client, times(2)).deploy(jobArgumentCaptor.capture());
+        verify(client, times(2)).deployJob(jobArgumentCaptor.capture());
         var jobs = jobArgumentCaptor.getAllValues();
         var expectedEnv = new V1EnvVar().name("NVIDIA_VISIBLE_DEVICES").value("");
         Assertions.assertTrue(jobs.get(0).getSpec().getTemplate().getSpec()
@@ -169,7 +169,7 @@ public class K8sTaskSchedulerTest {
     public static class K8sJobTemplateMock extends K8sJobTemplate {
 
         public K8sJobTemplateMock(String templatePath) throws IOException {
-            super("", "/path");
+            super("", "", "/path");
         }
 
         @Override


### PR DESCRIPTION
## Description

- Add api `/api/v1/project/{projectUrl}/serving` for create model serving workload, params are:
  - model version
  - runtime version
  - resource pool
  - time to live 
- directly deploy the workload to k8s (for MVP, need to refactor later)
  - stateful set
  - svc

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
