### PR TITLE
feat: http backend

### DIFF
--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -108,7 +108,7 @@ class DataLoader(metaclass=ABCMeta):
             load_dotenv(auth_env_fpath)
 
     def _get_store(self, row: TabularDatasetRow) -> ObjectStore:
-        _k = f"{self.dataset_uri}.{row.auth_name}"
+        _k = f"{self.dataset_uri}.{row.data_link.scheme}.{row.auth_name}"
         _store = self._stores.get(_k)
         if _store:
             return _store

--- a/client/starwhale/consts/__init__.py
+++ b/client/starwhale/consts/__init__.py
@@ -95,6 +95,7 @@ class SWDSBackendType:
     S3 = "s3"
     LocalFS = "local_fs"
     SignedUrl = "signed_url"
+    Http = "http"
 
 
 class EvalHandlerType:

--- a/client/starwhale/core/dataset/store.py
+++ b/client/starwhale/core/dataset/store.py
@@ -298,6 +298,8 @@ class ObjectStore:
             self.backend = S3StorageBackend(conn)
         elif backend == SWDSBackendType.SignedUrl:
             self.backend = SignedUrlBackend(dataset_uri)
+        elif backend == SWDSBackendType.Http:
+            self.backend = HttpBackend()
         else:
             self.backend = LocalFSStorageBackend()
 
@@ -315,10 +317,14 @@ class ObjectStore:
             raise FieldTypeOrValueError("data_link is empty")
 
         # TODO: support other uri type
-        if data_link.uri.startswith("s3://"):
+        if data_link.scheme in ["s3", "minio", "oss", "aliyun"]:
             backend = SWDSBackendType.S3
             conn = S3Connection.from_uri(data_link.uri, auth_name)
             bucket = conn.bucket
+        elif data_link.scheme in ["http", "https"]:
+            backend = SWDSBackendType.Http
+            bucket = ""
+            conn = None
         else:
             backend = SWDSBackendType.LocalFS
             bucket = ""
@@ -455,6 +461,22 @@ class SignedUrlBackend(StorageBackend, CloudRequestMixed):
             use_raise=True,
         ).json()
         return r["data"].get(uri, "")  # type: ignore
+
+
+class HttpBackend(StorageBackend, CloudRequestMixed):
+    def __init__(self) -> None:
+        super().__init__(kind=SWDSBackendType.Http)
+
+    @http_retry
+    def _make_file(
+        self, auth: str, key_compose: t.Tuple[Link, int, int]
+    ) -> FileLikeObj:
+        _key, _start, _end = key_compose
+        return HttpBufferedFileLike(
+            url=_key.uri,
+            headers={"Range": f"bytes={_start or 0}-{_end or sys.maxsize}"},
+            timeout=90,
+        )
 
 
 _BFType = t.TypeVar("_BFType", bound="BaseBufferedFileLike")

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -620,6 +620,8 @@ class Link(ASDictMixin, SwObject):
     ) -> None:
         self._type = "link"
         self.uri = (str(uri)).strip()
+        _up = urlparse(self.uri)
+        self.scheme = _up.scheme
         self.offset = offset
         self.size = size
         self.auth = auth
@@ -678,8 +680,7 @@ class Link(ASDictMixin, SwObject):
             key_compose = self, 0, 0
             store = ObjectStore.to_signed_http_backend(dataset_uri)
         else:
-            _up = urlparse(self.uri)
-            if _up.scheme:
+            if self.scheme:
                 key_compose = (
                     Link(self.local_fs_uri) if self.local_fs_uri else self,
                     0,

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -412,6 +412,7 @@ class TestJsonDict(TestCase):
                         {
                             "_type": data_store.STRING,
                             "uri": data_store.STRING,
+                            "scheme": data_store.STRING,
                             "offset": data_store.INT64,
                             "size": data_store.INT64,
                             "auth": data_store.UNKNOWN,

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -351,6 +351,7 @@ class TestDatasetCopy(BaseTestCase):
                     "attributes": [
                         {"type": "STRING", "name": "_type"},
                         {"type": "STRING", "name": "uri"},
+                        {"type": "STRING", "name": "scheme"},
                         {"type": "INT64", "name": "offset"},
                         {"type": "INT64", "name": "size"},
                         {"type": "UNKNOWN", "name": "auth"},
@@ -426,6 +427,7 @@ class TestDatasetCopy(BaseTestCase):
                                 {"name": "_type", "type": "STRING"},
                                 {"name": "data_type", "type": "UNKNOWN"},
                                 {"name": "uri", "type": "STRING"},
+                                {"name": "scheme", "type": "STRING"},
                             ],
                         },
                         {"type": "STRING", "name": "data_format"},
@@ -470,6 +472,7 @@ class TestDatasetCopy(BaseTestCase):
                                 "_type": "link",
                                 "data_type": None,
                                 "uri": "111",
+                                "scheme": "",
                             },
                             "data_format": "swds_bin",
                             "data_offset": "0000000000000080",

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -122,19 +122,19 @@ class TestDataLoader(TestCase):
 
         assert loader.kind == DataFormatType.USER_RAW
         assert list(loader._stores.keys()) == [
-            "local/project/self/dataset/mnist/version/1122334455667788."
+            "local/project/self/dataset/mnist/version/1122334455667788.."
         ]
         assert loader._stores[
-            "local/project/self/dataset/mnist/version/1122334455667788."
+            "local/project/self/dataset/mnist/version/1122334455667788.."
         ].bucket == str(data_dir)
         assert (
             loader._stores[
-                "local/project/self/dataset/mnist/version/1122334455667788."
+                "local/project/self/dataset/mnist/version/1122334455667788.."
             ].backend.kind
             == SWDSBackendType.LocalFS
         )
         assert not loader._stores[
-            "local/project/self/dataset/mnist/version/1122334455667788."
+            "local/project/self/dataset/mnist/version/1122334455667788.."
         ].key_prefix
 
         loader = get_data_loader("mnist/version/1122334455667788")
@@ -301,13 +301,13 @@ class TestDataLoader(TestCase):
         assert len(loader._stores) == 3
         assert (
             loader._stores[
-                "local/project/self/dataset/mnist/version/1122334455667788.server1"
+                "local/project/self/dataset/mnist/version/1122334455667788.s3.server1"
             ].backend.kind
             == SWDSBackendType.S3
         )
         assert (
             loader._stores[
-                "local/project/self/dataset/mnist/version/1122334455667788.server1"
+                "local/project/self/dataset/mnist/version/1122334455667788.s3.server1"
             ].bucket
             == "starwhale"
         )
@@ -403,23 +403,23 @@ class TestDataLoader(TestCase):
         assert isinstance(_data, Image)
 
         assert list(loader._stores.keys()) == [
-            "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788."
+            "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788.."
         ]
         backend = loader._stores[
-            "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788."
+            "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788.."
         ].backend
         assert isinstance(backend, SignedUrlBackend)
         assert backend.kind == SWDSBackendType.SignedUrl
 
         assert (
             loader._stores[
-                "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788."
+                "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788.."
             ].bucket
             == ""
         )
         assert (
             loader._stores[
-                "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788."
+                "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788.."
             ].key_prefix
             == ""
         )
@@ -494,18 +494,18 @@ class TestDataLoader(TestCase):
         assert isinstance(_data.to_bytes(), bytes)
 
         assert list(loader._stores.keys()) == [
-            "local/project/self/dataset/mnist/version/1122334455667788."
+            "local/project/self/dataset/mnist/version/1122334455667788.."
         ]
         backend = loader._stores[
-            "local/project/self/dataset/mnist/version/1122334455667788."
+            "local/project/self/dataset/mnist/version/1122334455667788.."
         ].backend
         assert isinstance(backend, LocalFSStorageBackend)
         assert backend.kind == SWDSBackendType.LocalFS
         assert loader._stores[
-            "local/project/self/dataset/mnist/version/1122334455667788."
+            "local/project/self/dataset/mnist/version/1122334455667788.."
         ].bucket == str(data_dir)
         assert not loader._stores[
-            "local/project/self/dataset/mnist/version/1122334455667788."
+            "local/project/self/dataset/mnist/version/1122334455667788.."
         ].key_prefix
 
     @Mocker()

--- a/example/datasets/coco/dataset.py
+++ b/example/datasets/coco/dataset.py
@@ -99,3 +99,32 @@ def do_iter_item_from_remote():
             data_type=Image(display_name=img_name, shape=img_shape),
             with_local_fs_data=False,
         ), anno
+
+
+def do_iter_item_from_http():
+    import requests
+
+    response = requests.get(
+        "https://starwhale-examples.oss-cn-beijing.aliyuncs.com/dataset/coco/extracted/annotations/panoptic_val2017.json"
+    )
+    index = json.loads(response.text)
+    img_dict = {img["id"]: img for img in index["images"]}
+    for anno in index["annotations"]:
+        img_meta = img_dict[anno["image_id"]]
+        img_name = img_meta["file_name"]
+        img_shape = (img_meta["height"], img_meta["width"])
+        msk_f_name = anno["file_name"]
+
+        anno["mask"] = Link(
+            with_local_fs_data=False,
+            data_type=Image(
+                display_name=msk_f_name, shape=img_shape, mime_type=MIMEType.PNG
+            ),
+            uri=f"https://starwhale-examples.oss-cn-beijing.aliyuncs.com/dataset/coco/extracted/annotations/panoptic_val2017/{msk_f_name}",
+        )
+
+        yield Link(
+            uri=f"https://starwhale-examples.oss-cn-beijing.aliyuncs.com/dataset/coco/extracted/val2017/{img_name}",
+            data_type=Image(display_name=img_name, shape=img_shape),
+            with_local_fs_data=False,
+        ), anno

--- a/example/datasets/coco/requirements.txt
+++ b/example/datasets/coco/requirements.txt
@@ -1,2 +1,3 @@
-starwhale==0.3.1
-Pillow==9.2.0
+starwhale
+Pillow
+requests


### PR DESCRIPTION
## Description
add http backend for dataset store

##validation
```shell
$ cd code/starwhale/example/datasets/coco
$ swcli dataset build . --name coco-link --handler dataset:do_iter_item_from_http
$ python3 example.py
```
![image](https://user-images.githubusercontent.com/89630947/207505052-222aa5a6-8d13-4802-be11-3178b109f59e.png)

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
