### PR TITLE
feat(controller): online eval support gc

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/common/ProxyServlet.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/ProxyServlet.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.Date;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -134,10 +135,10 @@ public class ProxyServlet extends HttpServlet {
         }
         var id = Long.parseLong(parts[1]);
 
-        // TODO add cache
         if (modelServingMapper.find(id) == null) {
             throw new IllegalArgumentException("can not find model serving entry " + parts[1]);
         }
+        modelServingMapper.updateLastVisitTime(id, new Date());
 
         var svc = ModelServingService.getServiceName(id);
         var handler = "";

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
@@ -26,10 +26,12 @@ import ai.starwhale.mlops.domain.job.po.ModelServingEntity;
 import ai.starwhale.mlops.domain.job.status.JobStatus;
 import ai.starwhale.mlops.domain.model.ModelDao;
 import ai.starwhale.mlops.domain.model.mapper.ModelMapper;
+import ai.starwhale.mlops.domain.model.mapper.ModelVersionMapper;
 import ai.starwhale.mlops.domain.model.po.ModelVersionEntity;
 import ai.starwhale.mlops.domain.project.ProjectManager;
 import ai.starwhale.mlops.domain.runtime.RuntimeDao;
 import ai.starwhale.mlops.domain.runtime.mapper.RuntimeMapper;
+import ai.starwhale.mlops.domain.runtime.mapper.RuntimeVersionMapper;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
 import ai.starwhale.mlops.domain.system.SystemSettingService;
 import ai.starwhale.mlops.domain.user.UserService;
@@ -37,20 +39,27 @@ import ai.starwhale.mlops.domain.user.bo.User;
 import ai.starwhale.mlops.exception.SwProcessException;
 import ai.starwhale.mlops.schedule.k8s.K8sClient;
 import ai.starwhale.mlops.schedule.k8s.K8sJobTemplate;
-import com.google.protobuf.Api;
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1OwnerReference;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServicePort;
 import io.kubernetes.client.openapi.models.V1ServiceSpec;
+import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.util.labels.EqualityMatcher;
+import io.kubernetes.client.util.labels.LabelSelector;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -64,15 +73,20 @@ public class ModelServingService {
     private final K8sClient k8sClient;
     private final K8sJobTemplate k8sJobTemplate;
     private final RuntimeMapper runtimeMapper;
+    private final RuntimeVersionMapper runtimeVersionMapper;
     private final ModelMapper modelMapper;
+    private final ModelVersionMapper modelVersionMapper;
     private final SystemSettingService systemSettingService;
     private final String instanceUri;
     private final RunTimeProperties runTimeProperties;
     private final ModelServingTokenValidator modelServingTokenValidator;
     private final IdConverter idConverter;
 
+    private final long maxTtlSec;
+    private final long minTtlSec;
 
     public static final String MODEL_SERVICE_PREFIX = "model-serving";
+    private static final Pattern modelServingNamePattern = Pattern.compile(MODEL_SERVICE_PREFIX + "-(\\d+)");
 
     public ModelServingService(
             ModelServingMapper modelServingMapper,
@@ -83,12 +97,16 @@ public class ModelServingService {
             K8sClient k8sClient,
             K8sJobTemplate k8sJobTemplate,
             RuntimeMapper runtimeMapper,
+            RuntimeVersionMapper runtimeVersionMapper,
             ModelMapper modelMapper,
+            ModelVersionMapper modelVersionMapper,
             SystemSettingService systemSettingService,
             RunTimeProperties runTimeProperties,
             @Value("${sw.instance-uri}") String instanceUri,
             ModelServingTokenValidator modelServingTokenValidator,
-            IdConverter idConverter
+            IdConverter idConverter,
+            @Value("${sw.online-eval.max-time-to-live-in-seconds}") long maxTtlSec,
+            @Value("${sw.online-eval.min-time-to-live-in-seconds}") long minTtlSec
     ) {
         this.modelServingMapper = modelServingMapper;
         this.runtimeDao = runtimeDao;
@@ -98,12 +116,16 @@ public class ModelServingService {
         this.k8sClient = k8sClient;
         this.k8sJobTemplate = k8sJobTemplate;
         this.runtimeMapper = runtimeMapper;
+        this.runtimeVersionMapper = runtimeVersionMapper;
         this.modelMapper = modelMapper;
+        this.modelVersionMapper = modelVersionMapper;
         this.systemSettingService = systemSettingService;
         this.runTimeProperties = runTimeProperties;
         this.instanceUri = instanceUri;
         this.modelServingTokenValidator = modelServingTokenValidator;
         this.idConverter = idConverter;
+        this.maxTtlSec = maxTtlSec;
+        this.minTtlSec = minTtlSec;
     }
 
     public ModelServingVo create(
@@ -114,28 +136,37 @@ public class ModelServingService {
     ) {
         User user = userService.currentUserDetail();
         Long projectId = projectManager.getProjectId(projectUrl);
+        Long runtimeVersionId = runtimeDao.getRuntimeVersionId(runtimeVersionUrl, null);
+        Long modelVersionId = modelDao.getModelVersionId(modelVersionUrl, null);
 
         // TODO move the deployment logic into the scheduler
-        var runtime = runtimeDao.getRuntimeVersion(runtimeVersionUrl);
-        var model = modelDao.getModelVersion(modelVersionUrl);
+        var runtime = runtimeVersionMapper.find(runtimeVersionId);
+        var model = modelVersionMapper.find(modelVersionId);
 
         var entity = ModelServingEntity.builder()
                 .ownerId(user.getId())
-                .runtimeVersionId(runtime.getId())
+                .runtimeVersionId(runtimeVersionId)
                 .projectId(projectId)
-                .modelVersionId(model.getId())
+                .modelVersionId(modelVersionId)
                 .jobStatus(JobStatus.CREATED)
                 .resourcePool(resourcePool)
+                .lastVisitTime(new Date())
                 .build();
 
-        modelServingMapper.add(entity);
+        long id;
+        synchronized (this) {
+            modelServingMapper.add(entity);
 
-        var services = modelServingMapper.list(projectId, model.getId(), runtime.getId(), resourcePool);
-        if (services.size() != 1) {
-            // this can not happen
-            throw new SwProcessException(SwProcessException.ErrorType.DB, "duplicate entries, size " + services.size());
+            var services = modelServingMapper.list(projectId, modelVersionId, runtimeVersionId, resourcePool);
+            if (services.size() != 1) {
+                // this can not happen
+                throw new SwProcessException(SwProcessException.ErrorType.DB,
+                        "duplicate entries, size " + services.size());
+            }
+            id = services.get(0).getId();
+            // update last visit time, prevents garbage collected
+            modelServingMapper.updateLastVisitTime(id, new Date());
         }
-        var id = services.get(0).getId();
 
         log.info("Model serving job has been created. ID={}", id);
 
@@ -189,7 +220,7 @@ public class ModelServingService {
         );
         var ss = k8sJobTemplate.renderModelServingOrch(envs, image, name);
         try {
-            k8sClient.deployStatefulSet(ss);
+            ss = k8sClient.deployStatefulSet(ss);
         } catch (ApiException e) {
             if (e.getCode() != HttpServletResponse.SC_CONFLICT) {
                 throw e;
@@ -204,24 +235,142 @@ public class ModelServingService {
         svc.metadata(meta);
         var spec = new V1ServiceSpec();
         svc.spec(spec);
-        var selector = Map.of("app", name);
+        var selector = Map.of(K8sJobTemplate.LABEL_APP, name);
         spec.selector(selector);
         var port = new V1ServicePort();
         port.name("model-serving-port");
         port.protocol("TCP");
         port.port(80);
-        port.targetPort(new IntOrString(8080));
+        port.targetPort(new IntOrString(K8sJobTemplate.ONLINE_EVAL_PORT_IN_POD));
         spec.ports(List.of(port));
+
+        // add owner reference for svc and we can just delete the stateful-set when gc is needed
+        var ownerRef = new V1OwnerReference();
+        ownerRef.kind(ss.getKind());
+        Objects.requireNonNull(ss.getMetadata());
+        ownerRef.uid(ss.getMetadata().getUid());
+        meta.ownerReferences(List.of(ownerRef));
+
+        // add svc to k8s
         k8sClient.deployService(svc);
-        // TODO add owner reference for svc
-        // TODO garbage collection when svc fails
+
+        // if operations of svc failed, the gc thread will delete the zombie stateful-set,
+        // so we do not need to delete the previous stateful-set when this fails
     }
 
     public static String getServiceName(long id) {
         return String.format("%s-%d", MODEL_SERVICE_PREFIX, id);
     }
 
+    public static Long getServiceIdFromName(String name) {
+        var match = modelServingNamePattern.matcher(name);
+        if (match.matches()) {
+            return Long.parseLong(match.group(1));
+        }
+        return null;
+    }
+
     public static String getServiceBaseUri(long id) {
         return String.format("/gateway/%s/%d", MODEL_SERVICE_PREFIX, id);
+    }
+
+
+    @Scheduled(initialDelay = 10000, fixedDelay = 10000)
+    public void gc() throws ApiException {
+        var labelSelector = K8sClient.toV1LabelSelector(Map.of(
+                K8sJobTemplate.LABEL_WORKLOAD_TYPE,
+                K8sJobTemplate.WORKLOAD_TYPE_ONLINE_EVAL
+        ));
+        var statefulSetList = k8sClient.getStatefulSetList(labelSelector);
+
+        boolean hasPending = false;
+        Map<Date, V1StatefulSet> mayBeGarbageCollected = new TreeMap<>((t1, t2) -> {
+            // oldest at the beginning
+            return t1 == t2 ? 0 : t1.before(t2) ? -1 : 1;
+        });
+
+        for (var statefulSet : statefulSetList.getItems()) {
+            // check if the stateful set is outdated
+            var meta = statefulSet.getMetadata();
+            if (meta == null || StringUtils.isEmpty(meta.getName())) {
+                continue;
+            }
+            // parse entity id from stateful set name
+            var name = meta.getName();
+            var id = getServiceIdFromName(name);
+            if (id == null) {
+                log.warn("can not get entity id from name {}", name);
+                continue;
+            }
+
+            // check if in db record
+            ModelServingEntity entity;
+            synchronized (this) {
+                entity = modelServingMapper.find(id);
+            }
+            if (entity == null) {
+                // delete the unknown stateful set
+                log.info("delete stateful set {} when there is no entry in db", name);
+                deleteStatefulSet(name);
+                continue;
+            }
+
+            var now = System.currentTimeMillis();
+            var last = entity.getLastVisitTime().getTime();
+            if (now - last > maxTtlSec * 1000) {
+                log.info("delete stateful set {} when it reaches the max TTL (since {})", name, last);
+                deleteStatefulSet(name);
+                continue;
+            }
+
+            var status = statefulSet.getStatus();
+            // check if the stateful set is pending
+            if (status == null) {
+                // may have just been deployed, ignore
+                log.info("ignore stateful set {} (no status found)", name);
+                continue;
+            }
+            // current replica of online eval is 1, so 0 means not ready
+            if (status.getReadyReplicas() == null || status.getReadyReplicas() == 0) {
+                hasPending = true;
+                log.info("found pending stateful set {}", name);
+                continue;
+            }
+
+            if (now - last < minTtlSec * 1000) {
+                log.info("stateful set {} not reach the TTL (since {}), won't gc", name, last);
+                continue;
+            }
+
+            mayBeGarbageCollected.put(entity.getLastVisitTime(), statefulSet);
+        }
+
+        if (!hasPending) {
+            log.info("no pending stateful set, done");
+            return;
+        }
+
+        // kill the oldest stateful set
+        if (mayBeGarbageCollected.isEmpty()) {
+            log.info("no stateful set to gc");
+            return;
+        }
+        var key = mayBeGarbageCollected.keySet().iterator().next();
+        var oldest = mayBeGarbageCollected.get(key);
+        var name = Objects.requireNonNull(oldest.getMetadata()).getName();
+        deleteStatefulSet(name);
+        log.info("delete stateful set {}", name);
+    }
+
+    private void deleteStatefulSet(String name) {
+        try {
+            k8sClient.deleteStatefulSet(name);
+        } catch (ApiException e) {
+            if (e.getCode() == HttpServletResponse.SC_NOT_FOUND) {
+                log.info("stateful set {} not found", name);
+                return;
+            }
+            log.error("delete stateful set {} failed, reason {}", name, e.getResponseBody(), e);
+        }
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapper.java
@@ -49,6 +49,10 @@ public interface ModelServingMapper {
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void add(ModelServingEntity entity);
 
+    @InsertProvider(value = SqlProviderAdapter.class, method = "insertIgnore")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    void insertIgnore(ModelServingEntity entity);
+
     @Select("select * from " + TABLE + " where id=#{id}")
     ModelServingEntity find(long id);
 
@@ -65,6 +69,19 @@ public interface ModelServingMapper {
 
     class SqlProviderAdapter {
         public String insert() {
+            var values = Arrays.stream(COLUMNS)
+                    .map(i -> "#{" + CaseUtils.toCamelCase(i, false, '_') + "}")
+                    .toArray(String[]::new);
+            return new SQL() {
+                {
+                    INSERT_INTO(TABLE);
+                    INTO_COLUMNS(COLUMNS);
+                    INTO_VALUES(values);
+                }
+            }.toString();
+        }
+
+        public String insertIgnore() {
             var values = Arrays.stream(COLUMNS)
                     .map(i -> "#{" + CaseUtils.toCamelCase(i, false, '_') + "}")
                     .toArray(String[]::new);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapper.java
@@ -18,6 +18,7 @@ package ai.starwhale.mlops.domain.job.mapper;
 
 import ai.starwhale.mlops.domain.job.po.ModelServingEntity;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import org.apache.commons.text.CaseUtils;
 import org.apache.ibatis.annotations.InsertProvider;
@@ -26,6 +27,7 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.Update;
 import org.apache.ibatis.jdbc.SQL;
 
 @Mapper
@@ -39,6 +41,7 @@ public interface ModelServingMapper {
             "job_status",
             "runtime_version_id",
             "resource_pool",
+            "last_visit_time",
     };
     String TABLE = "model_serving_info";
 
@@ -48,6 +51,9 @@ public interface ModelServingMapper {
 
     @Select("select * from " + TABLE + " where id=#{id}")
     ModelServingEntity find(long id);
+
+    @Update("update " + TABLE + " set last_visit_time=#{date} where id=#{id}")
+    void updateLastVisitTime(long id, Date date);
 
     @SelectProvider(value = SqlProviderAdapter.class, method = "listByConditions")
     List<ModelServingEntity> list(

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/ModelServingEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/ModelServingEntity.java
@@ -25,7 +25,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder
 @NoArgsConstructor
@@ -41,4 +41,5 @@ public class ModelServingEntity extends BaseEntity {
     private Long runtimeVersionId;
     private Integer isDeleted;
     private String resourcePool;
+    private Date lastVisitTime;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/ContainerOverwriteSpec.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/ContainerOverwriteSpec.java
@@ -17,6 +17,7 @@
 package ai.starwhale.mlops.schedule.k8s;
 
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1Probe;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,6 +39,8 @@ public class ContainerOverwriteSpec {
     ResourceOverwriteSpec resourceOverwriteSpec;
 
     List<V1EnvVar> envs;
+
+    V1Probe readinessProbe;
 
     public ContainerOverwriteSpec(String name) {
         this.name = name;

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
@@ -33,6 +33,7 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.openapi.models.V1StatefulSetList;
 import io.kubernetes.client.util.CallGeneratorParams;
 import io.kubernetes.client.util.labels.LabelSelector;
 import java.io.IOException;
@@ -102,6 +103,10 @@ public class K8sClient {
         batchV1Api.deleteNamespacedJob(id, ns, null, null, 1, false, null, null);
     }
 
+    public void deleteStatefulSet(String name) throws ApiException {
+        appsV1Api.deleteNamespacedStatefulSet(name, ns, null, null, 1, false, null, null);
+    }
+
     /**
      * get all jobs with in this.ns
      *
@@ -109,6 +114,11 @@ public class K8sClient {
      */
     public V1JobList getJobs(String labelSelector) throws ApiException {
         return batchV1Api.listNamespacedJob(ns, null, null, null, null, labelSelector, null, null, null, 30, null);
+    }
+
+    public V1StatefulSetList getStatefulSetList(String labelSelector) throws ApiException {
+        return appsV1Api.listNamespacedStatefulSet(ns, null, null, null, labelSelector,
+                null, null, null, null, 30, null);
     }
 
     public void watchJob(ResourceEventHandler<V1Job> eventH, String selector) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
@@ -117,8 +117,12 @@ public class K8sClient {
     }
 
     public V1StatefulSetList getStatefulSetList(String labelSelector) throws ApiException {
-        return appsV1Api.listNamespacedStatefulSet(ns, null, null, null, labelSelector,
-                null, null, null, null, 30, null);
+        return appsV1Api.listNamespacedStatefulSet(ns, null, null, null, null,
+                labelSelector, null, null, null, 30, null);
+    }
+
+    public V1PodList getPodList(String labelSelector) throws ApiException {
+        return coreV1Api.listNamespacedPod(ns, null, null, null, null, labelSelector, null, null, null, 30, null);
     }
 
     public void watchJob(ResourceEventHandler<V1Job> eventH, String selector) {
@@ -237,7 +241,7 @@ public class K8sClient {
 
     public V1PodList getPodsByJobName(String job) throws ApiException {
         var selector = toV1LabelSelector(Map.of(K8sJobTemplate.JOB_IDENTITY_LABEL, job));
-        return coreV1Api.listNamespacedPod(ns, null, null, null, null, selector, null, null, null, 30, null);
+        return getPodList(selector);
     }
 
     public static String toV1LabelSelector(Map<String, String> labels) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
@@ -121,9 +121,15 @@ public class K8sJobTemplate {
 
         // set name and labels
         ss.getMetadata().name(name);
+
+        var labels = new HashMap<String, String>();
+        labels.putAll(Map.of(LABEL_APP, name, LABEL_WORKLOAD_TYPE, WORKLOAD_TYPE_ONLINE_EVAL));
+        labels.putAll(starwhaleJobLabel);
+
+        ss.getMetadata().labels(labels);
+
         var spec = ss.getSpec();
         Objects.requireNonNull(spec);
-        var labels = Map.of(LABEL_APP, name, LABEL_WORKLOAD_TYPE, WORKLOAD_TYPE_ONLINE_EVAL);
         spec.getSelector().matchLabels(labels);
         Objects.requireNonNull(spec.getTemplate().getMetadata());
         spec.getTemplate().getMetadata().labels(labels);
@@ -142,7 +148,7 @@ public class K8sJobTemplate {
         readiness.httpGet(httpGet);
         httpGet.path("/");
         httpGet.port(new IntOrString(ONLINE_EVAL_PORT_IN_POD));
-        httpGet.scheme("http");
+        httpGet.scheme("HTTP");
 
         var containerSpecMap = new HashMap<String, ContainerOverwriteSpec>();
         containerSpecMap.put(containerName, cos);

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
@@ -16,14 +16,17 @@
 
 package ai.starwhale.mlops.schedule.k8s;
 
+import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EmptyDirVolumeSource;
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1HTTPGetAction;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobSpec;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
+import io.kubernetes.client.openapi.models.V1Probe;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.util.Yaml;
@@ -55,6 +58,10 @@ public class K8sJobTemplate {
     private final String pipCacheHostPath;
 
     public static final String DEVICE_LABEL_NAME_PREFIX = "device.starwhale.ai-";
+    public static final String LABEL_APP = "app";
+    public static final String LABEL_WORKLOAD_TYPE = "starwhale-workload-type";
+    public static final String WORKLOAD_TYPE_ONLINE_EVAL = "online-eval";
+    public static final int ONLINE_EVAL_PORT_IN_POD = 8080;
 
     final String evalJobTemplate;
     final String modelServingJobTemplate;
@@ -111,24 +118,37 @@ public class K8sJobTemplate {
     public V1StatefulSet renderModelServingOrch(Map<String, String> envs, String image, String name) {
         var ss = Yaml.loadAs(this.modelServingJobTemplate, V1StatefulSet.class);
         Objects.requireNonNull(ss.getMetadata());
+
+        // set name and labels
         ss.getMetadata().name(name);
         var spec = ss.getSpec();
         Objects.requireNonNull(spec);
-        var labels = Map.of("app", name);
+        var labels = Map.of(LABEL_APP, name, LABEL_WORKLOAD_TYPE, WORKLOAD_TYPE_ONLINE_EVAL);
         spec.getSelector().matchLabels(labels);
         Objects.requireNonNull(spec.getTemplate().getMetadata());
         spec.getTemplate().getMetadata().labels(labels);
-        var podSpec = spec.getTemplate().getSpec();
-        Objects.requireNonNull(podSpec);
 
+        // set container spec
         final String containerName = "worker";
         var cos = new ContainerOverwriteSpec();
         cos.setName(containerName);
         cos.setImage(image);
         cos.setEnvs(envs.entrySet().stream().map(K8sJobTemplate::toEnvVar).collect(Collectors.toList()));
+        // add readiness probe
+        var readiness = new V1Probe();
+        cos.setReadinessProbe(readiness);
+        readiness.failureThreshold(3);
+        var httpGet = new V1HTTPGetAction();
+        readiness.httpGet(httpGet);
+        httpGet.path("/");
+        httpGet.port(new IntOrString(ONLINE_EVAL_PORT_IN_POD));
+        httpGet.scheme("http");
+
         var containerSpecMap = new HashMap<String, ContainerOverwriteSpec>();
         containerSpecMap.put(containerName, cos);
 
+        var podSpec = spec.getTemplate().getSpec();
+        Objects.requireNonNull(podSpec);
         patchPodSpec("Always", containerSpecMap, null, podSpec);
         patchPipCacheVolume(ss.getSpec().getTemplate().getSpec().getVolumes());
         addDeviceInfoLabel(spec.getTemplate(), containerSpecMap);
@@ -172,7 +192,9 @@ public class K8sJobTemplate {
             if (!CollectionUtils.isEmpty(containerOverwriteSpec.envs)) {
                 c.env(containerOverwriteSpec.envs);
             }
-
+            if (containerOverwriteSpec.readinessProbe != null) {
+                c.readinessProbe(containerOverwriteSpec.readinessProbe);
+            }
         });
     }
 

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -27,6 +27,9 @@ sw:
   task:
     size: ${SW_TASK_SPLIT_SIZE:1}
     deletion-delay-minutes: ${SW_TASK_DELETION_DELAY_MINUTES:30}
+  online-eval:
+    max-time-to-live-in-seconds: ${SW_ONLINE_EVAL_MAX_TTL_SECS:43200} # 12h
+    min-time-to-live-in-seconds: ${SW_ONLINE_EVAL_MIN_TTL_SECS:1800} # 30min
   instance-uri: ${SW_INSTANCE_URI:http://console.pre.intra.starwhale.ai}
   infra:
     k8s:

--- a/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_008__add_last_visit.sql
+++ b/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_008__add_last_visit.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE `model_serving_info`
+    ADD last_visit_time DATETIME NOT NULL;

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -225,7 +225,7 @@ public class ModelServingServiceTest {
 
         var capture = ArgumentCaptor.forClass(String.class);
         svc.gc();
-        verify(k8sClient, atLeastOnce()).deleteStatefulSet(capture.capture());
+        verify(k8sClient, times(3)).deleteStatefulSet(capture.capture());
         var names = capture.getAllValues();
         assertThat(names, containsInAnyOrder(oldestName, noEntityName, maxTtlName));
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -16,9 +16,13 @@
 
 package ai.starwhale.mlops.domain.job;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,10 +48,17 @@ import ai.starwhale.mlops.domain.user.bo.User;
 import ai.starwhale.mlops.schedule.k8s.K8sClient;
 import ai.starwhale.mlops.schedule.k8s.K8sJobTemplate;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.openapi.models.V1StatefulSetList;
+import io.kubernetes.client.openapi.models.V1StatefulSetStatus;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class ModelServingServiceTest {
@@ -78,12 +89,16 @@ public class ModelServingServiceTest {
                 k8sClient,
                 k8sJobTemplate,
                 runtimeMapper,
+                runtimeVersionMapper,
                 modelMapper,
+                modelVersionMapper,
                 systemSettingService,
                 runTimeProperties,
                 "inst",
                 modelServingTokenValidator,
-                new IdConverter()
+                new IdConverter(),
+                3600,
+                1
         );
 
         var user = User.builder().id(1L).name("starwhale").build();
@@ -99,12 +114,12 @@ public class ModelServingServiceTest {
         var runtime = RuntimeEntity.builder().runtimeName("rt").build();
         when(runtimeMapper.find(any())).thenReturn(runtime);
         var runtimeVer = RuntimeVersionEntity.builder().id(8L).image("img").build();
-        when(runtimeDao.getRuntimeVersion(any())).thenReturn(runtimeVer);
+        when(runtimeVersionMapper.find(any())).thenReturn(runtimeVer);
 
         var model = ModelEntity.builder().modelName("md").build();
         when(modelMapper.find(any())).thenReturn(model);
         var modelVer = ModelVersionEntity.builder().id(9L).build();
-        when(modelDao.getModelVersion(any())).thenReturn(modelVer);
+        when(modelVersionMapper.find(any())).thenReturn(modelVer);
 
         var pypi = mock(RunTimeProperties.Pypi.class);
         when(runTimeProperties.getPypi()).thenReturn(pypi);
@@ -126,12 +141,13 @@ public class ModelServingServiceTest {
                 .runtimeVersionId(8L)
                 .resourcePool(resourcePool)
                 .build();
-        when(modelServingMapper.list(2L, 9L, 8L, resourcePool))
-                .thenReturn(List.of(entity));
-        when(runtimeDao.getRuntimeVersion("8"))
-                .thenReturn(RuntimeVersionEntity.builder().id(8L).image("img").build());
-        when(modelDao.getModelVersion("9"))
-                .thenReturn(ModelVersionEntity.builder().id(9L).build());
+        when(modelServingMapper.list(2L, 9L, 8L, resourcePool)).thenReturn(List.of(entity));
+        when(runtimeDao.getRuntimeVersionId("8", null)).thenReturn(8L);
+        when(modelDao.getModelVersionId("9", null)).thenReturn(9L);
+
+        var ss = new V1StatefulSet();
+        ss.metadata(new V1ObjectMeta());
+        when(k8sClient.deployStatefulSet(any())).thenReturn(ss);
         svc.create("2", "9", "8", resourcePool);
 
         verify(k8sJobTemplate).renderModelServingOrch(
@@ -149,5 +165,68 @@ public class ModelServingServiceTest {
                 ), "img", "model-serving-7");
 
         verify(k8sClient).deployService(any());
+    }
+
+
+    @Test
+    public void testGarbageCollection() throws ApiException {
+        final String oldestName = "model-serving-7";
+        final String noEntityName = "model-serving-9";
+        final String maxTtlName = "model-serving-10";
+
+        var now = System.currentTimeMillis();
+
+        final var noStatus = new V1StatefulSet().metadata(new V1ObjectMeta().name("model-serving-1"));
+        when(modelServingMapper.find(1L)).thenReturn(
+                ModelServingEntity.builder().lastVisitTime(new Date(now - 5 * 1000)).build());
+        final var noMeta = new V1StatefulSet().status(new V1StatefulSetStatus());
+
+        var oldEntity = ModelServingEntity.builder().lastVisitTime(new Date(now - 30 * 1000)).build();  // oldest time
+        var newEntity = ModelServingEntity.builder().lastVisitTime(new Date(now - 10 * 1000)).build();
+        when(modelServingMapper.find(7L)).thenReturn(oldEntity); // the oldest
+        when(modelServingMapper.find(8L)).thenReturn(newEntity);
+        final var runningStatus = new V1StatefulSetStatus().readyReplicas(1);
+        final var oldest = new V1StatefulSet()
+                .metadata(new V1ObjectMeta().name(oldestName))
+                .status(runningStatus);
+        final var shouldNotBeGc = new V1StatefulSet()
+                .metadata(new V1ObjectMeta().name("model-serving-8"))
+                .status(runningStatus);
+
+        final var noEntity = new V1StatefulSet().metadata(new V1ObjectMeta().name(noEntityName));
+        when(modelServingMapper.find(9L)).thenReturn(null);
+
+        final var reachesTheMaxTtl = new V1StatefulSet().metadata(new V1ObjectMeta().name(maxTtlName));
+        when(modelServingMapper.find(10L)).thenReturn(
+                ModelServingEntity.builder().lastVisitTime(new Date(now - 3601 * 1000)).build());
+
+        final var pending = new V1StatefulSet()
+                .status(new V1StatefulSetStatus().readyReplicas(0))
+                .metadata(new V1ObjectMeta().name("model-serving-11"));
+        when(modelServingMapper.find(11L)).thenReturn(
+                ModelServingEntity.builder().lastVisitTime(new Date(now - 2 * 1000)).build());
+
+
+        var list = new V1StatefulSetList();
+        list.setItems(List.of(noStatus, noMeta, oldest, shouldNotBeGc, pending, noEntity, reachesTheMaxTtl));
+        when(k8sClient.getStatefulSetList(any())).thenReturn(list);
+
+        var capture = ArgumentCaptor.forClass(String.class);
+        svc.gc();
+        verify(k8sClient, times(3)).deleteStatefulSet(capture.capture());
+        var names = capture.getAllValues();
+        assertThat(names, containsInAnyOrder(oldestName, noEntityName, maxTtlName));
+
+
+        final var theOnlyRunningAndInMinTtl = new V1StatefulSet()
+                .metadata(new V1ObjectMeta().name("model-serving-1"))
+                .status(runningStatus);
+        when(modelServingMapper.find(1L)).thenReturn(
+                ModelServingEntity.builder().lastVisitTime(new Date(now - 500)).build());
+        list.setItems(List.of(pending, theOnlyRunningAndInMinTtl));
+        reset(k8sClient);
+        when(k8sClient.getStatefulSetList(any())).thenReturn(list);
+        svc.gc();
+        verify(k8sClient, times(0)).deleteStatefulSet(any());
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -75,9 +75,7 @@ public class ModelServingServiceTest {
     private final K8sClient k8sClient = mock(K8sClient.class);
     private final K8sJobTemplate k8sJobTemplate = mock(K8sJobTemplate.class);
     private final RuntimeMapper runtimeMapper = mock(RuntimeMapper.class);
-    private final RuntimeVersionMapper runtimeVersionMapper = mock(RuntimeVersionMapper.class);
     private final ModelMapper modelMapper = mock(ModelMapper.class);
-    private final ModelVersionMapper modelVersionMapper = mock(ModelVersionMapper.class);
     private final SystemSettingService systemSettingService = mock(SystemSettingService.class);
     private final RunTimeProperties runTimeProperties = mock(RunTimeProperties.class);
     private final ModelServingTokenValidator modelServingTokenValidator = mock(ModelServingTokenValidator.class);
@@ -93,9 +91,7 @@ public class ModelServingServiceTest {
                 k8sClient,
                 k8sJobTemplate,
                 runtimeMapper,
-                runtimeVersionMapper,
                 modelMapper,
-                modelVersionMapper,
                 systemSettingService,
                 runTimeProperties,
                 "inst",
@@ -117,13 +113,9 @@ public class ModelServingServiceTest {
 
         var runtime = RuntimeEntity.builder().runtimeName("rt").build();
         when(runtimeMapper.find(any())).thenReturn(runtime);
-        var runtimeVer = RuntimeVersionEntity.builder().id(8L).image("img").build();
-        when(runtimeVersionMapper.find(any())).thenReturn(runtimeVer);
 
         var model = ModelEntity.builder().modelName("md").build();
         when(modelMapper.find(any())).thenReturn(model);
-        var modelVer = ModelVersionEntity.builder().id(9L).build();
-        when(modelVersionMapper.find(any())).thenReturn(modelVer);
 
         var pypi = mock(RunTimeProperties.Pypi.class);
         when(runTimeProperties.getPypi()).thenReturn(pypi);
@@ -146,8 +138,10 @@ public class ModelServingServiceTest {
                 .resourcePool(resourcePool)
                 .build();
         when(modelServingMapper.list(2L, 9L, 8L, resourcePool)).thenReturn(List.of(entity));
-        when(runtimeDao.getRuntimeVersionId("8", null)).thenReturn(8L);
-        when(modelDao.getModelVersionId("9", null)).thenReturn(9L);
+        var runtimeVer = RuntimeVersionEntity.builder().id(8L).image("img").build();
+        when(runtimeDao.getRuntimeVersion("8")).thenReturn(runtimeVer);
+        var modelVer = ModelVersionEntity.builder().id(9L).build();
+        when(modelDao.getModelVersion("9")).thenReturn(modelVer);
 
         var ss = new V1StatefulSet();
         ss.metadata(new V1ObjectMeta());

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
@@ -19,6 +19,7 @@ package ai.starwhale.mlops.domain.job.mapper;
 import ai.starwhale.mlops.domain.MySqlContainerHolder;
 import ai.starwhale.mlops.domain.job.po.ModelServingEntity;
 import ai.starwhale.mlops.domain.job.status.JobStatus;
+import java.util.Date;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -44,6 +45,7 @@ public class ModelServingMapperTest extends MySqlContainerHolder {
                 .isDeleted(0)
                 .resourcePool("bar")
                 .jobStatus(JobStatus.RUNNING)
+                .lastVisitTime(new Date(System.currentTimeMillis() / 1000 * 1000))
                 .build();
         modelServingMapper.add(entity);
         var id = entity.getId();
@@ -54,7 +56,8 @@ public class ModelServingMapperTest extends MySqlContainerHolder {
         // insert if not exists (ignore)
         modelServingMapper.add(entity);
         // no insertion
-        Assertions.assertEquals(null, entity.getId());
+        Assertions.assertNull(entity.getId());
+        entity.setId(id);
 
 
         var list = modelServingMapper.list(null, null, null, null);
@@ -65,5 +68,13 @@ public class ModelServingMapperTest extends MySqlContainerHolder {
         Assertions.assertEquals(0, list.size());
         list = modelServingMapper.list(2L, 1L, 3L, "bar");
         Assertions.assertEquals(1, list.size());
+
+        // test updating last visit time
+        var visit = new Date(1000);
+        modelServingMapper.updateLastVisitTime(id, visit);
+        result = modelServingMapper.find(id);
+        Assertions.assertEquals(visit, result.getLastVisitTime());
+        entity.setLastVisitTime(visit);
+        Assertions.assertEquals(entity, result);
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
@@ -47,21 +47,36 @@ public class ModelServingMapperTest extends MySqlContainerHolder {
                 .jobStatus(JobStatus.RUNNING)
                 .lastVisitTime(new Date(System.currentTimeMillis() / 1000 * 1000))
                 .build();
-        modelServingMapper.add(entity);
+        modelServingMapper.insertIgnore(entity);
         var id = entity.getId();
         var result = modelServingMapper.find(id);
         Assertions.assertEquals(entity, result);
 
         entity.setId(null);
         // insert if not exists (ignore)
-        modelServingMapper.add(entity);
+        modelServingMapper.insertIgnore(entity);
         // no insertion
         Assertions.assertNull(entity.getId());
         entity.setId(id);
 
+        var another = ModelServingEntity.builder()
+                .modelVersionId(2L)
+                .projectId(entity.getProjectId())
+                .runtimeVersionId(entity.getRuntimeVersionId())
+                .ownerId(entity.getOwnerId())
+                .createUser(entity.getCreateUser())
+                .isDeleted(entity.getIsDeleted())
+                .resourcePool(entity.getResourcePool())
+                .jobStatus(entity.getJobStatus())
+                .lastVisitTime(entity.getLastVisitTime())
+                .build();
+        modelServingMapper.add(another);
+        result = modelServingMapper.find(another.getId());
+        Assertions.assertEquals(another, result);
+
 
         var list = modelServingMapper.list(null, null, null, null);
-        Assertions.assertEquals(1, list.size());
+        Assertions.assertEquals(2, list.size());
         Assertions.assertEquals(id, list.get(0).getId());
 
         list = modelServingMapper.list(null, 7L, null, null);

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
@@ -38,6 +38,8 @@ import io.kubernetes.client.openapi.models.V1NodeList;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.openapi.models.V1StatefulSet;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
@@ -70,7 +72,7 @@ public class K8sClientTest {
     }
 
     @Test
-    public void testDeploy() throws ApiException {
+    public void testDeployJob() throws ApiException {
         V1Job job = new V1Job();
         k8sClient.deployJob(job);
         verify(batchV1Api).createNamespacedJob(eq(nameSpace), eq(job), any(), eq(null), any(), any());
@@ -83,7 +85,7 @@ public class K8sClientTest {
     }
 
     @Test
-    public void testGet() throws ApiException {
+    public void testGetJob() throws ApiException {
         V1JobList t = new V1JobList();
         when(batchV1Api.listNamespacedJob(nameSpace, null, null, null, null, "ls", null, null, null, 30,
                 null)).thenReturn(
@@ -157,5 +159,26 @@ public class K8sClientTest {
         when(coreV1Api.listNamespacedPod(nameSpace, null, null, null, null, label,
                 null, null, null, 30, null)).thenReturn(pods);
         Assertions.assertEquals(k8sClient.getPodsByJobName("foo"), pods);
+    }
+
+    @Test
+    public void testDeployStatefulSet() throws ApiException {
+        var ss = new V1StatefulSet();
+        k8sClient.deployStatefulSet(ss);
+        verify(appsV1Api).createNamespacedStatefulSet(eq(nameSpace), eq(ss), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testDeleteStatefulSet() throws ApiException {
+        var n = "foo";
+        k8sClient.deleteStatefulSet(n);
+        verify(appsV1Api).deleteNamespacedStatefulSet(eq(n), eq(nameSpace), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testDeployService() throws ApiException {
+        var svc = new V1Service();
+        k8sClient.deployService(svc);
+        verify(coreV1Api).createNamespacedService(eq(nameSpace), eq(svc), any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
## Description

Online eval support garbage collection
- removes the workloads that reached the max TTL
- removes the oldest workload when there are pending workloads
  - prevent removing the workloads that not reached the min TTL

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
