### PR TITLE
feat(client): support owner:project instead of project name in uri

### DIFF
--- a/client/starwhale/base/uri.py
+++ b/client/starwhale/base/uri.py
@@ -3,12 +3,12 @@ import typing as t
 from pathlib import Path
 from urllib.parse import urlparse
 
-from starwhale.utils import validate_obj_name
-from starwhale.consts import UserRoleType, SW_API_VERSION, VERSION_PREFIX_CNT
 from starwhale.base.type import URIType
+from starwhale.consts import UserRoleType, SW_API_VERSION, VERSION_PREFIX_CNT
 from starwhale.consts.env import SWEnv
-from starwhale.utils.error import URIFormatError
+from starwhale.utils import validate_obj_name
 from starwhale.utils.config import SWCliConfigMixed
+from starwhale.utils.error import URIFormatError
 
 from .type import InstanceType
 
@@ -239,17 +239,17 @@ class URI:
         return self.sw_instance_config.get("user_role", UserRoleType.NORMAL)
 
     @property
-    def project(self):
+    def project(self) -> str:
         return URI.project_and_owner_to_uri(self._project, self._owner)
 
     @project.setter
-    def project(self, proj: str):
+    def project(self, proj: str) -> None:
         project, owner = self.uri_to_project_and_owner(proj)
         self._owner = owner
         self._project = project
 
     @staticmethod
-    def project_and_owner_to_uri(proj: str, owner: str):
+    def project_and_owner_to_uri(proj: str, owner: str) -> str:
         if owner:
             return f"{owner}:{proj}"
         else:

--- a/client/starwhale/base/uri.py
+++ b/client/starwhale/base/uri.py
@@ -42,7 +42,8 @@ class URI:
         self.instance = ""
         self.instance_type = ""
         self.instance_alias = ""
-        self.project = ""
+        self._owner = ""
+        self._project = ""
         self.object = ObjField()
 
         self._do_parse()
@@ -116,7 +117,8 @@ class URI:
         if self.expected_type == URIType.PROJECT and not raw.startswith(
             URIType.PROJECT + "/"
         ):
-            ok, reason = validate_obj_name(raw)
+            project, owner = URI.uri_to_project_and_owner(raw)
+            ok, reason = validate_obj_name(project)
             if not ok:
                 raise Exception(reason)
             return raw, ""
@@ -235,6 +237,31 @@ class URI:
     @property
     def user_role(self) -> str:
         return self.sw_instance_config.get("user_role", UserRoleType.NORMAL)
+
+    @property
+    def project(self):
+        return URI.project_and_owner_to_uri(self._project, self._owner)
+
+    @project.setter
+    def project(self, proj: str):
+        project, owner = self.uri_to_project_and_owner(proj)
+        self._owner = owner
+        self._project = project
+
+    @staticmethod
+    def project_and_owner_to_uri(proj: str, owner: str):
+        if owner:
+            return f"{owner}:{proj}"
+        else:
+            return proj
+
+    @staticmethod
+    def uri_to_project_and_owner(proj: str) -> t.Tuple[str, str]:
+        _np = proj.split(":", 1)
+        if len(_np) > 1:
+            return _np[1], _np[0]
+        else:
+            return _np[0], ""
 
     @classmethod
     def capsulate_uri_str(

--- a/client/starwhale/base/uri.py
+++ b/client/starwhale/base/uri.py
@@ -257,11 +257,11 @@ class URI:
 
     @staticmethod
     def uri_to_project_and_owner(proj: str) -> t.Tuple[str, str]:
-        _np = proj.split(":", 1)
-        if len(_np) > 1:
-            return _np[1], _np[0]
+        _op = proj.split(":", 1)
+        if len(_op) > 1:
+            return _op[1], _op[0]
         else:
-            return _np[0], ""
+            return _op[0], ""
 
     @classmethod
     def capsulate_uri_str(

--- a/client/starwhale/base/uri.py
+++ b/client/starwhale/base/uri.py
@@ -244,9 +244,7 @@ class URI:
 
     @project.setter
     def project(self, proj: str) -> None:
-        project, owner = self.uri_to_project_and_owner(proj)
-        self._owner = owner
-        self._project = project
+        self._project, self._owner = URI.uri_to_project_and_owner(proj)
 
     @staticmethod
     def project_and_owner_to_uri(proj: str, owner: str) -> str:

--- a/client/starwhale/base/uri.py
+++ b/client/starwhale/base/uri.py
@@ -3,12 +3,12 @@ import typing as t
 from pathlib import Path
 from urllib.parse import urlparse
 
-from starwhale.base.type import URIType
-from starwhale.consts import UserRoleType, SW_API_VERSION, VERSION_PREFIX_CNT
-from starwhale.consts.env import SWEnv
 from starwhale.utils import validate_obj_name
-from starwhale.utils.config import SWCliConfigMixed
+from starwhale.consts import UserRoleType, SW_API_VERSION, VERSION_PREFIX_CNT
+from starwhale.base.type import URIType
+from starwhale.consts.env import SWEnv
 from starwhale.utils.error import URIFormatError
+from starwhale.utils.config import SWCliConfigMixed
 
 from .type import InstanceType
 

--- a/client/starwhale/cli/board/project_tree.py
+++ b/client/starwhale/cli/board/project_tree.py
@@ -2,14 +2,15 @@ import typing as t
 from dataclasses import dataclass
 
 import rich.repr
-from rich.text import Text
-from starwhale.base.uri import URI
-from starwhale.core.instance.view import InstanceTermView
-from starwhale.core.project.model import Project
 from textual import events
+from rich.text import Text
 from textual._types import MessageTarget
 from textual.widget import Style, Message, RenderableType
 from textual.widgets import NodeID, TreeNode, TreeClick, TreeControl
+
+from starwhale.base.uri import URI
+from starwhale.core.instance.view import InstanceTermView
+from starwhale.core.project.model import Project
 
 
 @dataclass

--- a/client/starwhale/cli/board/project_tree.py
+++ b/client/starwhale/cli/board/project_tree.py
@@ -2,14 +2,14 @@ import typing as t
 from dataclasses import dataclass
 
 import rich.repr
-from textual import events
 from rich.text import Text
+from starwhale.base.uri import URI
+from starwhale.core.instance.view import InstanceTermView
+from starwhale.core.project.model import Project
+from textual import events
 from textual._types import MessageTarget
 from textual.widget import Style, Message, RenderableType
 from textual.widgets import NodeID, TreeNode, TreeClick, TreeControl
-
-from starwhale.core.instance.view import InstanceTermView
-from starwhale.core.project.model import Project
 
 
 @dataclass
@@ -84,7 +84,7 @@ class ProjectTree(TreeControl[ProjectEntry]):
         ins = node.data.path
         ps, _ = Project.list(ins)
         for i in ps:
-            proj = i["name"]
+            proj = URI.project_and_owner_to_uri(i["name"], i.get("owner", ""))
             path = f"{ins}/{proj}"
             await node.add(proj, ProjectEntry(path, True))
 

--- a/client/starwhale/core/project/view.py
+++ b/client/starwhale/core/project/view.py
@@ -1,15 +1,14 @@
 import sys
 import typing as t
 
-from rich.tree import Tree
 from rich.panel import Panel
 from rich.pretty import Pretty
-
-from starwhale.utils import console, pretty_bytes
-from starwhale.consts import DEFAULT_PROJECT, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
-from starwhale.base.uri import URI
+from rich.tree import Tree
 from starwhale.base.type import URIType
+from starwhale.base.uri import URI
 from starwhale.base.view import BaseTermView
+from starwhale.consts import DEFAULT_PROJECT, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
+from starwhale.utils import console, pretty_bytes
 
 from .model import Project, ProjectObjType
 
@@ -41,14 +40,16 @@ class ProjectTermView(BaseTermView):
         result = list()
         for _p in projects:
             _name = _p["name"]
-            _is_current = _name == _current_project
+            _owner = _p.get("owner", "")
+            _c_project, _c_owner = URI.uri_to_project_and_owner(_current_project)
+            _is_current = _name == _c_project and (_c_owner == "" or _owner == _c_owner)
 
             result.append(
                 {
                     "in_use": _is_current,
                     "name": _name,
                     "location": _p.get("location", ""),
-                    "owner": _p.get("owner", ""),
+                    "owner": _owner,
                     "created_at": _p["created_at"],
                 }
             )

--- a/client/starwhale/core/project/view.py
+++ b/client/starwhale/core/project/view.py
@@ -7,7 +7,8 @@ from rich.tree import Tree
 from starwhale.base.type import URIType
 from starwhale.base.uri import URI
 from starwhale.base.view import BaseTermView
-from starwhale.consts import DEFAULT_PROJECT, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
+from starwhale.consts import DEFAULT_PROJECT, DEFAULT_PAGE_IDX, \
+    DEFAULT_PAGE_SIZE
 from starwhale.utils import console, pretty_bytes
 
 from .model import Project, ProjectObjType

--- a/client/starwhale/core/project/view.py
+++ b/client/starwhale/core/project/view.py
@@ -1,15 +1,15 @@
 import sys
 import typing as t
 
+from rich.tree import Tree
 from rich.panel import Panel
 from rich.pretty import Pretty
-from rich.tree import Tree
-from starwhale.base.type import URIType
-from starwhale.base.uri import URI
-from starwhale.base.view import BaseTermView
-from starwhale.consts import DEFAULT_PROJECT, DEFAULT_PAGE_IDX, \
-    DEFAULT_PAGE_SIZE
+
 from starwhale.utils import console, pretty_bytes
+from starwhale.consts import DEFAULT_PROJECT, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
+from starwhale.base.uri import URI
+from starwhale.base.type import URIType
+from starwhale.base.view import BaseTermView
 
 from .model import Project, ProjectObjType
 

--- a/client/tests/base/test_uri.py
+++ b/client/tests/base/test_uri.py
@@ -1,9 +1,10 @@
 from pyfakefs.fake_filesystem_unittest import TestCase
-from starwhale.base.type import URIType, InstanceType
-from starwhale.base.uri import URI
-from starwhale.utils import config as sw_config
-from starwhale.utils.config import get_swcli_config_path
+
 from tests import get_predefined_config_yaml
+from starwhale.utils import config as sw_config
+from starwhale.base.uri import URI
+from starwhale.base.type import URIType, InstanceType
+from starwhale.utils.config import get_swcli_config_path
 
 _existed_config_contents = get_predefined_config_yaml()
 

--- a/client/tests/base/test_uri.py
+++ b/client/tests/base/test_uri.py
@@ -1,10 +1,9 @@
 from pyfakefs.fake_filesystem_unittest import TestCase
-
-from tests import get_predefined_config_yaml
-from starwhale.utils import config as sw_config
-from starwhale.base.uri import URI
 from starwhale.base.type import URIType, InstanceType
+from starwhale.base.uri import URI
+from starwhale.utils import config as sw_config
 from starwhale.utils.config import get_swcli_config_path
+from tests import get_predefined_config_yaml
 
 _existed_config_contents = get_predefined_config_yaml()
 
@@ -122,6 +121,11 @@ class URITestCase(TestCase):
         assert uri.instance_type == InstanceType.CLOUD
         assert uri.project == "project_for_test1"
 
+        uri = URI("starwhale:project_for_test1", expected_type=URIType.PROJECT)
+        assert uri.instance == "http://1.1.1.1:8182"
+        assert uri.instance_type == InstanceType.CLOUD
+        assert uri.project == "starwhale:project_for_test1"
+
         uri = URI("test", expected_type=URIType.MODEL)
         assert uri.instance == "http://1.1.1.1:8182"
         assert uri.instance_type == InstanceType.CLOUD
@@ -148,6 +152,11 @@ class URITestCase(TestCase):
         uri = URI("http://12.2.2.2:8080/project/test2", expected_type=URIType.PROJECT)
         assert uri.instance == "http://12.2.2.2:8080"
         assert uri.project == "test2"
+        assert uri.object.name == ""
+
+        uri = URI("http://12.2.2.2:8080/project/st:pro", expected_type=URIType.PROJECT)
+        assert uri.instance == "http://12.2.2.2:8080"
+        assert uri.project == "st:pro"
         assert uri.object.name == ""
 
         uri = URI("mnist/version/g4zwkyjumm2d", expected_type=URIType.RUNTIME)


### PR DESCRIPTION
## Description
use owner:project instead of project name in swcli
![图片](https://user-images.githubusercontent.com/25220194/207414196-00ad2442-0e04-4c3f-9b24-ad2b61070fe5.png)
![图片](https://user-images.githubusercontent.com/25220194/207414749-73f546e5-2895-4c46-a37a-0ce721bb1444.png)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
