### PR TITLE
fix: typo in storage path(citycapes -> cityscapes)

### DIFF
--- a/example/datasets/citycapes/person_bbox/dataset.py
+++ b/example/datasets/citycapes/person_bbox/dataset.py
@@ -3,7 +3,7 @@ import requests
 from starwhale import Link, Image, dataset, MIMEType, BoundingBox  # noqa: F401
 from starwhale.utils.retry import http_retry
 
-PATH_ROOT = "https://starwhale-examples.oss-cn-beijing.aliyuncs.com/dataset/citycapes"
+PATH_ROOT = "https://starwhale-examples.oss-cn-beijing.aliyuncs.com/dataset/cityscapes"
 ANNO_PATH = "gtBboxCityPersons/train"
 DATA_PATH = "leftImg8bit/train"
 SUFFIX_ANNO = "_gtBboxCityPersons.json"


### PR DESCRIPTION
## Description
fix typo in storage path(citycapes -> cityscapes)
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
