### PR TITLE
feat(client): support owner:project instead of project name in uri

### DIFF
--- a/client/starwhale/base/uri.py
+++ b/client/starwhale/base/uri.py
@@ -42,7 +42,8 @@ class URI:
         self.instance = ""
         self.instance_type = ""
         self.instance_alias = ""
-        self.project = ""
+        self._owner = ""
+        self._project = ""
         self.object = ObjField()
 
         self._do_parse()
@@ -116,7 +117,8 @@ class URI:
         if self.expected_type == URIType.PROJECT and not raw.startswith(
             URIType.PROJECT + "/"
         ):
-            ok, reason = validate_obj_name(raw)
+            project, owner = URI.uri_to_project_and_owner(raw)
+            ok, reason = validate_obj_name(project)
             if not ok:
                 raise Exception(reason)
             return raw, ""
@@ -235,6 +237,31 @@ class URI:
     @property
     def user_role(self) -> str:
         return self.sw_instance_config.get("user_role", UserRoleType.NORMAL)
+
+    @property
+    def project(self):
+        return URI.project_and_owner_to_uri(self._project, self._owner)
+
+    @project.setter
+    def project(self, proj: str):
+        project, owner = self.uri_to_project_and_owner(proj)
+        self._owner = owner
+        self._project = project
+
+    @staticmethod
+    def project_and_owner_to_uri(proj: str, owner: str):
+        if owner:
+            return f"{owner}:{proj}"
+        else:
+            return proj
+
+    @staticmethod
+    def uri_to_project_and_owner(proj: str) -> t.Tuple[str, str]:
+        _np = proj.split(":", 1)
+        if len(_np) > 1:
+            return _np[1], _np[0]
+        else:
+            return _np[0], ""
 
     @classmethod
     def capsulate_uri_str(

--- a/client/starwhale/cli/board/project_tree.py
+++ b/client/starwhale/cli/board/project_tree.py
@@ -10,6 +10,7 @@ from textual.widgets import NodeID, TreeNode, TreeClick, TreeControl
 
 from starwhale.core.instance.view import InstanceTermView
 from starwhale.core.project.model import Project
+from starwhale.base.uri import URI
 
 
 @dataclass
@@ -84,7 +85,7 @@ class ProjectTree(TreeControl[ProjectEntry]):
         ins = node.data.path
         ps, _ = Project.list(ins)
         for i in ps:
-            proj = i["name"]
+            proj = URI.project_and_owner_to_uri(i["name"], i.get("owner"))
             path = f"{ins}/{proj}"
             await node.add(proj, ProjectEntry(path, True))
 

--- a/client/starwhale/core/project/view.py
+++ b/client/starwhale/core/project/view.py
@@ -45,7 +45,7 @@ class ProjectTermView(BaseTermView):
             _c_project, _c_owner = URI.uri_to_project_and_owner(
                 _current_project)
             _is_current = _name == _c_project and (
-                    _c_owner == "" or _owner == _c_owner)
+                _c_owner == "" or _owner == _c_owner)
 
             result.append(
                 {

--- a/client/starwhale/core/project/view.py
+++ b/client/starwhale/core/project/view.py
@@ -41,14 +41,18 @@ class ProjectTermView(BaseTermView):
         result = list()
         for _p in projects:
             _name = _p["name"]
-            _is_current = _name == _current_project
+            _owner = _p.get("owner", "")
+            _c_project, _c_owner = URI.uri_to_project_and_owner(
+                _current_project)
+            _is_current = _name == _c_project and (
+                    _c_owner == "" or _owner == _c_owner)
 
             result.append(
                 {
                     "in_use": _is_current,
                     "name": _name,
                     "location": _p.get("location", ""),
-                    "owner": _p.get("owner", ""),
+                    "owner": _owner,
                     "created_at": _p["created_at"],
                 }
             )

--- a/client/tests/base/test_uri.py
+++ b/client/tests/base/test_uri.py
@@ -155,7 +155,8 @@ class URITestCase(TestCase):
         assert uri.project == "test2"
         assert uri.object.name == ""
 
-        uri = URI("http://12.2.2.2:8080/project/starwhale:test2", expected_type=URIType.PROJECT)
+        uri = URI("http://12.2.2.2:8080/project/starwhale:test2",
+                  expected_type=URIType.PROJECT)
         assert uri.instance == "http://12.2.2.2:8080"
         assert uri.project == "starwhale:test2"
         assert uri.object.name == ""

--- a/client/tests/base/test_uri.py
+++ b/client/tests/base/test_uri.py
@@ -122,6 +122,11 @@ class URITestCase(TestCase):
         assert uri.instance_type == InstanceType.CLOUD
         assert uri.project == "project_for_test1"
 
+        uri = URI("starwhale:project_for_test1", expected_type=URIType.PROJECT)
+        assert uri.instance == "http://1.1.1.1:8182"
+        assert uri.instance_type == InstanceType.CLOUD
+        assert uri.project == "starwhale:project_for_test1"
+
         uri = URI("test", expected_type=URIType.MODEL)
         assert uri.instance == "http://1.1.1.1:8182"
         assert uri.instance_type == InstanceType.CLOUD
@@ -148,6 +153,11 @@ class URITestCase(TestCase):
         uri = URI("http://12.2.2.2:8080/project/test2", expected_type=URIType.PROJECT)
         assert uri.instance == "http://12.2.2.2:8080"
         assert uri.project == "test2"
+        assert uri.object.name == ""
+
+        uri = URI("http://12.2.2.2:8080/project/starwhale:test2", expected_type=URIType.PROJECT)
+        assert uri.instance == "http://12.2.2.2:8080"
+        assert uri.project == "starwhale:test2"
         assert uri.object.name == ""
 
         uri = URI("mnist/version/g4zwkyjumm2d", expected_type=URIType.RUNTIME)


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
