### PR TITLE
refactor: take equal treatment to dataset data and annotation

### DIFF
--- a/client/starwhale/__init__.py
+++ b/client/starwhale/__init__.py
@@ -27,7 +27,6 @@ from starwhale.api.dataset import (
     DefaultS3LinkAuth,
     COCOObjectAnnotation,
     SWDSBinBuildExecutor,
-    UserRawBuildExecutor,
 )
 from starwhale.api.evaluation import Evaluation
 from starwhale.core.dataset.tabular import get_dataset_consumption
@@ -55,7 +54,6 @@ __all__ = [
     "MIMEType",
     "LinkType",
     "BuildExecutor",  # SWDSBinBuildExecutor alias
-    "UserRawBuildExecutor",
     "SWDSBinBuildExecutor",
     "Binary",
     "Text",

--- a/client/starwhale/api/_impl/dataset/__init__.py
+++ b/client/starwhale/api/_impl/dataset/__init__.py
@@ -22,7 +22,7 @@ from starwhale.core.dataset.type import (
 
 from .model import Dataset
 from .loader import get_data_loader, SWDSBinDataLoader, UserRawDataLoader
-from .builder import BuildExecutor, SWDSBinBuildExecutor, UserRawBuildExecutor
+from .builder import BuildExecutor, SWDSBinBuildExecutor
 
 __all__ = [
     "get_data_loader",
@@ -34,7 +34,6 @@ __all__ = [
     "MIMEType",
     "LinkType",
     "BuildExecutor",  # SWDSBinBuildExecutor alias
-    "UserRawBuildExecutor",
     "SWDSBinBuildExecutor",
     "SWDSBinDataLoader",
     "UserRawDataLoader",

--- a/client/starwhale/api/_impl/dataset/builder.py
+++ b/client/starwhale/api/_impl/dataset/builder.py
@@ -178,9 +178,6 @@ class BaseBuildExecutor(metaclass=ABCMeta):
             s.rows += _fs.rows
             s.unchanged_rows += _fs.rows
             s.data_byte_size += _fs.data_byte_size
-            s.annotations = list(set(s.annotations) | set(_fs.annotations))
-            s.include_link |= _fs.include_link
-            s.include_user_raw |= _fs.include_user_raw
 
         return s
 
@@ -203,7 +200,7 @@ class BaseBuildExecutor(metaclass=ABCMeta):
                 idx, row = row_data
             else:
                 raise FormatError(
-                    f"iter_item must return (data, annotations) or (id, data, annotations): {row_data}"
+                    f"iter_item must return data, (data) or (id, data): {row_data}"
                 )
         else:
             raise FormatError(

--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -34,12 +34,10 @@ class DataRow:
     def __init__(
         self,
         index: t.Union[str, int],
-        data: t.Optional[t.Union[BaseArtifact, Link]],
-        annotations: t.Dict,
+        content: t.Dict,
     ) -> None:
         self.index = index
-        self.data = data
-        self.annotations = annotations
+        self.content = content
 
         self._do_validate()
 
@@ -47,13 +45,13 @@ class DataRow:
         return f"{self.index}"
 
     def __repr__(self) -> str:
-        return f"index:{self.index}, data:{self.data}, annotations:{self.annotations}"
+        return f"index:{self.index}, content:{self.content}"
 
     def __iter__(self) -> t.Iterator:
-        return iter((self.index, self.data, self.annotations))
+        return iter((self.index, self.content))
 
     def __getitem__(self, i: int) -> t.Any:
-        return (self.index, self.data, self.annotations)[i]
+        return (self.index, self.content)[i]
 
     def __len__(self) -> int:
         return len(self.__dict__)
@@ -62,11 +60,8 @@ class DataRow:
         if not isinstance(self.index, (str, int)):
             raise TypeError(f"index({self.index}) is not int or str type")
 
-        if self.data is not None and not isinstance(self.data, (BaseArtifact, Link)):
-            raise TypeError(f"data({self.data}) is not BaseArtifact or Link type")
-
-        if not isinstance(self.annotations, dict):
-            raise TypeError(f"annotations({self.annotations}) is not dict type")
+        if not isinstance(self.content, dict):
+            raise TypeError(f"content({self.content}) is not dict type")
 
     def __lt__(self, obj: DataRow) -> bool:
         return str(self.index) < str(obj.index)
@@ -74,8 +69,7 @@ class DataRow:
     def __eq__(self, obj: t.Any) -> bool:
         return bool(
             self.index == obj.index
-            and self.data == obj.data
-            and self.annotations == obj.annotations
+            and self.content == obj.content
         )
 
 
@@ -257,14 +251,14 @@ class DataLoader(metaclass=ABCMeta):
         self, row: TabularDatasetRow, skip_fetch_data: bool = False
     ) -> DataRow:
         if skip_fetch_data:
-            return DataRow(index=row.id, data=None, annotations=row.annotations)
+            return DataRow(index=row.id, data=None, content=row.annotations)
 
         store = self._get_store(row)
         key_compose = self._get_key_compose(row, store)
         file = store.backend._make_file(store.bucket, key_compose)
         data_content, _ = self._read_data(file, row)
         data = BaseArtifact.reflect(data_content, row.data_type)
-        return DataRow(index=row.id, data=data, annotations=row.annotations)
+        return DataRow(index=row.id, data=data, content=row.annotations)
 
     def _unpack_row_with_queue(
         self,

--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -34,24 +34,23 @@ class DataRow:
     def __init__(
         self,
         index: t.Union[str, int],
-        content: t.Dict,
+        data: t.Dict,
     ) -> None:
         self.index = index
-        self.content = content
-
+        self.data = data
         self._do_validate()
 
     def __str__(self) -> str:
         return f"{self.index}"
 
     def __repr__(self) -> str:
-        return f"index:{self.index}, content:{self.content}"
+        return f"index:{self.index}, content:{self.data}"
 
     def __iter__(self) -> t.Iterator:
-        return iter((self.index, self.content))
+        return iter((self.index, self.data))
 
     def __getitem__(self, i: int) -> t.Any:
-        return (self.index, self.content)[i]
+        return (self.index, self.data)[i]
 
     def __len__(self) -> int:
         return len(self.__dict__)
@@ -60,8 +59,8 @@ class DataRow:
         if not isinstance(self.index, (str, int)):
             raise TypeError(f"index({self.index}) is not int or str type")
 
-        if not isinstance(self.content, dict):
-            raise TypeError(f"content({self.content}) is not dict type")
+        if not isinstance(self.data, dict):
+            raise TypeError(f"content({self.data}) is not dict type")
 
     def __lt__(self, obj: DataRow) -> bool:
         return str(self.index) < str(obj.index)
@@ -69,7 +68,7 @@ class DataRow:
     def __eq__(self, obj: t.Any) -> bool:
         return bool(
             self.index == obj.index
-            and self.content == obj.content
+            and self.data == obj.data
         )
 
 
@@ -256,7 +255,7 @@ class DataLoader(metaclass=ABCMeta):
             if skip_fetch_data:
                 continue
             at.fetch_data()
-        return DataRow(index=row.id, content=row.content)
+        return DataRow(index=row.id, data=row.data)
 
     def _unpack_row_with_queue(
         self,

--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -16,7 +16,7 @@ from starwhale.base.uri import URI
 from starwhale.base.type import URIType, InstanceType, DataFormatType, ObjectStoreType
 from starwhale.base.cloud import CloudRequestMixed
 from starwhale.utils.error import ParameterError
-from starwhale.core.dataset.type import Link, BaseArtifact
+from starwhale.core.dataset.type import Link
 from starwhale.core.dataset.store import FileLikeObj, ObjectStore, DatasetStorage
 from starwhale.api._impl.data_store import SwObject
 from starwhale.core.dataset.tabular import (

--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -321,13 +321,12 @@ class Dataset:
     def _getitem(
         self,
         item: _ItemType,
-        skip_fetch_data: bool = False,
     ) -> _GItemType:
         def _run() -> _GItemType:
             loader = self._get_data_loader(disable_consumption=True)
             if isinstance(item, (int, str)):
                 row = next(loader.tabular_dataset.scan(item, item, end_inclusive=True))
-                return loader._unpack_row(row, skip_fetch_data)
+                return loader._unpack_row(row)
             elif isinstance(item, slice):
                 step = item.step or 1
                 if step <= 0:
@@ -339,7 +338,7 @@ class Dataset:
                 rows = []
                 for row in loader.tabular_dataset.scan(item.start, item.stop):
                     if cnt % step == 0:
-                        rows.append(loader._unpack_row(row, skip_fetch_data))
+                        rows.append(loader._unpack_row(row))
                     cnt += 1
                 return rows
             else:
@@ -491,10 +490,10 @@ class Dataset:
         # TODO: render artifact in JupyterNotebook
         return self.__core_dataset.head(n, show_raw_data)
 
-    def fetch_one(self, skip_fetch_data: bool = False) -> DataRow:
+    def fetch_one(self) -> DataRow:
         loader = self._get_data_loader(disable_consumption=True)
         row = next(loader.tabular_dataset.scan())
-        return loader._unpack_row(row, skip_fetch_data)
+        return loader._unpack_row(row)
 
     def to_pytorch(
         self,
@@ -595,9 +594,9 @@ class Dataset:
 
         items: t.List
         if isinstance(key, (str, int)):
-            items = [self._getitem(key, skip_fetch_data=True)]
+            items = [self._getitem(key)]
         elif isinstance(key, slice):
-            items = self._getitem(key, skip_fetch_data=True)  # type: ignore
+            items = self._getitem(key)  # type: ignore
         else:
             raise TypeError(f"key({key}) is not str, int or slice type")
 

--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -115,7 +115,6 @@ class Dataset:
         if create:
             setattr(self.__core_dataset, "_version", self.version)
 
-        self._append_use_swds_bin = False
         _summary = None
         origin_uri_exists = self._check_uri_exists(_origin_uri)
         if origin_uri_exists:
@@ -130,10 +129,6 @@ class Dataset:
                 self._create_by_append = True
                 self._fork_dataset()
                 _summary = CoreDataset.get_dataset(_origin_uri).summary()
-                if _summary:
-                    self._append_use_swds_bin = not (
-                        _summary.include_link or _summary.include_user_raw
-                    )
             else:
                 self._append_from_version = ""
                 self._create_by_append = False
@@ -586,7 +581,6 @@ class Dataset:
                     append=self._create_by_append,
                     append_from_version=append_from_version,
                     append_from_uri=append_from_uri,
-                    append_with_swds_bin=self._append_use_swds_bin,
                     instance_name=self.project_uri.instance,
                 )
         return self._row_writer

--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -547,7 +547,7 @@ class Dataset:
             else:
                 raise ValueError(f"{value} cannot unpack")
 
-            row = DataRow(index=key, data=data, annotations=annotations)
+            row = DataRow(index=key, data=data, content=annotations)
         else:
             raise TypeError(f"value only supports tuple or DataRow type: {value}")
 

--- a/client/starwhale/api/_impl/model.py
+++ b/client/starwhale/api/_impl/model.py
@@ -27,7 +27,7 @@ from starwhale.api._impl.job import context_holder
 from starwhale.core.job.model import STATUS
 from starwhale.core.eval.store import EvaluationStorage
 from starwhale.api._impl.dataset import Dataset
-from starwhale.core.dataset.tabular import TabularDataset, TabularDatasetInfo
+from starwhale.core.dataset.tabular import TabularDataset, TabularDatasetInfo, TabularDatasetRow
 
 
 class _LogType:
@@ -85,7 +85,7 @@ class PipelineHandler(metaclass=ABCMeta):
         self.context: Context = context_holder.context
 
         # TODO: add args for compare result and label directly
-        self.ignore_annotations = ignore_annotations
+        self.ignore_ds_data = ignore_annotations
         self.ignore_error = ignore_error
         self.flush_result = flush_result
 
@@ -248,7 +248,6 @@ class PipelineHandler(metaclass=ABCMeta):
                     if self._is_ppl_batch():
                         _results = self.ppl(
                             [row.data for row in rows],
-                            annotations=[row.annotations for row in rows],
                             index=[row.index for row in rows],
                             index_with_dataset=[
                                 f"{_uri.object}{join_str}{row.index}" for row in rows
@@ -259,7 +258,6 @@ class PipelineHandler(metaclass=ABCMeta):
                         _results = [
                             self.ppl(
                                 rows[0].data,
-                                annotations=rows[0].annotations,
                                 index=rows[0].index,
                                 index_with_dataset=f"{_uri.object}{join_str}{rows[0].index}",
                                 dataset_info=dataset_info,
@@ -276,7 +274,7 @@ class PipelineHandler(metaclass=ABCMeta):
                 else:
                     _exception = None
 
-                for (_idx, _data, _annotations), _result in zip(rows, _results):
+                for (_idx, _data), _result in zip(rows, _results):
                     cnt += 1
                     _idx_with_ds = f"{_uri.object}{join_str}{_idx}"
 
@@ -294,11 +292,16 @@ class PipelineHandler(metaclass=ABCMeta):
                         }
                     )
 
+                    artifacts = TabularDatasetRow.artifacts_of_content(_data)
+                    for at in artifacts:
+                        if isinstance(at.fp, bytes):
+                            at.fp = None
+
                     result_storage.save(
                         data_id=_idx_with_ds,
                         index=_idx,
                         result=_result,
-                        annotations={} if self.ignore_annotations else _annotations,
+                        ds_data={} if self.ignore_ds_data else _data,
                     )
 
         if self.flush_result:

--- a/client/starwhale/api/dataset.py
+++ b/client/starwhale/api/dataset.py
@@ -24,7 +24,6 @@ from ._impl.dataset import (
     UserRawDataLoader,
     COCOObjectAnnotation,
     SWDSBinBuildExecutor,
-    UserRawBuildExecutor,
 )
 
 # TODO: add dataset build/push/list/info api
@@ -40,7 +39,6 @@ __all__ = [
     "MIMEType",
     "LinkType",
     "BuildExecutor",  # SWDSBinBuildExecutor alias
-    "UserRawBuildExecutor",
     "SWDSBinBuildExecutor",
     "SWDSBinDataLoader",
     "UserRawDataLoader",

--- a/client/starwhale/base/mixin.py
+++ b/client/starwhale/base/mixin.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import typing as t
 from copy import deepcopy
@@ -37,6 +38,8 @@ def _do_asdict_convert(obj: t.Any) -> t.Any:
         return obj.value
     elif hasattr(obj, "asdict"):
         return obj.asdict()
+    elif isinstance(obj, bytes):
+        return base64.b64encode(obj).decode()
     else:
         # TODO: add more type parse
         return obj

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -69,22 +69,12 @@ class Dataset(BaseBundle, metaclass=ABCMeta):
         for idx, row in enumerate(loader._iter_meta()):
             if idx >= rows:
                 break
+            if show_raw_data:
+                row = loader._unpack_row(row)
             info: t.Dict[str, t.Any] = {
                 "index": idx,
-                "annotations": row.annotations,
-                "data": {
-                    "id": row.id,
-                    "type": row.data_type,
-                    "link": row.data_link,
-                    "size": row.data_size,
-                },
+                "data": row.data,
             }
-            if show_raw_data:
-                _un_row = loader._unpack_row(row)
-                info["data"]["raw"] = (
-                    _un_row.data.to_bytes() if _un_row and _un_row.data else b""
-                )
-                info["data"]["size"] = len(info["data"]["raw"])
             ret.append(info)
 
         return ret

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -178,18 +178,19 @@ class TabularDatasetRow(ASDictMixin):
             d[f"{self.DATA_PREFIX}{k}"] = JsonDict.from_data(v)
         return d
 
-    def _artifacts(self, content: t.Dict) -> t.List[BaseArtifact]:
+    @classmethod
+    def artifacts_of_content(cls, content: t.Dict) -> t.List[BaseArtifact]:
         artifacts = []
         for _, v in content.items():
             if isinstance(v, dict):
-                artifacts.extend(self._artifacts(v))
+                artifacts.extend(cls.artifacts_of_content(v))
             if not isinstance(v, BaseArtifact):
                 continue
             artifacts.append(v)
         return artifacts
 
     def artifacts(self) -> t.List[BaseArtifact]:
-        return self._artifacts(self.data)
+        return TabularDatasetRow.artifacts_of_content(self.data)
 
 
 

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -816,7 +816,6 @@ class DatasetSummary(ASDictMixin):
         data_byte_size: int = 0,
         include_link: bool = False,
         include_user_raw: bool = False,
-        annotations: t.Optional[t.List[str]] = None,
         **kw: t.Any,
     ) -> None:
         self.rows = rows
@@ -825,7 +824,6 @@ class DatasetSummary(ASDictMixin):
         self.data_byte_size = data_byte_size
         self.include_link = include_link
         self.include_user_raw = include_user_raw
-        self.annotations = annotations or []
 
     def __str__(self) -> str:
         return f"Dataset Summary: rows({self.rows}), include user-raw({self.include_user_raw}), include link({self.include_link})"
@@ -834,7 +832,7 @@ class DatasetSummary(ASDictMixin):
         return (
             f"Dataset Summary: rows({self.rows}, increased: {self.increased_rows}), "
             f"include user-raw({self.include_user_raw}), include link({self.include_link}),"
-            f"size(data:{self.data_byte_size}, annotations: {self.annotations})"
+            f"size(data:{self.data_byte_size})"
         )
 
 

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -270,18 +270,24 @@ class BaseArtifact(ASDictMixin, metaclass=ABCMeta):
             raise NoSupportError(f"Artifact reflect error: {data_type}")
 
     def to_bytes(self, encoding: str = "utf-8") -> bytes:
+        self.fetch_data()
+        return self.fp
+
+    def fetch_data(self) -> None:
         if isinstance(self.fp, bytes):
-            return self.fp
+            return
         elif isinstance(self.fp, (str, Path)):
-            return Path(self.fp).read_bytes()
+            self.fp = Path(self.fp).read_bytes()
+            return
         elif isinstance(self.fp, io.IOBase):
             _pos = self.fp.tell()
             _content = self.fp.read()
             self.fp.seek(_pos)
-            return _content.encode(encoding) if isinstance(_content, str) else _content  # type: ignore
+            self.fp = _content.encode(encoding) if isinstance(_content, str) else _content  # type: ignore
+            return
         elif self.owner and self.link:
             self.fp = self.link.to_bytes(self.owner)
-            return self.fp
+            return
         else:
             raise NoSupportError(f"read raw for type:{type(self.fp)}")
 

--- a/client/starwhale/core/dataset/view.py
+++ b/client/starwhale/core/dataset/view.py
@@ -204,22 +204,13 @@ class DatasetTermView(BaseTermView):
 
         for row in self.dataset.head(rows, show_raw_data):
             console.rule(f"row [{row['index']}]", align="left")
-            size = pretty_bytes(row["data"]["size"])
             output = (
-                f":deciduous_tree: id: {row['data']['id']} \n"
+                f":deciduous_tree: id: {row['index']} \n"
                 ":cyclone: data:\n"
-                f"\t :dim_button: type: {row['data']['type']['type']} \n"
-                f"\t :duck: mime: {row['data']['type']['mime_type']} \n"
-                f"\t :palm_tree: display name: {row['data']['type'].get('display_name', '')} \n"
-                f"\t :diving_mask: size: {size} \n"
-                f"\t :dizzy: uri: {row['data']['link'].uri} \n"
-                f":dna: annotations({len(row['annotations'])}): \n"
+                f"\t :dim_button: type: {row['data']} \n"
             )
-            for _k, _v in row["annotations"].items():
+            for _k, _v in row["data"].items():
                 output += f"\t :droplet: {_k}: value[{_v}], type[{_get_type(_v)} | {type(_v)}] \n"
-
-            if show_raw_data:
-                output += f":parrot: raw data({size}): \n \t {row['data']['raw']}"
 
             console.print(output)
 
@@ -271,9 +262,6 @@ class DatasetTermViewJson(DatasetTermView):
         from starwhale.base.mixin import _do_asdict_convert
 
         info = self.dataset.head(rows, show_raw_data)
-        if show_raw_data:
-            for i in info:
-                i["data"]["raw"] = base64.b64encode(i["data"].get("raw", b"")).decode()
         self.pretty_json(_do_asdict_convert(info))
 
     def diff(self, compare_uri: URI, show_details: bool = False) -> None:

--- a/client/starwhale/integrations/pytorch/dataset.py
+++ b/client/starwhale/integrations/pytorch/dataset.py
@@ -66,9 +66,9 @@ class TorchIterableDataset(IterableDataset):
         _t = self.transform
         for row in self.dataset:
             if self.drop_index:
-                yield _t(row.data), _t(row.annotations)
+                yield _t(row.data)
             else:
-                yield _t(row.index), _t(row.data), _t(row.annotations)
+                yield _t(row.index), _t(row.data)
 
     def __len__(self) -> int:
         return len(self.dataset)

--- a/client/starwhale/integrations/tensorflow/dataset.py
+++ b/client/starwhale/integrations/tensorflow/dataset.py
@@ -98,18 +98,16 @@ def to_tf_dataset(dataset: Dataset, drop_index: bool = True) -> tf.data.Dataset:
     def _generator() -> t.Generator:
         for row in dataset:
             if drop_index:
-                yield _transform(row.data), _transform(row.annotations)
+                yield _transform(row.data)
             else:
-                yield _transform(row.index), _transform(row.data), _transform(
-                    row.annotations
-                )
+                yield _transform(row.index), _transform(row.data)
 
     def _make_signature() -> t.Any:
         row = dataset.fetch_one()
         signature = []
         if not drop_index:
             signature.append(_inspect_spec(row.index))
-        signature.extend([_inspect_spec(row.data), _inspect_spec(row.annotations)])
+        signature.extend([_inspect_spec(row.data)])
         return tuple(signature)
 
     return tf.data.Dataset.from_generator(

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -1834,7 +1834,6 @@ class TestRowWriter(BaseTestCase):
             dataset_version="123456",
             append=True,
             append_from_version="abcdefg",
-            append_with_swds_bin=True,
         )
         assert isinstance(rw._builder, SWDSBinBuildExecutor)
 
@@ -1845,7 +1844,6 @@ class TestRowWriter(BaseTestCase):
             dataset_version="123456",
             append=True,
             append_from_version="abcdefg",
-            append_with_swds_bin=False,
         )
         assert isinstance(rw._builder, UserRawBuildExecutor)
 

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -1621,18 +1621,18 @@ class TestRowWriter(BaseTestCase):
 
         rw._builder = MagicMock()
 
-        rw.update(DataRow(index=1, data=Binary(b"test"), annotations={"label": 1}))
+        rw.update(DataRow(index=1, data=Binary(b"test"), content={"label": 1}))
         first_builder = rw._builder
         assert rw._builder is not None
         assert rw._queue.qsize() == 1
 
-        rw.update(DataRow(index=2, data=Binary(b"test"), annotations={"label": 2}))
+        rw.update(DataRow(index=2, data=Binary(b"test"), content={"label": 2}))
         second_builder = rw._builder
         assert first_builder == second_builder
         assert rw._queue.qsize() == 2
 
         rw._builder = None
-        rw.update(DataRow(index=3, data=Binary(b"test"), annotations={"label": 3}))
+        rw.update(DataRow(index=3, data=Binary(b"test"), content={"label": 3}))
         assert rw._builder is not None
         assert rw.daemon
         assert isinstance(rw._builder, SWDSBinBuildExecutor)
@@ -1645,27 +1645,27 @@ class TestRowWriter(BaseTestCase):
 
         assert rw._raise_run_exception() is None
         rw._builder = MagicMock()
-        rw.update(DataRow(index=1, data=Binary(b"test"), annotations={"label": 1}))
+        rw.update(DataRow(index=1, data=Binary(b"test"), content={"label": 1}))
         assert rw._run_exception is None
 
         rw._run_exception = ValueError("test")
         with self.assertRaises(threading.ThreadError):
-            rw.update(DataRow(index=1, data=Binary(b"test"), annotations={"label": 1}))
+            rw.update(DataRow(index=1, data=Binary(b"test"), content={"label": 1}))
 
         rw._run_exception = None
         rw._builder = None
         m_make_swds.side_effect = TypeError("thread test")
         with self.assertRaises(threading.ThreadError):
-            rw.update(DataRow(index=2, data=Binary(b"test"), annotations={"label": 2}))
+            rw.update(DataRow(index=2, data=Binary(b"test"), content={"label": 2}))
             rw.join()
-            rw.update(DataRow(index=3, data=Binary(b"test"), annotations={"label": 3}))
+            rw.update(DataRow(index=3, data=Binary(b"test"), content={"label": 3}))
 
     def test_iter(self) -> None:
         rw = RowWriter(dataset_name="mnist", dataset_version="123456")
         rw._builder = MagicMock()
         size = 10
         for i in range(0, size):
-            rw.update(DataRow(index=i, data=Binary(b"test"), annotations={"label": i}))
+            rw.update(DataRow(index=i, data=Binary(b"test"), content={"label": i}))
 
         rw.update(None)  # type: ignore
         assert not rw.is_alive()
@@ -1679,7 +1679,7 @@ class TestRowWriter(BaseTestCase):
     def test_iter_block(self) -> None:
         rw = RowWriter(dataset_name="mnist", dataset_version="123456")
         rw._builder = MagicMock()
-        rw.update(DataRow(index=1, data=Binary(b"test"), annotations={"label": 1}))
+        rw.update(DataRow(index=1, data=Binary(b"test"), content={"label": 1}))
 
         thread = threading.Thread(target=lambda: list(rw), daemon=True)
         thread.start()
@@ -1708,7 +1708,7 @@ class TestRowWriter(BaseTestCase):
         for _ in range(0, size):
             rw.update(None)  # type: ignore
 
-        rw.update(DataRow(index=1, data=Binary(b"test"), annotations={"label": 1}))
+        rw.update(DataRow(index=1, data=Binary(b"test"), content={"label": 1}))
         rw.update(None)  # type: ignore
 
         assert rw._queue.qsize() == size + 2
@@ -1721,7 +1721,7 @@ class TestRowWriter(BaseTestCase):
             rw = RowWriter(
                 dataset_name="mnist", dataset_version="123456", workdir=Path(tmpdirname)
             )
-            rw.update(DataRow(index=1, data=Binary(b"test"), annotations={"label": 1}))
+            rw.update(DataRow(index=1, data=Binary(b"test"), content={"label": 1}))
             rw.close()
             assert not rw.is_alive()
 
@@ -1729,7 +1729,7 @@ class TestRowWriter(BaseTestCase):
                 dataset_name="mnist", dataset_version="123456", workdir=Path(tmpdirname)
             ) as context_rw:
                 context_rw.update(
-                    DataRow(index=1, data=Binary(b"test"), annotations={"label": 1})
+                    DataRow(index=1, data=Binary(b"test"), content={"label": 1})
                 )
             assert not rw.is_alive()
 
@@ -1741,7 +1741,7 @@ class TestRowWriter(BaseTestCase):
         assert rw._builder is None
         size = 100
         for i in range(0, size):
-            rw.update(DataRow(index=i, data=Binary(b"test"), annotations={"label": i}))
+            rw.update(DataRow(index=i, data=Binary(b"test"), content={"label": i}))
         rw.close()
 
         assert isinstance(rw._builder, SWDSBinBuildExecutor)
@@ -1773,7 +1773,7 @@ class TestRowWriter(BaseTestCase):
                 DataRow(
                     index=i,
                     data=Link(uri=raw_data_file, with_local_fs_data=True),
-                    annotations={"label": i, "label2": 2},
+                    content={"label": i, "label2": 2},
                 )
             )
         rw.close()
@@ -1810,7 +1810,7 @@ class TestRowWriter(BaseTestCase):
                 DataRow(
                     index=i,
                     data=Link(uri="minio://1/1/1/", auth=DefaultS3LinkAuth),
-                    annotations={"label": i, "label2": 2},
+                    content={"label": i, "label2": 2},
                 )
             )
         rw.close()
@@ -1854,7 +1854,7 @@ class TestRowWriter(BaseTestCase):
         rw._builder = MagicMock()
         rw.flush()
 
-        rw.update(DataRow(index=1, data=Binary(b"test"), annotations={"label": 1}))
+        rw.update(DataRow(index=1, data=Binary(b"test"), content={"label": 1}))
         thread = threading.Thread(target=rw.flush, daemon=True)
         thread.start()
         time.sleep(0.2)

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -49,7 +49,7 @@ class _DatasetSDKTestBase(BaseTestCase):
                     DataRow(
                         index=i,
                         data=Binary(f"data-{i}".encode()),
-                        annotations={"label": i},
+                        content={"label": i},
                     )
                 )
             ds.commit()
@@ -62,7 +62,7 @@ class _DatasetSDKTestBase(BaseTestCase):
                     DataRow(
                         index=f"{i}",
                         data=Binary(f"data-{i}".encode()),
-                        annotations={"label": i},
+                        content={"label": i},
                     )
                 )
             ds.commit()
@@ -99,7 +99,7 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         size = 11
         ds = dataset("mnist", create=True)
         assert len(ds) == 0
-        ds.append(DataRow(index=0, data=Binary(b""), annotations={"label": 1}))
+        ds.append(DataRow(index=0, data=Binary(b""), content={"label": 1}))
         assert len(ds) == 1
         for i in range(1, size):
             ds.append((i, Binary(), {"label": i}))
@@ -127,7 +127,7 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         size = 10
         ds.extend(
             [
-                DataRow(index=i, data=Binary(), annotations={"label": i})
+                DataRow(index=i, data=Binary(), content={"label": i})
                 for i in range(0, size)
             ]
         )
@@ -155,10 +155,10 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         assert ds._row_writer is None
 
         ds["index-2"] = DataRow(
-            index="index-2", data=Binary(), annotations={"label": 2}
+            index="index-2", data=Binary(), content={"label": 2}
         )
         ds["index-1"] = DataRow(
-            index="index-1", data=Binary(), annotations={"label": 1}
+            index="index-1", data=Binary(), content={"label": 1}
         )
 
         assert len(ds) == 2
@@ -200,7 +200,7 @@ class TestDatasetSDK(_DatasetSDKTestBase):
 
         def _do_task(_start: int) -> None:
             for i in range(_start, size):
-                ds.append(DataRow(index=i, data=Binary(), annotations={"label": i}))
+                ds.append(DataRow(index=i, data=Binary(), content={"label": i}))
 
         pool = ThreadPoolExecutor(max_workers=10)
         tasks = [pool.submit(_do_task, i * 10) for i in range(0, 9)]
@@ -448,11 +448,11 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         assert len(ds) == 10
         ds.flush()
 
-        ds.append(DataRow(index=1, data=Binary(b""), annotations={"label": 101}))
+        ds.append(DataRow(index=1, data=Binary(b""), content={"label": 101}))
         # assert len(ds) == 10 TODO restore this case len(ds) after improving accuracy of _rows_cnt during building
-        ds.append(DataRow(index=100, data=Binary(b""), annotations={"label": 100}))
+        ds.append(DataRow(index=100, data=Binary(b""), content={"label": 100}))
         # assert len(ds) == 11 TODO restore this case len(ds) after improving accuracy of _rows_cnt during building
-        ds.append(DataRow(index=101, data=Binary(b""), annotations={"label": 101}))
+        ds.append(DataRow(index=101, data=Binary(b""), content={"label": 101}))
         ds.commit()
         ds.close()
 
@@ -666,7 +666,7 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         for i in range(0, cnt):
             ds.append(
                 DataRow(
-                    index=i, data=Binary(f"data-{i}".encode()), annotations={"label": i}
+                    index=i, data=Binary(f"data-{i}".encode()), content={"label": i}
                 )
             )
 

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -644,7 +644,7 @@ class TestDataLoader(TestCase):
         self.assertEqual(len(_label_uris_map), 4)
 
     def test_data_row(self) -> None:
-        dr = DataRow(index=1, data=Image(), annotations={"label": 1})
+        dr = DataRow(index=1, data=Image(), content={"label": 1})
         index, data, annotations = dr
         assert index == 1
         assert isinstance(data, Image)
@@ -652,25 +652,25 @@ class TestDataLoader(TestCase):
         assert dr[0] == 1
         assert len(dr) == 3
 
-        dr_another = DataRow(index=2, data=Image(), annotations={"label": 2})
+        dr_another = DataRow(index=2, data=Image(), content={"label": 2})
         assert dr < dr_another
         assert dr != dr_another
 
-        dr_third = DataRow(index=1, data=Image(fp=b""), annotations={"label": 10})
+        dr_third = DataRow(index=1, data=Image(fp=b""), content={"label": 10})
         assert dr >= dr_third
 
-        dr_none = DataRow(index=1, data=None, annotations={})
+        dr_none = DataRow(index=1, data=None, content={})
         assert dr_none.data is None
 
     def test_data_row_exceptions(self) -> None:
         with self.assertRaises(TypeError):
-            DataRow(index=b"", data=Image(), annotations={})  # type: ignore
+            DataRow(index=b"", data=Image(), content={})  # type: ignore
 
         with self.assertRaises(TypeError):
-            DataRow(index=1, data=b"", annotations={})  # type: ignore
+            DataRow(index=1, data=b"", content={})  # type: ignore
 
         with self.assertRaises(TypeError):
-            DataRow(index=1, data=Image(), annotations=1)  # type: ignore
+            DataRow(index=1, data=Image(), content=1)  # type: ignore
 
     def test_travel_link(self) -> None:
         class _SW(SwObject):

--- a/example/mnist/mnist/dataset_read.py
+++ b/example/mnist/mnist/dataset_read.py
@@ -1,0 +1,17 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from starwhale import dataset
+
+
+def show_image(image) -> None:
+    plt.imshow(image, cmap="gray")
+    plt.show(block=True)
+
+ds_name = "mnist/version/latest"
+ds = dataset(ds_name)
+row = ds.fetch_one()
+data = row.data["img"]
+label = row.data["label"]
+show_image(np.frombuffer(data.to_bytes(), dtype=np.uint8).reshape(data.shape))
+print(label)

--- a/example/mnist/mnist/evaluator.py
+++ b/example/mnist/mnist/evaluator.py
@@ -21,8 +21,8 @@ class MNISTInference(PipelineHandler):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = self._load_model(self.device)
 
-    def ppl(self, img: Image, **kw: t.Any) -> t.Tuple[float, t.List[float]]:  # type: ignore
-        data_tensor = self._pre(img)
+    def ppl(self, data: t.Dict[str, t.Any], **kw: t.Any) -> t.Tuple[float, t.List[float]]:  # type: ignore
+        data_tensor = self._pre(data["img"])
         output = self.model(data_tensor)
         return self._post(output)
 
@@ -45,7 +45,7 @@ class MNISTInference(PipelineHandler):
     ) -> t.Tuple[t.List[int], t.List[int], t.List[t.List[float]]]:
         result, label, pr = [], [], []
         for _data in ppl_result:
-            label.append(_data["annotations"]["label"])
+            label.append(_data["ds_data"]["label"])
             result.append(_data["result"][0])
             pr.append(_data["result"][1])
         return label, result, pr


### PR DESCRIPTION
## Description
related issue: https://github.com/star-whale/starwhale/issues/1530
implementation:
1. tabular dataset row only contains `idx,data(JsonDict)`
2. only one dataset builder implementation(UserRawBuilder is removed)
3. auto convert bytes/localPath in `data` to uri
4. evaluation related interface change
5. UI related change
6. example related change

## Gains
support below datasets:
- optical flow， 
- scene flow， 
- depth， 
- 3d box， 
- stereo
- pairing
- translation
- Speech synthesis

## Verification
http://row-refactor-20230105.pre.intra.starwhale.ai/


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
