### PR TITLE
chore(controller): reuse model serving entries and workloads

### DIFF
--- a/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_007__update_model_serving_info.sql
+++ b/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_007__update_model_serving_info.sql
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE `model_serving_info`
+    ADD CONSTRAINT model_serving_info_uniq
+        UNIQUE (project_id, model_version_id, runtime_version_id, resource_pool);

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -44,6 +44,7 @@ import ai.starwhale.mlops.domain.user.bo.User;
 import ai.starwhale.mlops.schedule.k8s.K8sClient;
 import ai.starwhale.mlops.schedule.k8s.K8sJobTemplate;
 import io.kubernetes.client.openapi.ApiException;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -118,11 +119,19 @@ public class ModelServingServiceTest {
 
     @Test
     public void testCreate() throws ApiException {
-        var project = "3";
-        var model = "4";
-        var runtime = "5";
         var resourcePool = "default";
-        svc.create(project, model, runtime, resourcePool);
+
+        var entity = ModelServingEntity.builder()
+                .id(7L)
+                .projectId(2L)
+                .modelVersionId(9L)
+                .runtimeVersionId(8L)
+                .resourcePool(resourcePool)
+                .build();
+        when(modelServingMapper.list(2L, 9L, 8L, resourcePool)).thenReturn(List.of(entity));
+        when(runtimeDao.getRuntimeVersionId("8", null)).thenReturn(8L);
+        when(modelDao.getModelVersionId("9", null)).thenReturn(9L);
+        svc.create("2", "9", "8", resourcePool);
 
         verify(k8sJobTemplate).renderModelServingOrch(
                 Map.of(

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
@@ -46,7 +46,24 @@ public class ModelServingMapperTest extends MySqlContainerHolder {
                 .jobStatus(JobStatus.RUNNING)
                 .build();
         modelServingMapper.add(entity);
-        var result = modelServingMapper.find(entity.getId());
+        var id = entity.getId();
+        var result = modelServingMapper.find(id);
         Assertions.assertEquals(entity, result);
+
+        entity.setId(null);
+        // insert if not exists (ignore)
+        modelServingMapper.add(entity);
+        // no insertion
+        Assertions.assertEquals(null, entity.getId());
+
+
+        var list = modelServingMapper.list(null, null, null, null);
+        Assertions.assertEquals(1, list.size());
+        Assertions.assertEquals(id, list.get(0).getId());
+
+        list = modelServingMapper.list(null, 7L, null, null);
+        Assertions.assertEquals(0, list.size());
+        list = modelServingMapper.list(2L, 1L, 3L, "bar");
+        Assertions.assertEquals(1, list.size());
     }
 }


### PR DESCRIPTION
## Description

Reuse model serving entries and workloads
- ignore insertion when entries with the same (project, model, runtime, resource pool) exist
- deploy workload and ignore 409 error (already exists)

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
