### PR TITLE
feat(cli): model eval command support use-docker flag

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -121,6 +121,6 @@ case "$1" in
         eval_task_prepare $1 && run
         ;;
     *)
-        exec "$@"
+        eval_task_prepare "starwhale" && exec "$@"
         ;;
 esac

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -191,6 +191,17 @@ def _recover(model: str, force: bool) -> None:
     multiple=True,
     help=f"dataset uri, env is {SWEnv.dataset_uri}",
 )
+@click.option(
+    "--use-docker",
+    is_flag=True,
+    help="[ONLY Standalone]use docker to run evaluation job",
+)
+@click.option("--gencmd", is_flag=True, help="[ONLY Standalone]gen docker run command")
+@click.option(
+    "--image",
+    default="",
+    help="[ONLY Standalone]the image used when use docker",
+)
 def _eval(
     project: str,
     target: str,
@@ -201,6 +212,9 @@ def _eval(
     task_index: int,
     override_task_num: int,
     runtime: str,
+    use_docker: bool,
+    gencmd: bool,
+    image: str,
 ) -> None:
     """
     [ONLY Standalone]Run evaluation processing with root dir of {target}.
@@ -217,6 +231,9 @@ def _eval(
         task_index=task_index,
         task_num=override_task_num,
         dataset_uris=datasets,
+        use_docker=use_docker,
+        gencmd=gencmd,
+        image=image,
     )
 
 

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -2,14 +2,20 @@ import os
 import typing as t
 from pathlib import Path
 
-from starwhale.utils import docker, console, load_yaml, pretty_bytes, in_production
+from starwhale.utils import (
+    docker,
+    console,
+    process,
+    load_yaml,
+    pretty_bytes,
+    in_production,
+)
 from starwhale.consts import DefaultYAMLName, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType, InstanceType
 from starwhale.base.view import BaseTermView
 from starwhale.consts.env import SWEnv
 from starwhale.utils.error import FieldTypeOrValueError
-from starwhale.utils.process import check_call
 from starwhale.core.model.store import ModelStorage
 from starwhale.core.runtime.model import StandaloneRuntime
 from starwhale.core.runtime.process import Process as RuntimeProcess
@@ -87,7 +93,7 @@ class ModelTermView(BaseTermView):
             console.print(f"{cmd}\n")
             if gencmd:
                 return
-            check_call(cmd, shell=True)
+            process.check_call(cmd, shell=True)
             return
 
         kw = dict(

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -2,7 +2,7 @@ import os
 import typing as t
 from pathlib import Path
 
-from starwhale.utils import console, load_yaml, pretty_bytes, in_production, docker
+from starwhale.utils import docker, console, load_yaml, pretty_bytes, in_production
 from starwhale.consts import DefaultYAMLName, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType, InstanceType
@@ -11,9 +11,9 @@ from starwhale.core.model.store import ModelStorage
 from starwhale.core.runtime.process import Process as RuntimeProcess
 
 from .model import Model, StandaloneModel
-from ..runtime.model import StandaloneRuntime
 from ...consts.env import SWEnv
 from ...utils.error import FieldTypeOrValueError
+from ..runtime.model import StandaloneRuntime
 from ...utils.process import check_call
 
 
@@ -116,7 +116,7 @@ class ModelTermView(BaseTermView):
         else:
             _uri = URI(target, URIType.MODEL)
             _store = ModelStorage(_uri)
-            workdir = _store.loc
+            workdir = _store.src_dir
         return workdir
 
     @classmethod

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -7,14 +7,14 @@ from starwhale.consts import DefaultYAMLName, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZ
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType, InstanceType
 from starwhale.base.view import BaseTermView
+from starwhale.consts.env import SWEnv
+from starwhale.utils.error import FieldTypeOrValueError
+from starwhale.utils.process import check_call
 from starwhale.core.model.store import ModelStorage
+from starwhale.core.runtime.model import StandaloneRuntime
 from starwhale.core.runtime.process import Process as RuntimeProcess
 
 from .model import Model, StandaloneModel
-from ...consts.env import SWEnv
-from ...utils.error import FieldTypeOrValueError
-from ..runtime.model import StandaloneRuntime
-from ...utils.process import check_call
 
 
 class ModelTermView(BaseTermView):

--- a/client/starwhale/utils/docker.py
+++ b/client/starwhale/utils/docker.py
@@ -6,7 +6,7 @@ import subprocess
 from pwd import getpwnam
 from pathlib import Path
 
-from starwhale.utils import console, config
+from starwhale.utils import config, console
 from starwhale.consts import SupportArch, CNTR_DEFAULT_PIP_CACHE_DIR
 from starwhale.utils.error import NoSupportError, MissingFieldError
 from starwhale.utils.process import check_call
@@ -152,6 +152,7 @@ def buildx(
     else:
         console.print(":panda_face: start to build image with buildx...")
         check_call(cmd, log=console.print, env=_BUILDX_CMD_ENV)
+
 
 def gen_swcli_docker_cmd(
     image: str,

--- a/client/tests/utils/test_docker.py
+++ b/client/tests/utils/test_docker.py
@@ -1,5 +1,6 @@
 import os
 import getpass as gt
+import tempfile
 from pwd import getpwnam
 from unittest import TestCase
 
@@ -9,20 +10,25 @@ from starwhale.utils.docker import gen_swcli_docker_cmd
 
 class TestDocker(TestCase):
     def test_gen_cmd(self) -> None:
-        cmd = gen_swcli_docker_cmd("image1")
-        self.assertTrue(cmd.startswith("docker run"))
-        args = cmd.split()
-        pwd = os.getcwd()
-        self.assertTrue("-w" in args)
-        self.assertTrue(pwd in args)
-        self.assertTrue(f"{pwd}:{pwd}" in args)
-        self.assertTrue("image1" in args)
-        self.assertTrue(f"SW_USER={gt.getuser()}" in args)
-        self.assertTrue(f"SW_USER_ID={getpwnam(gt.getuser()).pw_uid}" in args)
-        self.assertTrue("SW_USER_GROUP_ID=0" in args)
-        rootdir = config.load_swcli_config()["storage"]["root"]
-        self.assertTrue(f"SW_LOCAL_STORAGE={rootdir}" in args)
-        self.assertTrue(f"{rootdir}:{rootdir}" in args)
-        config_path = config.get_swcli_config_path()
-        self.assertTrue(f"SW_CLI_CONFIG={config_path}" in args)
-        self.assertTrue(f"{config_path}:{config_path}" in args)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config._config = {}
+            print("created temporary directory", tmpdirname)
+            os.environ["SW_CLI_CONFIG"] = tmpdirname + "/config.yaml"
+            os.environ["SW_LOCAL_STORAGE"] = tmpdirname
+            cmd = gen_swcli_docker_cmd("image1")
+            self.assertTrue(cmd.startswith("docker run"))
+            args = cmd.split()
+            pwd = os.getcwd()
+            self.assertTrue("-w" in args)
+            self.assertTrue(pwd in args)
+            self.assertTrue(f"{pwd}:{pwd}" in args)
+            self.assertTrue("image1" in args)
+            self.assertTrue(f"SW_USER={gt.getuser()}" in args)
+            self.assertTrue(f"SW_USER_ID={getpwnam(gt.getuser()).pw_uid}" in args)
+            self.assertTrue("SW_USER_GROUP_ID=0" in args)
+            rootdir = config.load_swcli_config()["storage"]["root"]
+            self.assertTrue(f"SW_LOCAL_STORAGE={rootdir}" in args)
+            self.assertTrue(f"{rootdir}:{rootdir}" in args)
+            config_path = config.get_swcli_config_path()
+            self.assertTrue(f"SW_CLI_CONFIG={config_path}" in args)
+            self.assertTrue(f"{config_path}:{config_path}" in args)

--- a/client/tests/utils/test_docker.py
+++ b/client/tests/utils/test_docker.py
@@ -1,0 +1,28 @@
+import os
+import getpass as gt
+from pwd import getpwnam
+from unittest import TestCase
+
+from starwhale.utils import config
+from starwhale.utils.docker import gen_swcli_docker_cmd
+
+
+class TestDocker(TestCase):
+    def test_gen_cmd(self) -> None:
+        cmd = gen_swcli_docker_cmd("image1")
+        self.assertTrue(cmd.startswith("docker run"))
+        args = cmd.split()
+        pwd = os.getcwd()
+        self.assertTrue("-w" in args)
+        self.assertTrue(pwd in args)
+        self.assertTrue(f"{pwd}:{pwd}" in args)
+        self.assertTrue("image1" in args)
+        self.assertTrue(f"SW_USER={gt.getuser()}" in args)
+        self.assertTrue(f"SW_USER_ID={getpwnam(gt.getuser()).pw_uid}" in args)
+        self.assertTrue("SW_USER_GROUP_ID=0" in args)
+        rootdir = config.load_swcli_config()["storage"]["root"]
+        self.assertTrue(f"SW_LOCAL_STORAGE={rootdir}" in args)
+        self.assertTrue(f"{rootdir}:{rootdir}" in args)
+        config_path = config.get_swcli_config_path()
+        self.assertTrue(f"SW_CLI_CONFIG={config_path}" in args)
+        self.assertTrue(f"{config_path}:{config_path}" in args)

--- a/docs/docs/reference/cli/model.md
+++ b/docs/docs/reference/cli/model.md
@@ -130,7 +130,6 @@ swcli model eval [OPTIONS] MODEL
 
 - This command creates a new job for model evaluation.
 - `MODEL` argument is required. The `Model URI` or model working dir path is ok for the `MODEL` argument.
-- This command does not depend on docker, so you should activate the python environment at first.
 - `model eval` command is beneficial for you to debug ppl/cmp and evaluate models in the standalone instance.
 - Options:
 
@@ -140,7 +139,7 @@ swcli model eval [OPTIONS] MODEL
     |`--name`||❌|String|""|evaluation job name|
     |`--desc`||❌|String|""|evaluation job description|
     |`--project`|`-p`|❌|String|Selected project|Project URI|
-
+    |`--use-docker`||❌|Boolean|False|Only for standalone instance, use docker environment to run model evaluation|
 - Example:
 
     ```bash

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/cli/model.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/cli/model.md
@@ -78,6 +78,9 @@ swcli model eval [OPTIONS] TARGET
 |`--task-index`||❌|Integer|| `--task-index` 参数用来表明 `--step` 中Step的第n个Task会执行，如果不指定 `--task-index`，则该Step中所有Tasks都会执行。Task索引从0开始，会通过 `starwhale.Context` 传入用户程序中，很多场景下Task的索引值用来指导评测数据集如何分割，实现评测的时候同一个Step的不同Task处理不同部分的评测数据集，实现并行提速。另外需要注意的是，`--task-index` 只有在同时设置 `--step` 参数时才生效。|
 |`--runtime`||❌|String||`--runtime`参数为Standalone Instance中的Runtime URI。若设置，则表示模型包构建的时候会使用该Runtime提供的运行时环境；若不设置，则使用当前shell环境作为运行时。设置`--runtime`参数是安全的，只在build运行时才会使用Runtime，不会污染当前shell环境。|
 |`--dataset`||✅||String||Dataset URI，该参数也可以通过 `SW_DATASET_URI` 环境变量来设置。|
+|`--gencmd`||❌|Boolean|False|当选用设置 `--use-docker` 参数后，只输出docker run的命令，不真正运行。该参数只能在Standalone Instance中使用。|
+|`--use-docker`||❌|Boolean|False|选用docker为载体来运行模型评测过程，该参数只能在Standalone Instance中使用。|
+|`--image`||❌|Boolean|False|当选用设置 `--use-docker` 参数后, 该参数生效。此image必须支持swcli命令，你可以先使用`--gencmd`查看具体生成的docker命令。如果`--runtime`被同时指定了，`swcli`会调用runtime的baseimage,本参数不再生效|
 
 ![model-eval.gif](../../img/model-eval.gif)
 


### PR DESCRIPTION
## Description
model eval command support use-docker flag
Tested with 4 commands(starwhale==0.3.3.dev1212202632):
1. swcli -vvv model eval --dataset mnist/version/latest mnist/version/latest --image runtime1 --use-docker
2. swcli -vvv model eval --dataset mnist/version/latest . --image runtime1 --use-docker
3. swcli -vvv model eval --dataset mnist/version/latest . --runtime pytorch/version/latest --use-docker
4. swcli -vvv model eval --dataset mnist/version/latest mnist/version/latest --runtime pytorch/version/latest --use-docker

docker file for runtime1, work dir is pytorch runtime code:
```shell
FROM 10.131.0.1:8083/starwhale:0.3.3.dev1212202632
COPY requirements-sw-lock.txt /
RUN python3 -m pip install -r /requirements-sw-lock.txt
RUN python3 -m pip install starwhale==0.3.3.dev1212202632
```

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
