### PR TITLE
feat(controller): support proxying to the serving model workload

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/common/ProxyServlet.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/ProxyServlet.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.common;
+
+import ai.starwhale.mlops.domain.job.ModelServingService;
+import ai.starwhale.mlops.domain.job.mapper.ModelServingMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.utils.URIUtils;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProxyServlet extends HttpServlet {
+    protected ModelServingMapper modelServingMapper;
+    protected HttpClient httpClient;
+    public static final String MODEL_SERVICE_PREFIX = "model-serving";
+
+    public ProxyServlet(ModelServingMapper modelServingMapper) {
+        this.modelServingMapper = modelServingMapper;
+    }
+
+    @Override
+    public void init() {
+        httpClient = HttpClientBuilder.create().setMaxConnTotal(-1).build();
+    }
+
+    @Override
+    public void service(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        var target = getTarget(req.getPathInfo());
+
+        URI uri;
+        try {
+            uri = new URI(target);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+
+        var host = new HttpHost(URIUtils.extractHost(uri));
+        var request = generateRequest(req, uri.getPath());
+        var response = httpClient.execute(host, request);
+        generateResponse(response, res);
+    }
+
+    protected HttpRequest generateRequest(HttpServletRequest req, String uri) throws IOException {
+        var request = new BasicHttpEntityEnclosingRequest(req.getMethod(), uri);
+        request.setEntity(new InputStreamEntity(req.getInputStream(), req.getContentLength()));
+
+        // copy headers
+        var names = req.getHeaderNames();
+        while (names.hasMoreElements()) {
+            var name = names.nextElement();
+            if (name.equalsIgnoreCase("content-length")) {
+                // use content-length generated above
+                continue;
+            }
+            var header = req.getHeaders(name);
+            while (header.hasMoreElements()) {
+                var h = header.nextElement();
+                request.addHeader(name, h);
+            }
+        }
+
+        return request;
+    }
+
+    protected void generateResponse(HttpResponse origin, HttpServletResponse resp) throws IOException {
+        var code = origin.getStatusLine().getStatusCode();
+        resp.setStatus(code);
+        var entity = origin.getEntity();
+        if (entity == null) {
+            return;
+        }
+        entity.writeTo(resp.getOutputStream());
+    }
+
+    /**
+     * get target url to proxy, only support model serving service for now
+     *
+     * @param uri original uri
+     * @return target url
+     */
+    public String getTarget(String uri) {
+        uri = StringUtils.stripStart(uri, "/");
+        var parts = uri.split("/", 3);
+        if (parts.length < 3) {
+            throw new IllegalArgumentException("can not parse uri " + uri);
+        }
+        if (!parts[0].equals(MODEL_SERVICE_PREFIX)) {
+            throw new IllegalArgumentException("can not recognize prefix " + parts[0]);
+        }
+        var id = Long.parseLong(parts[1]);
+
+        // TODO add cache
+        if (modelServingMapper.find(id) == null) {
+            throw new IllegalArgumentException("can not find model serving entry " + parts[1]);
+        }
+
+        var svc = ModelServingService.getServiceName(id);
+        return String.format("http://%s/%s", svc, parts[2]);
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/configuration/ProxyServletConfiguration.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/configuration/ProxyServletConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.configuration;
+
+import ai.starwhale.mlops.common.ProxyServlet;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ProxyServletConfiguration {
+    @Bean
+    public ServletRegistrationBean<ProxyServlet> servletRegistrationBean(ProxyServlet proxyServlet) {
+        return new ServletRegistrationBean<>(proxyServlet, "/gateway/*");
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
@@ -155,7 +155,7 @@ public class ModelServingService {
                     .resolve(systemSettingService.getSystemSetting().getDockerSetting().getRegistry());
         }
 
-        var name = String.format("model-serving-%d", id);
+        var name = getServiceName(id);
 
         var rt = runtimeMapper.find(runtime.getRuntimeId());
         var md = modelMapper.find(model.getModelId());
@@ -190,5 +190,9 @@ public class ModelServingService {
         k8sClient.deployService(svc);
         // TODO add owner reference for svc
         // TODO garbage collection when svc fails
+    }
+
+    public static String getServiceName(long id) {
+        return String.format("model-serving-%d", id);
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/ProxyServletTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/ProxyServletTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.common;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.intThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.starwhale.mlops.domain.job.mapper.ModelServingMapper;
+import ai.starwhale.mlops.domain.job.po.ModelServingEntity;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ProxyServletTest {
+    private ProxyServlet proxyServlet;
+    private ModelServingMapper modelServingMapper;
+
+    @BeforeEach
+    public void setUp() {
+        modelServingMapper = mock(ModelServingMapper.class);
+        proxyServlet = new ProxyServlet(modelServingMapper);
+    }
+
+    @Test
+    public void testGetTarget() {
+        long id = 1L;
+        when(modelServingMapper.find(id)).thenReturn(ModelServingEntity.builder().build());
+
+        var uri = String.format("/%s/%d/ppl", ProxyServlet.MODEL_SERVICE_PREFIX, id);
+        var rt = proxyServlet.getTarget(uri);
+        Assertions.assertEquals("http://model-serving-1/ppl", rt);
+
+        var tooShort = ProxyServlet.MODEL_SERVICE_PREFIX + "/1";
+        Assertions.assertThrows(IllegalArgumentException.class, () -> proxyServlet.getTarget(tooShort));
+
+        var wrongStartsWith = "/foo/1/ppl";
+        Assertions.assertThrows(IllegalArgumentException.class, () -> proxyServlet.getTarget(wrongStartsWith));
+
+        var notFound = String.format("/%s/%d/ppl", ProxyServlet.MODEL_SERVICE_PREFIX, id + 1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> proxyServlet.getTarget(notFound));
+    }
+
+    @Test
+    public void testService() throws ServletException, IOException {
+        proxyServlet.init();
+
+        var req = mock(HttpServletRequest.class);
+        var uri = String.format("/%s/1/ppl", ProxyServlet.MODEL_SERVICE_PREFIX);
+        when(req.getPathInfo()).thenReturn(uri);
+        when(req.getMethod()).thenReturn("GET");
+        var inputStream = mock(ServletInputStream.class);
+        when(req.getInputStream()).thenReturn(inputStream);
+        when(req.getHeaderNames()).thenReturn(Collections.enumeration(List.of()));
+
+        var resp = mock(HttpServletResponse.class);
+        var outputStream = mock(ServletOutputStream.class);
+        when(resp.getOutputStream()).thenReturn(outputStream);
+
+        var servlet = spy(proxyServlet);
+        doReturn("https://starwhale.ai/").when(servlet).getTarget(any());
+        servlet.service(req, resp);
+        verify(outputStream, atLeastOnce()).write(any(), anyInt(), intThat(len -> len > 0));
+    }
+}
+


### PR DESCRIPTION
## Description

live demo

```bash
# curl -s http://jialei.pre.intra.starwhale.ai/gateway/model-serving/20/ppl -X POST -F "data=@/home/foo/foo" | jq
[
  [
    9
  ],
  [
    [
      3.3270520369869727e-09,
      1.2171811490062852e-10,
      1.2030677147728627e-09,
      1.7674929805337285e-09,
      9.05094143771982e-05,
      6.260217371438276e-08,
      4.5112372466471804e-10,
      4.308098875417157e-06,
      1.1480706309613537e-05,
      0.999893676619871
    ]
  ]
]
```

api spec in model
http://jialei.pre.intra.starwhale.ai/gateway/model-serving/20/api-spec



## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
