### PR TITLE
feat: add support for controller to get http uri content

### DIFF
--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/objectstore/DsFileGetterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/objectstore/DsFileGetterTest.java
@@ -55,6 +55,15 @@ public class DsFileGetterTest {
     }
 
     @Test
+    public void testDataOfHttp() {
+        DsFileGetter fileGetter = new DsFileGetter(null, null);
+        byte[] bytes = fileGetter.dataOf(1L,
+                "https://starwhale-examples.oss-cn-beijing.aliyuncs.com/dataset/celeba/img_align_celeba/000003.jpg",
+                -1L, -1L);
+        Assertions.assertEquals(4253, bytes.length);
+    }
+
+    @Test
     public void testLinkOf() throws IOException {
         StorageAccessParser storageAccessParser = mock(StorageAccessParser.class);
         StorageAccessService storageAccessService = mock(

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/objectstore/DsFileGetterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/objectstore/DsFileGetterTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.when;
 
 import ai.starwhale.mlops.domain.dataset.mapper.DatasetVersionMapper;
 import ai.starwhale.mlops.domain.dataset.po.DatasetVersionEntity;
+import ai.starwhale.mlops.exception.SwProcessException;
+import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.storage.LengthAbleInputStream;
 import ai.starwhale.mlops.storage.StorageAccessService;
 import ai.starwhale.mlops.storage.StorageObjectInfo;
@@ -61,6 +63,14 @@ public class DsFileGetterTest {
                 "https://starwhale-examples.oss-cn-beijing.aliyuncs.com/dataset/celeba/img_align_celeba/000003.jpg",
                 -1L, -1L);
         Assertions.assertEquals(4253, bytes.length);
+
+        Assertions.assertThrows(SwProcessException.class, () -> fileGetter.dataOf(1L,
+                "https://starwhale-examples.oss-cn-beijing.aliyuncs.com/dataset/celeba/img_align_celeba/000003.jpgasfa",
+                -1L, -1L));
+
+        Assertions.assertThrows(SwValidationException.class, () -> fileGetter.dataOf(1L,
+                "https://abcd:adg",
+                -1L, -1L));
     }
 
     @Test


### PR DESCRIPTION
## Description
add support for controller to get http uri content
## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
