### PR TITLE
fix(controller):tune consumption default value to false for param 'isSerial'

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/dataloader/DataConsumptionRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/dataloader/DataConsumptionRequest.java
@@ -28,7 +28,7 @@ public class DataConsumptionRequest {
     /**
      * Whether serial under the same consumer
      */
-    private boolean isSerial = true;
+    private boolean isSerial = false;
 
     private int batchSize;
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
@@ -156,11 +156,11 @@ public class DataReadManager {
                     dataReadLogDao.updateToProcessed(
                             sid, consumerId, indexDesc.getStart(), indexDesc.getEnd());
                 }
-                // Whether to process serially under the same consumer,
-                // if serial is true, unassigned the previous unprocessed data
-                if (isSerial) {
-                    dataReadLogDao.updateUnProcessedToUnAssigned(sid, consumerId);
-                }
+            }
+            // Whether to process serially under the same consumer,
+            // if serial is true, unassigned the previous unprocessed data
+            if (isSerial) {
+                dataReadLogDao.updateUnProcessedToUnAssigned(sid, consumerId);
             }
         } finally {
             lock.unlock();

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadRequest.java
@@ -30,7 +30,7 @@ import lombok.NoArgsConstructor;
 public class DataReadRequest {
     private String sessionId;
     private String consumerId;
-    private boolean isSerial = true;
+    private boolean isSerial = false;
 
     private String datasetName;
     private String datasetVersion;


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
