### PR TITLE
chore(sdk): hijack submit on premises

### DIFF
--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -721,7 +721,7 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
     ) -> None:
         _model_config = cls.load_model_config(workdir / model_yaml)
         svc = cls._get_service(_model_config.run.handler, workdir)
-        svc.serve(host, port)
+        svc.serve(host, port, _model_config.name)
 
 
 class CloudModel(CloudBundleModelMixin, Model):

--- a/client/tests/sdk/test_service.py
+++ b/client/tests/sdk/test_service.py
@@ -18,14 +18,13 @@ class ServiceTestCase(BaseTestCase):
         assert list(svc.apis.keys()) == ["foo", "bar"]
 
         for i in svc.apis.values():
-            assert i.input.__class__.__name__ == "CustomInput"
-            assert i.output.__class__.__name__ == "CustomOutput"
+            assert i.input.__class__.__name__ == "list"
+            assert i.input[0].__class__.__name__ == "CustomInput"
+            assert i.output.__class__.__name__ == "list"
+            assert i.output[0].__class__.__name__ == "CustomOutput"
 
         spec = svc.get_spec()
-        assert list(filter(bool, [i["api_name"] for i in spec["dependencies"]])) == [
-            "predict",
-            "predict_1",
-        ]
+        assert len(spec["dependencies"]) == 2
 
     def test_default_class(self):
         svc = StandaloneModel._get_service("default_class:MyDefaultClass", self.root)

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
@@ -171,7 +171,9 @@ public class ModelServingService {
                 "SW_PYPI_INDEX_URL", runTimeProperties.getPypi().getIndexUrl(),
                 "SW_PYPI_EXTRA_INDEX_URL", runTimeProperties.getPypi().getExtraIndexUrl(),
                 "SW_PYPI_TRUSTED_HOST", runTimeProperties.getPypi().getTrustedHost(),
-                "SW_MODEL_SERVING_BASE_URI", String.format("/gateway/%s/%d", MODEL_SERVICE_PREFIX, id)
+                "SW_MODEL_SERVING_BASE_URI", String.format("/gateway/%s/%d", MODEL_SERVICE_PREFIX, id),
+                // see https://github.com/star-whale/starwhale/blob/c1d85ab98045a95ab3c75a89e7af56a17e966714/client/starwhale/utils/__init__.py#L51
+                "SW_PRODUCTION", "1"
         );
         var ss = k8sJobTemplate.renderModelServingOrch(envs, image, name);
         k8sClient.deployStatefulSet(ss);

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -132,7 +132,8 @@ public class ModelServingServiceTest {
                         "SW_INSTANCE_URI", "inst",
                         "SW_MODEL_VERSION", "md/version/9",
                         "SW_RUNTIME_VERSION", "rt/version/8",
-                        "SW_MODEL_SERVING_BASE_URI", "/gateway/model-serving/7"
+                        "SW_MODEL_SERVING_BASE_URI", "/gateway/model-serving/7",
+                        "SW_PRODUCTION", "1"
                 ), "img", "model-serving-7");
 
         verify(k8sClient).deployService(any());


### PR DESCRIPTION
## Description

Call outer `wait()` function when on premises for waiting backend service to ready and getting the predicted result.
cc @waynelwz 

gradio doc ref: https://www.gradio.app/custom_CSS_and_JS/

local dev mode has no effect

https://user-images.githubusercontent.com/3217223/210331418-d3f499bb-d011-4c5e-b911-88a1f962f272.mp4

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [x] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
