### PR TITLE
fix(client): runtime restore use enable_pre=false by default 

### DIFF
--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -787,9 +787,7 @@ def install_starwhale(
             req=req, prefix_path=prefix_path, use_pip_install=True, configs=configs
         )
     elif mode == PythonRunEnv.VENV:
-        venv_install_req(
-            venvdir=prefix_path, req=req, enable_pre=True, pip_config=configs.get("pip")
-        )
+        venv_install_req(venvdir=prefix_path, req=req, pip_config=configs.get("pip"))
     else:
         raise NoSupportError(f"mode({mode}) install {SW_PYPI_PKG_NAME}")
 

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -1008,7 +1008,7 @@ class StandaloneRuntimeTestCase(TestCase):
             [f"{workdir}/wheels/dummy.whl"],
             ["c"],
             ["d"],
-            ["--pre", "starwhale"],
+            ["starwhale"],
         ]
 
         assert m_venv.call_args[0][0] == [
@@ -1030,7 +1030,6 @@ class StandaloneRuntimeTestCase(TestCase):
             "install",
             "--exists-action",
             "w",
-            "--pre",
             "starwhale",
         ]
         assert (Path(workdir) / "export/venv/bin/prepare.sh").exists()


### PR DESCRIPTION
## Description
avoid install pre_version when restore

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
