### PR TITLE
fix(model): file desc typo

### DIFF
--- a/client/starwhale/consts/__init__.py
+++ b/client/starwhale/consts/__init__.py
@@ -119,7 +119,7 @@ class SWDSSubFileType:
 
 
 @unique
-class FileType(Enum):
+class FileDesc(Enum):
     MANIFEST = "MANIFEST"
     SRC = "SRC"
     SRC_TAR = "SRC_TAR"
@@ -135,11 +135,11 @@ class FileFlag:
 
 
 @dataclass
-class FileDesc:
+class FileNode:
     path: pathlib.Path
     name: str
     size: int
-    file_type: FileType
+    file_desc: FileDesc
     signature: str = ""
     flag: str = ""
 

--- a/client/starwhale/core/model/copy.py
+++ b/client/starwhale/core/model/copy.py
@@ -3,23 +3,23 @@ from typing import Iterator
 from pathlib import Path
 
 from starwhale.utils import load_yaml
-from starwhale.consts import FileDesc, FileType, SWMP_SRC_FNAME, DEFAULT_MANIFEST_NAME
+from starwhale.consts import FileDesc, FileNode, SWMP_SRC_FNAME, DEFAULT_MANIFEST_NAME
 from starwhale.utils.fs import extract_tar
 from starwhale.base.bundle_copy import BundleCopy
 
 
 class ModelCopy(BundleCopy):
-    def upload_files(self, workdir: Path) -> Iterator[FileDesc]:
+    def upload_files(self, workdir: Path) -> Iterator[FileNode]:
         _manifest = load_yaml(workdir / DEFAULT_MANIFEST_NAME)
         for _m in _manifest.get("resources", []):
-            if _m["type"] != FileType.MODEL.name:
+            if _m["desc"] != FileDesc.MODEL.name:
                 continue
             _path = workdir / _m["path"]
-            yield FileDesc(
+            yield FileNode(
                 path=_path,
                 name=_m["name"],
                 size=_path.stat().st_size,
-                file_type=FileType.MODEL,
+                file_desc=FileDesc.MODEL,
                 signature=_m["signature"],
             )
 
@@ -27,23 +27,23 @@ class ModelCopy(BundleCopy):
 
         for _n in _meta_names:
             _path = workdir / _n
-            yield FileDesc(
+            yield FileNode(
                 path=_path,
                 name=os.path.basename(_path),
                 size=_path.stat().st_size,
-                file_type=FileType.SRC_TAR,
+                file_desc=FileDesc.SRC_TAR,
                 signature="",
             )
 
-    def download_files(self, workdir: Path) -> Iterator[FileDesc]:
+    def download_files(self, workdir: Path) -> Iterator[FileNode]:
         _manifest = load_yaml(workdir / DEFAULT_MANIFEST_NAME)
         for _f in (SWMP_SRC_FNAME,):
-            yield FileDesc(
+            yield FileNode(
                 path=workdir / _f,
                 signature="",
                 size=0,
                 name=_f,
-                file_type=FileType.SRC_TAR,
+                file_desc=FileDesc.SRC_TAR,
             )
             extract_tar(
                 tar_path=workdir / SWMP_SRC_FNAME,
@@ -52,17 +52,17 @@ class ModelCopy(BundleCopy):
             )
         # this must after src download
         for _m in _manifest.get("resources", []):
-            if _m["type"] != FileType.MODEL.name:
+            if _m["desc"] != FileDesc.MODEL.name:
                 continue
             _sign = _m["signature"]
             _dest = workdir / _m["path"]
 
-            yield FileDesc(
+            yield FileNode(
                 path=_dest,
                 signature=_sign,
                 size=0,
                 name=_m["name"],
-                file_type=FileType.MODEL,
+                file_desc=FileDesc.MODEL,
             )
             # TODO use unified storage
             # Path(workdir / _m["path"]).symlink_to(

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -21,7 +21,7 @@ from starwhale.utils.fs import ensure_dir, ensure_file
 from starwhale.base.type import URIType
 from starwhale.utils.config import SWCliConfigMixed, get_swcli_config_path
 from starwhale.core.model.copy import ModelCopy
-from starwhale.base.bundle_copy import FileType, BundleCopy
+from starwhale.base.bundle_copy import FileDesc, BundleCopy
 from starwhale.core.dataset.copy import DatasetCopy
 from starwhale.core.dataset.store import DatasetStorage
 
@@ -234,7 +234,7 @@ class TestBundleCopy(TestCase):
             HTTPMethod.GET,
             f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?part_name=",
             headers={
-                "X-SW-DOWNLOAD-TYPE": FileType.MANIFEST.name,
+                "X-SW-DOWNLOAD-TYPE": FileDesc.MANIFEST.name,
                 "X-SW-DOWNLOAD-OBJECT-NAME": "_manifest.yaml",
                 "X-SW-DOWNLOAD-OBJECT-HASH": "",
             },
@@ -244,7 +244,7 @@ class TestBundleCopy(TestCase):
             HTTPMethod.GET,
             f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?part_name=",
             headers={
-                "X-SW-DOWNLOAD-TYPE": FileType.SRC_TAR.name,
+                "X-SW-DOWNLOAD-TYPE": FileDesc.SRC_TAR.name,
                 "X-SW-DOWNLOAD-OBJECT-NAME": "src.tar",
                 "X-SW-DOWNLOAD-OBJECT-HASH": "",
             },
@@ -406,7 +406,7 @@ class TestBundleCopy(TestCase):
             upload_request = rm.request(
                 HTTPMethod.POST,
                 f"http://1.1.1.1:8182/api/v1/project/mnist/model/{case['dest_model']}/version/{version}/file",
-                headers={"X-SW-UPLOAD-TYPE": FileType.MANIFEST.name},
+                headers={"X-SW-UPLOAD-TYPE": FileDesc.MANIFEST.name},
                 json={"data": {"upload_id": "123"}},
             )
             ModelCopy(
@@ -447,7 +447,7 @@ class TestBundleCopy(TestCase):
             HTTPMethod.GET,
             f"http://1.1.1.1:8182/api/v1/project/myproject/dataset/mnist/version/{version}/file?part_name=",
             headers={
-                "X-SW-DOWNLOAD-TYPE": FileType.MANIFEST.name,
+                "X-SW-DOWNLOAD-TYPE": FileDesc.MANIFEST.name,
                 "X-SW-DOWNLOAD-OBJECT-NAME": "_manifest.yaml",
                 "X-SW-DOWNLOAD-OBJECT-HASH": "",
             },

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -26,7 +26,7 @@ from starwhale.api._impl.job import Context, context_holder
 from starwhale.core.job.model import Step
 from starwhale.api._impl.model import PipelineHandler, PPLResultIterator
 from starwhale.core.model.view import ModelTermView
-from starwhale.core.model.model import StandaloneModel, resource_to_file_desc
+from starwhale.core.model.model import StandaloneModel, resource_to_file_node
 from starwhale.core.instance.view import InstanceTermView
 from starwhale.base.spec.openapi.components import OpenApi
 
@@ -174,8 +174,8 @@ class StandaloneModelTestCase(TestCase):
         _file = Path("tmp/file.txt")
         ensure_dir("tmp")
         ensure_file(_file, "123456")
-        fd = resource_to_file_desc(
-            [{"path": "file.txt", "type": "SRC"}], parent_path=Path("tmp")
+        fd = resource_to_file_node(
+            [{"path": "file.txt", "desc": "SRC"}], parent_path=Path("tmp")
         )
         assert "file.txt" in fd
         assert fd.get("file.txt").size == 6

--- a/client/tests/data/model/base_manifest.yaml
+++ b/client/tests/data/model/base_manifest.yaml
@@ -8,23 +8,23 @@ resources:
   path: src/model/empty.pt
   size: 10
   signature: 786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce
-  type: MODEL
+  desc: MODEL
 - duplicate_check: false
   name: svc.yaml
   path: src/svc.yaml
   size: 10
   signature: 035bda269db519c0bb15018359b4baf73c447696af19a05af322ab2a051084e71143e662845edaf8c591a382f18da989c6b69e8271f33e58f617a9fc67911370
-  type: SRC
+  desc: SRC
 - duplicate_check: false
   name: runtime.yaml
   path: src/runtime.yaml
   size: 10
   signature: 1dfcf6fbbc0044276e89f1a3e7cde63ac0e96a037e4f0303c514887f6d9c4590af1ee377ab5acbca2535a399f9425d84425d86588d7b4f474b85226ff16789b5
-  type: SRC
+  desc: SRC
 - duplicate_check: false
   name: model.yaml
   path: src/model.yaml
   size: 10
   signature: b0660bfbb4f0d8ac1e4e75ce8d351bebf2e80f5c79816ed2e3b28e4309b57433d6cb027414a45f27a318116a10dec7f93cdb1d4ea99ec3ebb76a7178a4044b26
-  type: SRC
+  desc: SRC
 version: base_mdklqrbwpyrb2s3eme63k5xqno4o4wwmd3n

--- a/client/tests/data/model/compare_manifest.yaml
+++ b/client/tests/data/model/compare_manifest.yaml
@@ -8,23 +8,23 @@ resources:
   path: src/model/empty.pt
   size: 10
   signature: update_786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce
-  type: MODEL
+  desc: MODEL
 - duplicate_check: false
   name: svc2.yaml
   path: src/svc2.yaml
   size: 10
   signature: add_035bda269db519c0bb15018359b4baf73c447696af19a05af322ab2a051084e71143e662845edaf8c591a382f18da989c6b69e8271f33e58f617a9fc67911370
-  type: SRC
+  desc: SRC
 - duplicate_check: false
   name: runtime.yaml
   path: src/runtime.yaml
   size: 10
   signature: 1dfcf6fbbc0044276e89f1a3e7cde63ac0e96a037e4f0303c514887f6d9c4590af1ee377ab5acbca2535a399f9425d84425d86588d7b4f474b85226ff16789b5
-  type: SRC
+  desc: SRC
 - duplicate_check: false
   name: model.yaml
   path: src/model.yaml
   size: 10
   signature: b0660bfbb4f0d8ac1e4e75ce8d351bebf2e80f5c79816ed2e3b28e4309b57433d6cb027414a45f27a318116a10dec7f93cdb1d4ea99ec3ebb76a7178a4044b26
-  type: SRC
+  desc: SRC
 version: compare_mdklqrbwpyrb2s3eme63k5xqno4o4ww

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/storage/FileDesc.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/storage/FileDesc.java
@@ -17,5 +17,5 @@
 package ai.starwhale.mlops.api.protocol.storage;
 
 public enum FileDesc {
-    MANIFEST, SRC_TAR, SRC, MODEL, DATA
+    MANIFEST, SRC_TAR, SRC, MODEL, DATA, UNKNOWN
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/storage/FileNode.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/storage/FileNode.java
@@ -152,7 +152,7 @@ public class FileNode {
             // parse one path
             var fork = FileNode.parse(fileDesc.getPath(), (node) -> {
                 node.setSize(FileUtil.readableFileSize(fileDesc.getSize()));
-                node.setDesc(fileDesc.getDesc().name());
+                node.setDesc(Objects.nonNull(fileDesc.getDesc()) ? fileDesc.getDesc().name() : FileDesc.UNKNOWN.name());
                 node.setSignature(fileDesc.getSignature());
             });
             // merge to main nodes


### PR DESCRIPTION
## Description

1. fix typo bug: change resources type from 'type' to 'desc'
2. rename class name 

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
