### PR TITLE
chore(controller): model serving api refactor

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/JobApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/JobApi.java
@@ -21,6 +21,7 @@ import ai.starwhale.mlops.api.protocol.job.JobModifyRequest;
 import ai.starwhale.mlops.api.protocol.job.JobRequest;
 import ai.starwhale.mlops.api.protocol.job.JobVo;
 import ai.starwhale.mlops.api.protocol.job.ModelServingRequest;
+import ai.starwhale.mlops.api.protocol.job.ModelServingVo;
 import ai.starwhale.mlops.api.protocol.task.TaskVo;
 import ai.starwhale.mlops.domain.dag.bo.Graph;
 import com.github.pagehelper.PageInfo;
@@ -273,7 +274,7 @@ public interface JobApi {
             @ApiResponse(responseCode = "200", description = "ok")})
     @PostMapping(value = "/project/{projectUrl}/serving")
     @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
-    ResponseEntity<ResponseMessage<String>> createModelServing(
+    ResponseEntity<ResponseMessage<ModelServingVo>> createModelServing(
             @Parameter(
                     in = ParameterIn.PATH,
                     description = "Project Url",

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/JobController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/JobController.java
@@ -22,6 +22,7 @@ import ai.starwhale.mlops.api.protocol.job.JobModifyRequest;
 import ai.starwhale.mlops.api.protocol.job.JobRequest;
 import ai.starwhale.mlops.api.protocol.job.JobVo;
 import ai.starwhale.mlops.api.protocol.job.ModelServingRequest;
+import ai.starwhale.mlops.api.protocol.job.ModelServingVo;
 import ai.starwhale.mlops.api.protocol.task.TaskVo;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.InvokerManager;
@@ -192,18 +193,17 @@ public class JobController implements JobApi {
     }
 
     @Override
-    public ResponseEntity<ResponseMessage<String>> createModelServing(
+    public ResponseEntity<ResponseMessage<ModelServingVo>> createModelServing(
             String projectUrl,
             ModelServingRequest request
     ) {
-        Long jobId = modelServingService.create(
+        var resp = modelServingService.create(
                 projectUrl,
                 request.getModelVersionUrl(),
                 request.getRuntimeVersionUrl(),
-                request.getResourcePool(),
-                request.getTtlInSeconds()
+                request.getResourcePool()
         );
 
-        return ResponseEntity.ok(Code.success.asResponse(idConvertor.convert(jobId)));
+        return ResponseEntity.ok(Code.success.asResponse(resp));
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/ModelServingVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/ModelServingVo.java
@@ -17,26 +17,19 @@
 package ai.starwhale.mlops.api.protocol.job;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
-import javax.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Data;
 import org.springframework.validation.annotation.Validated;
 
 @Data
+@Builder
 @Validated
-public class ModelServingRequest implements Serializable {
-    @NotNull
-    @JsonProperty("modelVersionUrl")
-    private String modelVersionUrl;
-
-    @NotNull
-    @JsonProperty("runtimeVersionUrl")
-    private String runtimeVersionUrl;
-
-    @JsonProperty("resourcePool")
-    private String resourcePool;
-
-    @Deprecated
-    @JsonProperty("ttlInSeconds")
-    private long ttlInSeconds;
+@Schema(description = "Model Serving object", title = "Model Serving")
+public class ModelServingVo implements Serializable {
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("baseUri")
+    private String baseUri;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/common/ProxyServlet.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/ProxyServlet.java
@@ -126,7 +126,7 @@ public class ProxyServlet extends HttpServlet {
     public String getTarget(String uri) {
         uri = StringUtils.trimLeadingCharacter(uri, '/');
         var parts = uri.split("/", 3);
-        if (parts.length < 3) {
+        if (parts.length < 2) {
             throw new IllegalArgumentException("can not parse uri " + uri);
         }
         if (!parts[0].equals(MODEL_SERVICE_PREFIX)) {
@@ -140,6 +140,10 @@ public class ProxyServlet extends HttpServlet {
         }
 
         var svc = ModelServingService.getServiceName(id);
-        return String.format("http://%s/%s", svc, parts[2]);
+        var handler = "";
+        if (parts.length == 3) {
+            handler = parts[2];
+        }
+        return String.format("http://%s/%s", svc, handler);
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/configuration/security/ModelServingTokenValidator.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/configuration/security/ModelServingTokenValidator.java
@@ -58,9 +58,6 @@ public class ModelServingTokenValidator implements JwtClaimValidator {
         if (m == null) {
             throw new SwValidationException(ValidSubject.USER, "can not find model serving by id");
         }
-        if (m.getFinishedTime() != null && m.getFinishedTime().before(new Date())) {
-            throw new SwValidationException(ValidSubject.USER, "token is expired");
-        }
         if (m.getIsDeleted() != null && m.getIsDeleted() != 0) {
             throw new SwValidationException(ValidSubject.USER, "model serving task is deleted");
         }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/ModelServingEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/ModelServingEntity.java
@@ -35,6 +35,7 @@ public class ModelServingEntity extends BaseEntity {
     private Long projectId;
     private Long modelVersionId;
     private Long ownerId;
+    @Deprecated
     private Date finishedTime;
     private JobStatus jobStatus;
     private Long runtimeVersionId;

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/JobControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/JobControllerTest.java
@@ -34,6 +34,7 @@ import ai.starwhale.mlops.api.protocol.job.JobModifyRequest;
 import ai.starwhale.mlops.api.protocol.job.JobRequest;
 import ai.starwhale.mlops.api.protocol.job.JobVo;
 import ai.starwhale.mlops.api.protocol.job.ModelServingRequest;
+import ai.starwhale.mlops.api.protocol.job.ModelServingVo;
 import ai.starwhale.mlops.api.protocol.task.TaskVo;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.PageParams;
@@ -224,14 +225,14 @@ public class JobControllerTest {
 
     @Test
     public void testCreateModelServing() {
-        given(modelServingService.create("foo", "bar", "baz", "default", 7L)).willReturn(8L);
+        var vo = ModelServingVo.builder().id("8").baseUri("/gateway/model-serving/8").build();
+        given(modelServingService.create("foo", "bar", "baz", "default")).willReturn(vo);
         var req = new ModelServingRequest();
         req.setModelVersionUrl("bar");
         req.setRuntimeVersionUrl("baz");
         req.setResourcePool("default");
-        req.setTtlInSeconds(7L);
         var resp = controller.createModelServing("foo", req);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
-        assertThat(resp.getBody().getData(), is("8"));
+        assertThat(resp.getBody().getData(), is(vo));
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/config/ModelServingTokenValidatorTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/config/ModelServingTokenValidatorTest.java
@@ -61,7 +61,6 @@ public class ModelServingTokenValidatorTest {
 
         var entity = ModelServingEntity.builder()
                 .id(1L)
-                .finishedTime(new Date(System.currentTimeMillis() + 1000))
                 .isDeleted(0)
                 .build();
 
@@ -76,12 +75,5 @@ public class ModelServingTokenValidatorTest {
                 () -> modelServingTokenValidator.validClaims(parsed));
         Assertions.assertTrue(e.getMessage().contains("deleted"));
         entity.setIsDeleted(0);
-
-        // expired
-        entity.setFinishedTime(new Date(1));
-        when(modelServingMapper.find(eq(1L))).thenReturn(entity);
-        e = Assertions.assertThrowsExactly(SwValidationException.class,
-                () -> modelServingTokenValidator.validClaims(parsed));
-        Assertions.assertTrue(e.getMessage().contains("expired"));
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/ProxyServletTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/ProxyServletTest.java
@@ -60,8 +60,9 @@ public class ProxyServletTest {
         var rt = proxyServlet.getTarget(uri);
         Assertions.assertEquals("http://model-serving-1/ppl", rt);
 
-        var tooShort = MODEL_SERVICE_PREFIX + "/1";
-        Assertions.assertThrows(IllegalArgumentException.class, () -> proxyServlet.getTarget(tooShort));
+        var shortUri = MODEL_SERVICE_PREFIX + "/1";
+        rt = proxyServlet.getTarget(shortUri);
+        Assertions.assertEquals("http://model-serving-1/", rt);
 
         var wrongStartsWith = "/foo/1/ppl";
         Assertions.assertThrows(IllegalArgumentException.class, () -> proxyServlet.getTarget(wrongStartsWith));

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.configuration.RunTimeProperties;
 import ai.starwhale.mlops.configuration.security.ModelServingTokenValidator;
 import ai.starwhale.mlops.domain.job.mapper.ModelServingMapper;
@@ -82,7 +83,9 @@ public class ModelServingServiceTest {
                 systemSettingService,
                 runTimeProperties,
                 "inst",
-                modelServingTokenValidator);
+                modelServingTokenValidator,
+                new IdConverter()
+        );
 
         var user = User.builder().id(1L).name("starwhale").build();
         when(userService.currentUserDetail()).thenReturn(user);
@@ -119,8 +122,7 @@ public class ModelServingServiceTest {
         var model = "4";
         var runtime = "5";
         var resourcePool = "default";
-        var ttl = 1000;
-        svc.create(project, model, runtime, resourcePool, ttl);
+        svc.create(project, model, runtime, resourcePool);
 
         verify(k8sJobTemplate).renderModelServingOrch(
                 Map.of(


### PR DESCRIPTION
## Description

- create model serving API returns {id, baseUri} instead of returning id only
- deprecate TTL seconds param 
- allow proxy URI without handler

After this pr, console will do the actions as follow:

1. post creation params
2. try getting the base URI returned in the last step
3. retry when getting 502
4. post user data when getting 200 in the last step

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
