### PR TITLE
feat(sdk): support track sdk for experiment

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -133,6 +133,11 @@ jobs:
           make install-sw
           make install-dev-req
 
+      - name: Git Config
+        run: |
+          git config --global user.name "starwhale-ci"
+          git config --global user.email "starwhale-ci@starwhale.ai"
+
       - name: Run Unittest
         working-directory: ./client
         run: make ut

--- a/client/Makefile
+++ b/client/Makefile
@@ -66,7 +66,7 @@ ut:
 .POHNY: fast-ut
 fast-ut:
 	echo "fast ut"
-	python -m pytest tests -vvrfEsxl --cov-config=.coveragerc --cov=starwhale --cov-report=xml:coverage.xml --cov-report=term-missing -n auto --dist=loadscope
+	python -m pytest tests -vvrfEsxl --cov-config=.coveragerc --cov=starwhale --cov-report=xml:coverage.xml --cov-report=term-missing -n 4 --dist=loadscope
 
 .POHNY: all-check
 all-check: ci-format-checker ci-lint ci-mypy ci-isort fast-ut

--- a/client/setup.py
+++ b/client/setup.py
@@ -32,6 +32,9 @@ install_requires = [
     "Jinja2>=3.1.2",
     "tenacity>=8.0.1",
     "gradio~=3.15.0",
+    # for system monitor
+    "psutil>=5.5.0",
+    "GitPython>=3.1.24",
 ]
 
 extras_require = {
@@ -98,5 +101,7 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: System :: Logging",
+        "Topic :: System :: Monitoring",
     ],
 )

--- a/client/starwhale/__init__.py
+++ b/client/starwhale/__init__.py
@@ -1,3 +1,4 @@
+from starwhale.api import track
 from starwhale.api.job import step, Context, pass_context
 from starwhale.version import STARWHALE_VERSION as __version__
 from starwhale.base.uri import URI, URIType
@@ -68,4 +69,5 @@ __all__ = [
     "PPLResultStorage",
     "PPLResultIterator",
     "get_dataset_consumption",
+    "track",
 ]

--- a/client/starwhale/api/_impl/metric.py
+++ b/client/starwhale/api/_impl/metric.py
@@ -14,8 +14,8 @@ from sklearn.metrics import (  # type: ignore
     multilabel_confusion_matrix,
 )
 
+from starwhale.utils.dict import flatten as flatten_dict
 from starwhale.api._impl.job import context_holder
-from starwhale.utils.flatten import do_flatten_dict
 from starwhale.api._impl.wrapper import Evaluation
 
 
@@ -61,7 +61,7 @@ def multi_classification(
             if show_cohen_kappa_score:
                 _r["summary"]["cohen_kappa_score"] = cohen_kappa_score(y_true, y_pred)
 
-            _record_summary = do_flatten_dict(_r["summary"])
+            _record_summary = flatten_dict(_r["summary"], extract_sequence=True)
             _record_summary["kind"] = _r["kind"]
             evaluation.log_metrics(_record_summary)
 

--- a/client/starwhale/api/_impl/track/base.py
+++ b/client/starwhale/api/_impl/track/base.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import copy
+import time
+import typing as t
+from enum import Enum, unique
+
+from starwhale.utils import now_str
+from starwhale.base.mixin import ASDictMixin
+from starwhale.core.dataset.type import Link
+
+
+@unique
+class _TrackMode(Enum):
+    OFFLINE = "offline"
+    ONLINE = "online"
+
+
+@unique
+class _TrackType(Enum):
+    METRICS = "metrics"
+    PARAMETERS = "parameters"
+    ARTIFACTS = "artifacts"
+
+
+@unique
+class _TrackSource(Enum):
+    USER = "user"
+    SYSTEM = "_system"
+    FRAMEWORK = "_framework"
+
+
+class TrackRecord:
+    def __init__(
+        self, typ: _TrackType, source: _TrackSource, start_time: float = 0
+    ) -> None:
+        self.typ = typ
+        self.source = source
+        self.clock_time = now_str()
+        self.relative_time = time.monotonic() - start_time
+
+    def __str__(self) -> str:
+        return f"TrackRecord[{self.typ}] from {self.source}"
+
+
+class MetricsRecord(TrackRecord):
+    def __init__(
+        self,
+        data: t.Dict[str, float],
+        step: int,
+        source: _TrackSource = _TrackSource.USER,
+        start_time: float = 0,
+    ) -> None:
+        super().__init__(_TrackType.METRICS, source, start_time)
+        self.data = data
+        self.step = step
+
+    def __str__(self) -> str:
+        return f"MetricsRecord[{self.step}] {self.data}"
+
+    __repr__ = __str__
+
+
+class ParamsRecord(TrackRecord):
+    def __init__(
+        self,
+        data: t.Dict[str, t.Any],
+        source: _TrackSource = _TrackSource.USER,
+        start_time: float = 0,
+    ) -> None:
+        super().__init__(_TrackType.PARAMETERS, source, start_time)
+        self.data = data
+
+    def __str__(self) -> str:
+        return f"ParamsRecord-{self.data}"
+
+    __repr__ = __str__
+
+
+class ArtifactsRecord(TrackRecord):
+    def __init__(
+        self,
+        data: t.Dict[str, t.Any],
+        source: _TrackSource = _TrackSource.USER,
+        start_time: float = 0,
+    ) -> None:
+        super().__init__(_TrackType.ARTIFACTS, source, start_time)
+        self.data = data
+
+    def __str__(self) -> str:
+        return f"ArtifactsRecord-{self.data}"
+
+    __repr__ = __str__
+
+
+class ArtifactsTabularRow(ASDictMixin):
+    def __init__(
+        self,
+        name: str,
+        index: int,
+        created_at: str,
+        data: Link,
+        link_wrapper: bool = True,
+    ) -> None:
+        self.name = name
+        self.index = index
+        self.key = f"{name}-{index:04}"
+        self.created_at = created_at
+        self.data = data
+        self._link_wrapper = link_wrapper
+
+        self._do_validate()
+
+    def _do_validate(self) -> None:
+        if not isinstance(self.data, Link):
+            raise TypeError(f"data:{self.data} is not Link type")
+
+        if self.index < 0 or self.index >= 10000:
+            raise ValueError(
+                f"index({self.index}) must be non negative integer number and less than 10000"
+            )
+
+    def __str__(self) -> str:
+        return f"ArtifactsTabularRow-{self.key}"
+
+    def __repr__(self) -> str:
+        return f"ArtifactsTabularRow-{self.key}-{self.created_at}-{self.data}"
+
+    @classmethod
+    def from_datastore(cls, **kw: t.Any) -> ArtifactsTabularRow:
+        return cls(
+            name=kw["name"],
+            index=kw["index"],
+            created_at=kw["created_at"],
+            data=kw["data"],
+            link_wrapper=kw.get("__link_wrapper", True),
+        )
+
+    def asdict(self, ignore_keys: t.Optional[t.List[str]] = None) -> t.Dict:
+        return {
+            "__key": self.key,
+            "__link_wrapper": self._link_wrapper,
+            "name": self.name,
+            "index": self.index,
+            "data": self.data,
+        }
+
+
+class MetricsTabularRow(ASDictMixin):
+    def __init__(
+        self,
+        step: int,
+        clock_time: str,
+        relative_time: float,
+        metrics: t.Dict[str, float],
+    ) -> None:
+        self.step = step
+        self.clock_time = clock_time
+        self.relative_time = float(relative_time)
+        self.metrics = metrics
+        # TODO: add synced flag for syncer thread?
+        self._do_validate()
+
+    def _do_validate(self) -> None:
+        if self.step < 0:
+            raise TypeError(f"step({self.step}) should be non-negative integer number")
+
+        for k, v in self.metrics.items():
+            if not isinstance(k, str) or not isinstance(v, float):
+                raise TypeError(
+                    f"metric(k:{k}, v:{v}) should be str key and float value."
+                )
+
+    def __str__(self) -> str:
+        return f"MetricsTabularRow[{self.step}] {self.metrics}"
+
+    def __repr__(self) -> str:
+        return f"MetricsTabularRow[{self.step}] {self.metrics} at {self.clock_time}, relative time({self.relative_time}s)"
+
+    @classmethod
+    def from_datastore(cls, **kw: t.Any) -> MetricsTabularRow:
+        metrics: t.Dict[str, float] = {}
+
+        for k, v in kw.items():
+            if k.startswith("__"):
+                continue
+
+            if isinstance(k, str) and isinstance(v, (int, float)):
+                metrics[k] = float(v)
+
+        return cls(
+            step=kw["__step"],
+            clock_time=kw["__clock_time"],
+            relative_time=kw["__relative_time"],
+            metrics=metrics,
+        )
+
+    @classmethod
+    def from_record(cls, record: MetricsRecord) -> MetricsTabularRow:
+        return cls(
+            step=record.step,
+            clock_time=record.clock_time,
+            relative_time=record.relative_time,
+            metrics=record.data,
+        )
+
+    def asdict(self, ignore_keys: t.Optional[t.List[str]] = None) -> t.Dict:
+        ret: t.Dict[str, t.Any] = copy.deepcopy(self.metrics)
+        ret.update(
+            {
+                "__step": self.step,
+                "__clock_time": self.clock_time,
+                "__relative_time": self.relative_time,
+            }
+        )
+        return ret
+
+
+HandleQueueElementType = t.Optional[
+    t.Union[TrackRecord, MetricsRecord, ArtifactsRecord, ParamsRecord]
+]

--- a/client/starwhale/api/_impl/track/collector.py
+++ b/client/starwhale/api/_impl/track/collector.py
@@ -1,0 +1,238 @@
+import os
+import sys
+import time
+import typing as t
+import platform
+import threading
+from pathlib import Path
+from collections import defaultdict
+
+import psutil
+from loguru import logger
+
+from starwhale.consts import FMT_DATETIME
+from starwhale.utils.dict import flatten
+from starwhale.utils.venv import guess_current_py_env
+from starwhale.utils.error import NotFoundError
+
+from .base import _TrackSource
+from .tracker import Tracker
+
+
+class CollectorThread(threading.Thread):
+    def __init__(
+        self,
+        tracker: Tracker,
+        workdir: t.Union[Path, str],
+        sample_interval: float = 1.0,
+        report_interval: float = 30.0,
+        run_exceptions_limits: int = 100,
+    ) -> None:
+        super().__init__(name="CollectorThread")
+        self.tracker = tracker
+        workdir = Path(workdir)
+        if not workdir.exists():
+            raise NotFoundError(f"Collector workdir({workdir}) not found")
+        self.workdir = workdir
+
+        if sample_interval > report_interval:
+            raise ValueError(
+                f"sample interval({sample_interval}) should be less than report interval({report_interval})"
+            )
+        if sample_interval <= 0 or sample_interval > 60:
+            raise ValueError(
+                f"sample interval seconds({sample_interval}) must be between 0 and 60"
+            )
+        self.sample_interval = sample_interval
+
+        if report_interval <= 0 or report_interval > 300:
+            raise ValueError(
+                f"report interval seconds({report_interval}) must be between 0 and 300"
+            )
+        self.report_interval = report_interval
+
+        self._pid = os.getpid()
+        self._staging_metrics: t.Dict = defaultdict(list)
+        self._metrics_step = 0
+        self._metrics_inspect_cnt = 0
+        self._stopped = True
+        self._stop_event = threading.Event()
+        self._run_exceptions: t.List[Exception] = []
+
+        self._run_exceptions_limits: int = max(run_exceptions_limits, 0)
+        self.daemon = True
+
+    def _raise_run_exceptions(self, limits: t.Optional[int] = None) -> None:
+        limits = self._run_exceptions_limits if limits is None else limits
+        if len(self._run_exceptions) > limits:
+            raise threading.ThreadError(
+                f"{self} run raise {len(self._run_exceptions)} exceptions: {self._run_exceptions}"
+            )
+
+    def run(self) -> None:
+        self._stopped = False
+        self._stop_event.clear()
+
+        inspect_cases = [
+            ("code info", self._inspect_code),
+            ("python run info", self._inspect_python_run),
+            ("system specs", self._inspect_system_specs),
+            ("process info", self._inspect_process_specs),
+            ("environments", self._inspect_environments),
+        ]
+        for _info, _action in inspect_cases:
+            try:
+                ret = _action()
+                self.tracker._log_params(ret, source=_TrackSource.SYSTEM)
+            except Exception as e:
+                logger.exception(f"failed to inspect {_info}: {e}")
+
+        # TODO: tune the accuracy of inspect and report interval
+        last_inspect_time = last_report_time = time.monotonic()
+        check_interval = min(0.1, self.sample_interval)
+        while True:
+            if self._stop_event.wait(timeout=check_interval):
+                break
+
+            try:
+                if time.monotonic() - last_inspect_time > self.sample_interval:
+                    metrics = self._inspect_metrics()
+                    for k, v in flatten(metrics).items():
+                        self._staging_metrics[k].append(float(v))
+                    last_inspect_time = time.monotonic()
+                    self._metrics_inspect_cnt += 1
+
+                if time.monotonic() - last_report_time > self.report_interval:
+                    self._report_metrics()
+                    last_report_time = time.monotonic()
+            except Exception as e:
+                logger.exception(e)
+                self._run_exceptions.append(e)
+                self._raise_run_exceptions()
+
+    def close(self) -> None:
+        self._stop_event.set()
+        self.join()
+        self._stopped = True
+        self._staging_metrics = defaultdict(list)
+        self._raise_run_exceptions(0)
+
+    def _inspect_code(self) -> t.Dict[str, t.Any]:
+        # TODO: log code file as artifacts
+        # TODO: support users custom to upload code scripts
+        # TODO: make git fetch robust
+        import git
+
+        def _get_git_info() -> t.Dict[str, t.Any]:
+            repo = git.Repo(self.workdir, search_parent_directories=True)
+            commit = repo.head.commit
+            return {
+                "commit_sha": commit.hexsha,
+                "message": commit.message,
+                "author_name": commit.author.name,
+                "author_email": commit.author.email,
+                "date": commit.committed_datetime.strftime(FMT_DATETIME),
+                "is_dirty": repo.is_dirty(untracked_files=True),
+                "branch": repo.active_branch.name,
+                "remote_urls": [r.url for r in repo.remotes],
+            }
+
+        try:
+            git_info = _get_git_info()
+        except git.InvalidGitRepositoryError:
+            git_info = {}
+
+        return {
+            "code": {
+                "git": git_info,
+                "workdir": str(self.workdir),
+            }
+        }
+
+    def _inspect_python_run(self) -> t.Dict[str, t.Any]:
+        # TODO: add starwhale runtime, pip dependencies(pip requirements.txt and conda export.yaml) info
+        return {
+            "python": {
+                "version": platform.python_version(),
+                "bin_path": sys.executable,
+                "env_mode": guess_current_py_env(),
+            }
+        }
+
+    def _inspect_system_specs(self) -> t.Dict[str, t.Any]:
+        # TODO: add more system specs: gpu, network, ip...
+        return {
+            "system": {
+                "hostname": platform.node(),
+                "platform": sys.platform,
+                "os": platform.platform(),
+                "arch": platform.machine(),
+            },
+            "hardware": {
+                "cpu": {
+                    "cores": psutil.cpu_count(logical=False),
+                    "cores_logical": psutil.cpu_count(logical=True),
+                },
+                "memory": {"total_bytes": psutil.virtual_memory().total},
+                "disk": {
+                    "total_bytes": psutil.disk_usage("/").total,
+                    "used_bytes": psutil.disk_usage("/").used,
+                },
+            },
+        }
+
+    def _inspect_process_specs(self) -> t.Dict[str, t.Any]:
+        # TODO: get process more info
+        return {
+            "process": {
+                "pid": self._pid,
+                "cwd": str(self.workdir),
+                "cmdline": " ".join(psutil.Process(self._pid).cmdline()),
+            },
+        }
+
+    def _inspect_environments(self) -> t.Dict[str, t.Any]:
+        return {
+            "environments": dict(os.environ),
+        }
+
+    def _inspect_metrics(self) -> t.Dict[str, t.Any]:
+        _process = psutil.Process(self._pid)
+        # TODO: support more system and process metrics: network, io, memory
+        system_cpu_percent = [float(v) for v in psutil.cpu_percent(percpu=True)]  # type: ignore
+        cpu_cores = float(len(system_cpu_percent))
+        return {
+            "system": {
+                "cpu": {
+                    "usage_percent": sum(system_cpu_percent) / cpu_cores,
+                },
+            },
+            "process": {
+                "cpu": {
+                    "usage_percent": _process.cpu_percent() / cpu_cores,
+                },
+                "num_threads": _process.num_threads(),
+            },
+        }
+
+    def _report_metrics(self) -> None:
+        data = {}
+        for k, v in self._staging_metrics.items():
+            if not v:
+                continue
+
+            data[f"{k}/last"] = float(v[-1])
+            data[f"{k}/avg"] = round(sum(v) / len(v), 3)
+
+        if not data:
+            return
+
+        self.tracker._log_metrics(
+            data=data,
+            step=self._metrics_step,
+            commit=True,
+            source=_TrackSource.SYSTEM,
+        )
+
+        self._metrics_step += 1
+        self._staging_metrics = defaultdict(list)

--- a/client/starwhale/api/_impl/track/handler.py
+++ b/client/starwhale/api/_impl/track/handler.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import queue
+import typing as t
+import threading
+from pathlib import Path
+from collections import defaultdict
+
+from starwhale.utils.fs import ensure_dir, ensure_file
+from starwhale.utils.error import NoSupportError
+from starwhale.core.dataset.type import Link
+from starwhale.api._impl.data_store import TableWriter, LocalDataStore
+
+from .base import (
+    TrackRecord,
+    ParamsRecord,
+    MetricsRecord,
+    ArtifactsRecord,
+    MetricsTabularRow,
+    ArtifactsTabularRow,
+    HandleQueueElementType,
+)
+
+
+class HandlerThread(threading.Thread):
+    def __init__(
+        self,
+        workdir: t.Union[Path, str],
+        handle_queue: queue.Queue[HandleQueueElementType],
+        sync_queue: t.Optional[queue.Queue[t.Any]] = None,
+    ) -> None:
+        super().__init__(name="HandlerThread")
+
+        self.handle_queue = handle_queue
+        self.sync_queue = sync_queue
+
+        self._run_exception: t.Optional[Exception] = None
+        self._workdir = Path(workdir)
+        self._data_store = LocalDataStore(str(self._workdir))
+        self._table_writers: t.Dict[str, TableWriter] = {}
+        self._params: t.Dict[str, t.Dict] = defaultdict(dict)
+        # TODO: support non-in-memory artifacts auto-incr counter with datastore
+        self._artifacts_counter: t.Dict = defaultdict(int)
+
+        self.daemon = True
+
+    def _raise_run_exception(self) -> None:
+        if self._run_exception is not None:
+            raise threading.ThreadError(
+                f"HandlerThread raise exception: {self._run_exception}"
+            )
+
+    def flush(self) -> None:
+        self._dump_params()
+
+        for writer in self._table_writers.values():
+            writer.flush()
+
+        self._data_store.dump()
+
+    def close(self) -> None:
+        self.handle_queue.put(None)
+        self.join()
+        self.flush()
+
+        for writer in self._table_writers.values():
+            writer.close()
+
+        self._raise_run_exception()
+
+    def _handle_metrics(self, record: MetricsRecord) -> None:
+        row = MetricsTabularRow.from_record(record)
+        table_name = f"{record.typ.value}/{record.source.value}"
+        self._update_table(table_name, row.asdict(), "__step")
+
+    def _handle_artifacts(self, record: ArtifactsRecord) -> None:
+        table_name = f"{record.typ.value}/{record.source.value}"
+        store_dir = self._workdir / record.typ.value / "_files"
+        for k, v in record.data.items():
+            row = ArtifactsTabularRow(
+                name=k,
+                index=self._artifacts_counter[k],
+                created_at=record.clock_time,
+                data=Link.from_local_artifact(v, store_dir),
+                link_wrapper=not isinstance(v, Link),
+            )
+            self._update_table(table_name, row.asdict(), "__key")
+            self._artifacts_counter[k] += 1
+
+    def _handle_params(self, record: ParamsRecord) -> None:
+        self._params[record.source.value].update(record.data)
+
+    def _dump_params(self) -> None:
+        params_dir = self._workdir / "params"
+        ensure_dir(params_dir)
+
+        for k, v in self._params.items():
+            if not v:
+                continue
+            ensure_file(params_dir / f"{k}.json", json.dumps(v, separators=(",", ":")))
+
+    def _dispatch(self, record: TrackRecord) -> None:
+        if isinstance(record, MetricsRecord):
+            self._handle_metrics(record)
+        elif isinstance(record, ParamsRecord):
+            self._handle_params(record)
+        elif isinstance(record, ArtifactsRecord):
+            self._handle_artifacts(record)
+        else:
+            raise NoSupportError(f"no support to handle {record}({type(record)})")
+
+    def _update_table(self, table_name: str, data: t.Dict, key_column: str) -> None:
+        if table_name not in self._table_writers:
+            self._table_writers[table_name] = TableWriter(
+                table_name=table_name,
+                key_column=key_column,
+                data_store=self._data_store,
+                run_exceptions_limits=10,
+            )
+
+        writer = self._table_writers[table_name]
+        writer.insert(data)
+
+    def run(self) -> None:
+        try:
+            while True:
+                record = self.handle_queue.get(block=True, timeout=None)
+                if record is None:
+                    if self.handle_queue.qsize() > 0:
+                        continue
+                    else:
+                        break  # pragma: no cover
+
+                self._dispatch(record)
+        except Exception as e:
+            self._run_exception = e
+            raise

--- a/client/starwhale/api/_impl/track/hooker.py
+++ b/client/starwhale/api/_impl/track/hooker.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import io
+import sys
+import typing as t
+import logging
+from pathlib import Path
+
+import loguru
+
+from starwhale.utils.fs import ensure_dir
+from starwhale.utils.log import StreamWrapper
+
+from .base import _TrackSource
+
+
+def hook_frameworks() -> None:
+    ...
+
+
+def hook_python_libs() -> None:
+    ...
+
+
+class ConsoleLogHook:
+    def __init__(self, log_dir: Path, track_id: str, rotation: str = "100 MB") -> None:
+        self.log_dir = log_dir
+
+        self._stdout_changed: bool = False
+        self._stderr_changed: bool = False
+        self._original_stdout: t.Optional[io.TextIOWrapper] = None
+        self._original_stderr: t.Optional[io.TextIOWrapper] = None
+
+        self._rotation = rotation
+        self._track_id = track_id
+        self._logger: t.Optional[loguru.Logger] = None
+        self._log_handler_id: t.Optional[int] = None
+
+    def _setup_logger(self) -> loguru.Logger:
+        ensure_dir(self.log_dir)
+        loguru.logger.remove()
+        self._log_handler_id = loguru.logger.add(
+            self.log_dir / "console-{time}.log",
+            rotation=self._rotation,
+            backtrace=True,
+            diagnose=True,
+            serialize=True,
+        )
+        _logger = loguru.logger.bind(
+            source=_TrackSource.USER.value,
+            track_id=self._track_id,
+        )
+        return _logger
+
+    def install(self) -> None:
+        if self._logger is None:
+            self._logger = self._setup_logger()
+
+        if not isinstance(sys.stdout, StreamWrapper) and isinstance(
+            sys.stdout, io.TextIOWrapper
+        ):
+            self._original_stdout = sys.stdout
+            sys.stdout = StreamWrapper(sys.stdout, self._logger, logging.INFO)  # type: ignore
+            self._stdout_changed = True
+
+        if not isinstance(sys.stderr, StreamWrapper) and isinstance(
+            sys.stderr, io.TextIOWrapper
+        ):
+            self._original_stderr = sys.stderr
+            sys.stderr = StreamWrapper(sys.stderr, self._logger, logging.WARN)  # type: ignore
+            self._stderr_changed = True
+
+        # TODO: redirect python standard logger
+
+    def uninstall(self) -> None:
+        if self._log_handler_id is not None and self._logger is not None:
+            self._logger.remove(self._log_handler_id)
+            self._logger = None
+            self._log_handler_id = None
+
+        if self._stdout_changed and self._original_stdout is not None:
+            sys.stdout = self._original_stdout
+            self._stdout_changed = False
+            self._original_stdout = None
+
+        if self._stderr_changed and self._original_stderr is not None:
+            sys.stderr = self._original_stderr
+            self._stderr_changed = False
+            self._original_stderr = None

--- a/client/starwhale/api/_impl/track/syncer.py
+++ b/client/starwhale/api/_impl/track/syncer.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import queue
+import typing as t
+import threading
+
+from starwhale.base.uri import URI
+
+
+class SyncerThread(threading.Thread):
+    def __init__(self, sync_queue: queue.Queue[t.Any], project_uri: URI) -> None:
+        super().__init__(name=f"SyncerThread-{project_uri}")
+
+        self.queue = sync_queue
+        self.project_uri = project_uri
+
+        self.daemon = True
+
+    def run(self) -> None:
+        ...
+
+    def close(self) -> None:
+        ...

--- a/client/starwhale/api/_impl/track/tracker.py
+++ b/client/starwhale/api/_impl/track/tracker.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+import os
+import copy
+import json
+import time
+import queue
+import atexit
+import typing as t
+import threading
+from types import TracebackType
+from pathlib import Path
+
+import yaml
+from loguru import logger
+
+from starwhale.utils import now_str, random_str, gen_uniq_version
+from starwhale.consts import SW_AUTO_DIRNAME, DEFAULT_MANIFEST_NAME
+from starwhale.base.uri import URI
+from starwhale.utils.fs import ensure_dir, ensure_file
+from starwhale.base.type import URIType, InstanceType
+from starwhale.consts.env import SWEnv
+from starwhale.utils.dict import flatten
+from starwhale.utils.error import NoSupportError
+from starwhale.utils.config import SWCliConfigMixed
+from starwhale.core.dataset.type import BaseArtifact
+
+from .base import (
+    _TrackMode,
+    _TrackSource,
+    ParamsRecord,
+    MetricsRecord,
+    ArtifactsRecord,
+    HandleQueueElementType,
+)
+from .hooker import ConsoleLogHook, hook_frameworks, hook_python_libs
+from .syncer import SyncerThread
+from .handler import HandlerThread
+
+_INSTANCE_NOT_INIT_ERROR = (
+    "Tracker instance has not been initialized, please call track.start() at first"
+)
+
+
+# TODO: use multi-process model to refactor Tracer for GIL performance
+class Tracker:
+    _instance: t.Optional[Tracker] = None
+    _lock = threading.Lock()
+
+    def __init__(
+        self,
+        name: str,
+        project_uri: URI,
+        access_token: str = "",
+        auto_run_collect: bool = True,
+        auto_framework_hook: bool = True,
+        auto_console_log_redirect: bool = True,
+        mode: _TrackMode = _TrackMode.ONLINE,
+        with_id: str = "",
+        tags: t.Optional[t.List[str]] = None,
+        description: str = "",
+        collector_sample_interval: float = 1.0,
+        collector_report_interval: float = 30.0,
+        saved_dir: t.Optional[t.Union[str, Path]] = None,
+    ) -> None:
+        name = name.strip()
+        if not name:
+            raise ValueError("name field is empty")
+        self.name = name
+
+        if not project_uri.project:
+            raise ValueError(
+                f"{project_uri} is wrong format, that cannot fetch project field"
+            )
+
+        if project_uri.instance_type == InstanceType.CLOUD:
+            access_token = (
+                access_token
+                or SWCliConfigMixed().get_sw_token(instance=project_uri.instance)
+                or os.environ.get(SWEnv.instance_token, "")
+            )
+            if not access_token:
+                raise ValueError("access_token is required for cloud instance")
+
+        self.project_uri = project_uri
+        self.access_token = access_token
+        self.auto_run_collect = auto_run_collect
+        self.auto_framework_hook = auto_framework_hook
+        self.auto_console_log_redirect = auto_console_log_redirect
+        # TODO: support envs setting for collector_*_interval
+        self.collector_sample_interval = collector_sample_interval
+        self.collector_report_interval = collector_report_interval
+        self.mode = mode
+        self.tags = tags or []
+        self.description = description
+
+        if saved_dir is None:
+            saved_dir = Path.cwd()
+
+        self._saved_dir = Path(saved_dir).absolute()
+
+        self._id = with_id or gen_uniq_version()
+        # TODO: support with_id argument from existed Tracker in the local storage
+        self._metric_step = 0
+        self._metric_lock = threading.Lock()
+        self._uncommitted_metrics: t.Dict[str, float] = {}
+
+        self._handle_queue: queue.Queue[HandleQueueElementType] = queue.Queue()
+        self._sync_queue: queue.Queue[t.Any] = queue.Queue()
+        self._threads: t.List[threading.Thread] = []
+        self._handler_thread: t.Optional[threading.Thread] = None
+        self._syncer_thread: t.Optional[threading.Thread] = None
+        self._collector_thread: t.Optional[threading.Thread] = None
+
+        self._start_time = time.monotonic()
+        self._workdir: t.Optional[Path] = None
+        self._log_hook: t.Optional[ConsoleLogHook] = None
+        self._manifest: t.Dict[str, t.Any] = {"start_time": now_str()}
+
+    def __str__(self) -> str:
+        return f"Starwhale Tracker[{self.mode.value}]-{self.name}-{self._id}"
+
+    def __repr__(self) -> str:
+        return f"Starwhale Tracker[{self.mode.value}]-{self.name}-{self._id}-{self.project_uri}"
+
+    def __enter__(self) -> Tracker:
+        return self
+
+    def __exit__(
+        self,
+        type: t.Optional[t.Type[BaseException]],
+        value: t.Optional[BaseException],
+        trace: TracebackType,
+    ) -> None:
+        if value:  # pragma: no cover
+            logger.warning(f"type:{type}, exception:{value}, traceback:{trace}")
+
+        self.end()
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    # TODO: support re-init for Tracker, create multi trackers
+    @classmethod
+    def start(
+        cls,
+        name: str = "",
+        project_uri: t.Optional[t.Union[str, URI]] = None,
+        access_token: str = "",
+        auto_run_collect: bool = True,
+        auto_framework_hook: bool = True,
+        auto_console_log_redirect: bool = True,
+        mode: str = "online",
+        with_id: str = "",
+        tags: t.Optional[t.List[str]] = None,
+        description: str = "",
+        collector_sample_interval: float = 1.0,
+        collector_report_interval: float = 30.0,
+        saved_dir: t.Optional[t.Union[str, Path]] = None,
+    ) -> Tracker:
+        """Starts an new tracker to track metrics, artifacts and parameters to Starwhale.
+
+        In your python script code, you should add `track.start()` to the beginning of training or evaluation code block,
+        and every thing will be tracked to Starwhale.
+
+        Arguments:
+            name: (str, optional) The name of tracker. If the name is not specified,
+                a random and human-readable name will be generated. Every name will be added an increment index suffix automatically.
+            project_uri: (str, URI, optional) The project URI is the place where tracker sends records.
+                If the project_uri is not specified, the default selected instance and project will be used. Standalone or Cloud instance
+                project is ok.
+            access_token: (str, optional) When project_uri is the cloud project, access_token is required. If access_token is not specified,
+                starwhale will try to fetch token by `SW_TOKEN` environment or `~/.config/starwhale/config.yaml` config file.
+            auto_run_collect: (bool, optional) When auto_environment value is `True`, Tracker will log program run environment information
+                automatically. The run environment information includes cpu/gpu/mem/python/os and so on. `auto_environment` is `True` in default.
+            auto_framework_hook: (bool, optional) Auto record MachineLearning Frameworks metrics. `auto_framework` is `True` in default.
+            auto_console_log_redirect: (bool, optional) Tracker will catch program stdout and stderr console log. `auto_console_log` is `True` in default.
+            mode: (str, optional) Config track mode. Options: `online` or `offline`. Defaults to `online`.
+                cases:
+                - `online`: sync track data to Starwhale Server.
+                - `offline`: Only record track data in the local dir. You can run `swcli track track` manually.
+            with_id: (str, optional) Reuse the existed Tracker. id is the tracker uuid.
+            tags: (list[str], optional) Tags are used to organize, filter tracks.
+            description: (str, optional) Tacker description.
+            collector_sample_interval: (float, optional) the interval seconds of the run collector collect, default is 2.0 seconds.
+            collector_report_interval: (float, optional) the interval seconds of the run collector report, all values will be aggregated to one value. default is 30.0 seconds.
+            saved_dir: (str, pathlib.Path, optional) the saved dir for track, default is cwd dir.
+
+        Examples:
+        ```python
+        from starwhale import track
+        track.start()
+        track.metrics(loss=0.768, accuracy=0.9)
+        track.end()
+
+        Returns:
+            A `Tracker` object.
+        ```
+        """
+        with Tracker._lock:
+            if Tracker._instance is not None:
+                raise RuntimeError(f"{Tracker._instance} has already been initialized")
+
+            if project_uri is None:
+                scm = SWCliConfigMixed()
+                _inst = scm.current_instance
+                _prj = scm.current_project
+                if not _inst or not _prj:
+                    raise ValueError(
+                        f"cannot get default project uri(instance:{_inst}, project:{_prj}) from swcli config"
+                    )
+                project_uri = URI(
+                    f"{_inst}/project/{_prj}", expected_type=URIType.PROJECT
+                )
+            elif isinstance(project_uri, str):
+                project_uri = URI(project_uri, expected_type=URIType.PROJECT)
+            elif isinstance(project_uri, URI):
+                project_uri = project_uri
+            else:
+                raise TypeError(
+                    f"project_uri({project_uri}) type is unexpected, only accepts str, URI or None"
+                )
+
+            name = name.strip()
+            if not name:
+                name = random_str()
+
+            _tracker = Tracker(
+                name=name,
+                project_uri=project_uri,
+                access_token=access_token,
+                auto_run_collect=auto_run_collect,
+                auto_framework_hook=auto_framework_hook,
+                auto_console_log_redirect=auto_console_log_redirect,
+                mode=_TrackMode(mode),
+                with_id=with_id,
+                tags=tags,
+                description=description,
+                collector_sample_interval=collector_sample_interval,
+                collector_report_interval=collector_report_interval,
+                saved_dir=saved_dir,
+            )
+            _tracker._setup()
+            Tracker._instance = _tracker
+            return _tracker
+
+    @classmethod
+    def end(cls) -> None:
+        """Ends a track.
+        Singleton Tracker instance will be released. If users don't call end function,
+        Tracker will call end function when the process exiting automatically.
+        """
+        with Tracker._lock:
+            if Tracker._instance is None:
+                return
+
+            _inst = Tracker._instance
+            Tracker._instance = None
+
+            _inst._render_manifest()
+            _inst._close_threads()
+
+            if _inst._log_hook is not None:
+                _inst._log_hook.uninstall()
+                _inst._log_hook = None
+
+            atexit.unregister(Tracker.end)
+
+    @classmethod
+    def metrics(
+        cls,
+        *args: t.Dict,
+        step: t.Optional[int] = None,
+        commit: bool = True,
+        **kwargs: float,
+    ) -> Tracker:
+        """Track metrics to Starwhale.
+        Metric value type must be float or convertible-float type. Each call to `metrics` function will trigger
+        internal step counter to be added by 1.
+
+        Arguments:
+            *args: [dict, optional] use dicts to store metrics.
+            **kwargs: [float, optional] use kv to store metrics.
+            step: [int, optional] custom step value.
+            commit: [bool, optional] when `commit` is `false`, the metrics will be aggregated with the same step value
+                until the next `track.metrics(commit=True)` function call. Defaults to `true`.
+
+        Examples:
+        ```python
+        track.metrics(loss=0.99)
+        track.metrics(loss=0.99, accuracy=0.98)
+        track.metrics({"loss": 0.99, "accuracy": 0.98})
+
+        # loss and accuracy use the same step.
+        track.metrics(loss=0.99, commit=False)
+        track.metrics(accuracy=0.98)
+
+        # use custom step value
+        track.metrics(loss=0.99, step=1)
+
+        Returns:
+            A `Tracker` object.
+        ```
+        """
+        if cls._instance is None:
+            raise RuntimeError(_INSTANCE_NOT_INIT_ERROR)
+
+        data = cls._merge_dicts(args, kwargs)
+        cls._instance._log_metrics(data=data, step=step, commit=commit)
+        return cls._instance
+
+    def _log_metrics(
+        self,
+        data: t.Dict[str, float],
+        step: t.Optional[int] = None,
+        commit: bool = False,
+        source: _TrackSource = _TrackSource.USER,
+    ) -> None:
+        if not data:
+            return
+
+        _data = flatten(data, extract_sequence=True)
+        for k, v in _data.items():
+            _data[k] = float(v)
+
+        _step: int = self._metric_step
+        if step is not None:
+            if not isinstance(step, int) or step < 0:
+                raise TypeError(
+                    f"step({step}) is unexpected, the normal step is non-negative integer"
+                )
+            _step = step
+
+        with self._metric_lock:
+            self._uncommitted_metrics.update(_data)
+            if commit:
+                self._handle_queue.put(
+                    MetricsRecord(
+                        data=copy.deepcopy(self._uncommitted_metrics),
+                        step=_step,
+                        source=source,
+                        start_time=self._start_time,
+                    )
+                )
+                self._metric_step = _step + 1
+                self._uncommitted_metrics = {}
+
+    @classmethod
+    def _merge_dicts(cls, *args: t.Any, **kwargs: t.Any) -> t.Dict:
+        data: t.Dict = {}
+        for item in args:
+            if not item:
+                continue
+            elif isinstance(item, tuple):
+                for i in item:
+                    if i and isinstance(i, dict):
+                        data.update(i)
+            elif isinstance(item, dict):
+                data.update(item)
+            else:
+                raise TypeError(f"item{item} no support type")
+
+        data.update(kwargs)
+        return data
+
+    @classmethod
+    def params(cls, *args: t.Dict[str, t.Any], **kwargs: t.Any) -> Tracker:
+        """Track parameters to Starwhale.
+        We can use `track.params` to record hyperparameter and configuration. The arguments must be jsonable values.
+
+        Arguments:
+            *args: [dict, optional] use dicts to store parameters.
+            **kwargs: [optional] use kv to store parameters.
+
+        Examples:
+        ```python
+        track.params(model="multi-classification")
+        track.params({"batch_size": 10})
+        ```
+        Returns:
+            A `Tracker` object.
+        """
+        if cls._instance is None:
+            raise RuntimeError(_INSTANCE_NOT_INIT_ERROR)
+        data = cls._merge_dicts(args, kwargs)
+        cls._instance._log_params(data)
+        return cls._instance
+
+    def _log_params(
+        self, data: t.Dict[str, t.Any], source: _TrackSource = _TrackSource.USER
+    ) -> None:
+        if not data:
+            return
+
+        if data != json.loads(json.dumps(data)):
+            raise TypeError(f"{data} keys should be string type")
+
+        self._handle_queue.put(
+            ParamsRecord(data=data, source=source, start_time=self._start_time)
+        )
+
+    @classmethod
+    def artifacts(cls, *args: t.Dict[str, t.Any], **kwargs: t.Any) -> Tracker:
+        """Track artifacts to Starwhale.
+
+        Arguments:
+            *args: [dict, optional] use dicts to store artifacts.
+            **kwargs: [optional] use kv to store artifacts.
+
+        Examples:
+        ```python
+        track.artifacts(model=Model("./model/mnist.pth"))
+        track.artifacts(image=Image("sample.png"))
+        ```
+        Returns:
+            A `Tracker` object.
+        """
+        if cls._instance is None:
+            raise RuntimeError(_INSTANCE_NOT_INIT_ERROR)
+        data = cls._merge_dicts(args, kwargs)
+        cls._instance._log_artifacts(data)
+        return cls._instance
+
+    def _log_artifacts(
+        self, data: t.Dict[str, t.Any], source: _TrackSource = _TrackSource.USER
+    ) -> None:
+        if not data:
+            return
+
+        _data = flatten(data, extract_sequence=True)
+        for k, v in _data.items():
+            # TODO: support more artifacts type
+            if not isinstance(v, BaseArtifact):
+                raise NoSupportError(f"v({v}:{type(v)}) not support for artifacts")
+
+        self._handle_queue.put(
+            ArtifactsRecord(data=_data, source=source, start_time=self._start_time)
+        )
+
+    def _close_threads(self) -> None:
+        for _t in self._threads:
+            if _t is None:
+                continue
+            _t.close()  # type: ignore
+
+    def _setup_dirs(self) -> None:
+        track_rootdir = self._saved_dir / SW_AUTO_DIRNAME / "track"
+        ensure_dir(track_rootdir)
+
+        target_idx = -1
+        for d in track_rootdir.iterdir():
+            if not d.is_dir() or "-" not in d.name:
+                continue
+
+            idx, tid = d.name.split("-", 1)
+            if tid == self._id:
+                self._workdir = track_rootdir / d.name
+                return
+
+            target_idx = max(target_idx, int(idx))
+
+        self._manifest["track_incr_index"] = target_idx + 1
+        self._workdir = track_rootdir / f"{target_idx + 1}-{self._id}"
+        ensure_dir(self._workdir)
+        ensure_dir(self._workdir / "logs")
+        ensure_dir(self._workdir / "metrics")
+        ensure_dir(self._workdir / "params")
+        ensure_dir(self._workdir / "artifacts")
+
+    def _setup(self) -> None:
+        atexit.register(Tracker.end)
+        self._setup_dirs()
+
+        if self._workdir is None:
+            raise RuntimeError("workdir is None")
+
+        if self.auto_run_collect:
+            from .collector import CollectorThread
+
+            self._collector_thread = CollectorThread(
+                tracker=self,
+                sample_interval=self.collector_sample_interval,
+                report_interval=self.collector_report_interval,
+                workdir=self._workdir,
+            )
+            self._threads.append(self._collector_thread)
+
+        if self.mode == _TrackMode.ONLINE:
+            self._syncer_thread = SyncerThread(self._sync_queue, self.project_uri)
+            self._threads.append(self._syncer_thread)
+            _sync_queue = self._sync_queue
+        else:
+            _sync_queue = None
+
+        self._handler_thread = HandlerThread(
+            workdir=self._workdir,
+            handle_queue=self._handle_queue,
+            sync_queue=_sync_queue,
+        )
+        self._threads.append(self._handler_thread)
+
+        for _t in self._threads:
+            if _t is None:  # pragma: no cover
+                continue
+            _t.start()
+
+        if self.auto_console_log_redirect and self._log_hook is None:
+            self._log_hook = ConsoleLogHook(
+                log_dir=self._workdir / "logs",
+                track_id=self._id,
+            )
+            self._log_hook.install()
+
+        if self.auto_framework_hook:
+            hook_frameworks()
+            hook_python_libs()
+
+    def _render_manifest(self) -> None:
+        if self._workdir is None:
+            raise RuntimeError("can not fetch workdir")
+
+        self._manifest.update(
+            {
+                "id": self._id,
+                "name": self.name,
+                "project_uri": str(self.project_uri),
+                "end_time": now_str(),
+                "auto": {
+                    "run_collect": self.auto_run_collect,
+                    "console_log_redirect": self.auto_console_log_redirect,
+                    "framework_hook": self.auto_framework_hook,
+                },
+                "collector_interval": {
+                    "sample": self.collector_sample_interval,
+                    "report": self.collector_report_interval,
+                },
+                "mode": self.mode.value,
+                "tags": self.tags,
+                "description": self.description,
+                "workdir": str(self._workdir),
+            }
+        )
+
+        ensure_dir(self._workdir)
+        ensure_file(
+            self._workdir / DEFAULT_MANIFEST_NAME,
+            yaml.safe_dump(self._manifest, default_flow_style=False),
+        )

--- a/client/starwhale/api/track.py
+++ b/client/starwhale/api/track.py
@@ -1,0 +1,9 @@
+from ._impl.track.tracker import Tracker
+
+start = Tracker.start
+end = Tracker.end
+metrics = Tracker.metrics
+artifacts = Tracker.artifacts
+params = Tracker.params
+
+__all__ = ["start", "end", "metrics", "artifacts", "params", "Tracker"]

--- a/client/starwhale/cli/__init__.py
+++ b/client/starwhale/cli/__init__.py
@@ -15,8 +15,8 @@ from starwhale.core.project.cli import project_cmd
 from starwhale.core.runtime.cli import runtime_cmd
 from starwhale.core.instance.cli import instance_cmd
 
-from .cli import config_cmd
 from .mngt import add_mngt_command
+from .config import config_cmd
 from .completion import completion_cmd
 
 

--- a/client/starwhale/cli/config.py
+++ b/client/starwhale/cli/config.py
@@ -7,12 +7,12 @@ from starwhale.utils.cli import AliasedGroup
 @click.group(
     "config",
     cls=AliasedGroup,
-    help="Configuration management, edit is supported now",
+    help="Configuration management",
 )
 def config_cmd() -> None:
     pass
 
 
-@config_cmd.command("edit", aliases=["e"], help="edit the configuration of swlci")
-def __edit() -> None:
+@config_cmd.command("edit", aliases=["e"], help="edit the configuration of swcli")
+def _edit() -> None:
     config.edit_from_shell()

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -17,10 +17,17 @@ from starwhale.utils import load_yaml, convert_to_bytes, validate_obj_name
 from starwhale.consts import (
     LATEST_TAG,
     SHORT_VERSION_CNT,
+    VERSION_PREFIX_CNT,
     DEFAULT_STARWHALE_API_VERSION,
 )
 from starwhale.base.uri import URI
-from starwhale.utils.fs import FilePosition
+from starwhale.utils.fs import (
+    ensure_dir,
+    ensure_file,
+    FilePosition,
+    blake2b_content,
+    BLAKE2B_SIGNATURE_ALGO,
+)
 from starwhale.base.mixin import ASDictMixin
 from starwhale.utils.error import (
     NoSupportError,
@@ -189,6 +196,10 @@ class ArtifactType(Enum):
     Audio = "audio"
     Text = "text"
     Link = "link"
+    Unknown = "unknown"
+
+
+# TODO: support File, Model artifacts
 
 
 _TBAType = t.TypeVar("_TBAType", bound="BaseArtifact")
@@ -283,11 +294,16 @@ class BaseArtifact(ASDictMixin, metaclass=ABCMeta):
         self._raw_base64_data = base64.b64encode(self.to_bytes()).decode()
         return self
 
+    def drop_data(self: _TBAType) -> _TBAType:
+        self.fp = b""
+        if hasattr(self, "_raw_base64_data"):
+            del self._raw_base64_data
+        return self
+
     def astype(self) -> t.Dict[str, t.Any]:
         return {
-            "type": self.type,
-            "mime_type": self.mime_type,
-            "shape": self.shape,
+            "type": self.type.value,
+            "mime_type": self.mime_type.value,
             "encoding": self.encoding,
             "display_name": self.display_name,
         }
@@ -730,7 +746,9 @@ class Link(ASDictMixin, SwObject):
         uri: t.Union[str, Path] = "",
         offset: int = FilePosition.START.value,
         size: int = -1,
+        data_type: t.Optional[t.Union[BaseArtifact, t.Dict]] = None,
         with_local_fs_data: bool = False,
+        use_plain_type: bool = False,
         owner: t.Optional[t.Union[str, URI]] = None,
         **kwargs: t.Any,
     ) -> None:
@@ -739,13 +757,28 @@ class Link(ASDictMixin, SwObject):
         self.uri = (str(uri)).strip()
         _up = urlparse(self.uri)
         self.scheme = _up.scheme
+        if offset < 0:
+            raise FieldTypeOrValueError(f"offset({offset}) must be non-negative")
+
         self.offset = offset
         self.size = size
+
+        if data_type is not None and not isinstance(data_type, (BaseArtifact, dict)):
+            raise TypeError(
+                f"data_type({data_type}) is not None or BaseArtifact or dict type"
+            )
+
+        if isinstance(data_type, BaseArtifact):
+            data_type = data_type.drop_data()
+            if use_plain_type:
+                data_type = data_type.astype()
+
+        self.data_type = data_type
+
         self.with_local_fs_data = with_local_fs_data
         self._local_fs_uri = ""
         self._signed_uri = ""
 
-        self.do_validate()
         self.extra_info = kwargs
 
     @property
@@ -764,13 +797,17 @@ class Link(ASDictMixin, SwObject):
     def signed_uri(self, value: str) -> None:
         self._signed_uri = value
 
-    def do_validate(self) -> None:
-        if self.offset < 0:
-            raise FieldTypeOrValueError(f"offset({self.offset}) must be non-negative")
-
     def astype(self) -> t.Dict[str, t.Any]:
+        data_type: t.Dict
+        if isinstance(self.data_type, dict):
+            data_type = self.data_type
+        elif isinstance(self.data_type, BaseArtifact):
+            data_type = self.data_type.astype()
+        else:
+            data_type = {}
         return {
             "type": self._type,
+            "data_type": data_type,
         }
 
     def __str__(self) -> str:
@@ -794,6 +831,33 @@ class Link(ASDictMixin, SwObject):
             key_compose=key_compose, bucket=store.bucket
         ) as f:
             return f.read(self.size)  # type: ignore
+
+    @classmethod
+    def from_local_artifact(
+        cls, data: t.Union[BaseArtifact, Link], store_dir: Path
+    ) -> Link:
+        if isinstance(data, Link):
+            return data
+
+        raw_content = data.to_bytes()
+        sign_name = blake2b_content(raw_content)
+        fpath = (
+            store_dir
+            / BLAKE2B_SIGNATURE_ALGO
+            / sign_name[:VERSION_PREFIX_CNT]
+            / sign_name
+        )
+        ensure_dir(fpath.parent)
+        ensure_file(fpath, raw_content)
+
+        return Link(
+            uri=fpath,
+            offset=0,
+            size=len(raw_content),
+            data_type=data,
+            with_local_fs_data=True,
+            use_plain_type=True,
+        )
 
 
 class DatasetSummary(ASDictMixin):

--- a/client/starwhale/utils/config.py
+++ b/client/starwhale/utils/config.py
@@ -124,8 +124,11 @@ class SWCliConfigMixed:
 
     @property
     def sw_remote_addr(self) -> str:
-        addr = self._current_instance_obj.get("uri", "")
-        return fmt_http_server(addr)
+        addr: str = self._current_instance_obj.get("uri", "")
+        if addr == "local":
+            return addr
+        else:
+            return fmt_http_server(addr)
 
     @property
     def user_name(self) -> str:

--- a/client/starwhale/utils/dict.py
+++ b/client/starwhale/utils/dict.py
@@ -2,7 +2,9 @@ import typing as t
 from copy import deepcopy
 
 
-def do_flatten_dict(origin: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+def flatten(
+    origin: t.Dict[str, t.Any], extract_sequence: bool = False
+) -> t.Dict[str, t.Any]:
     rt = {}
 
     def _f_dict(_s: t.Dict[str, t.Any], _prefix: str = "") -> None:
@@ -10,20 +12,20 @@ def do_flatten_dict(origin: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
             _k = f"{_prefix}{_k}"
             if isinstance(_v, dict):
                 _f_dict(_v, _prefix=f"{_k}/")
-            elif isinstance(_v, (tuple, list)):
-                _f_list(_v, _prefix=f"{_k}/")
+            elif isinstance(_v, (tuple, list)) and extract_sequence:
+                _f_sequence(_v, _prefix=f"{_k}/")
             else:
                 rt[_k] = _v
 
-    def _f_list(
+    def _f_sequence(
         data: t.Union[t.Tuple[t.Any, ...], t.List[t.Any]], _prefix: str = ""
     ) -> None:
         index = 0
         for _d in data:
             if isinstance(_d, dict):
-                _f_dict(_d, _prefix=f"{_prefix}/")
+                _f_dict(_d, _prefix=f"{_prefix}")
             elif isinstance(_d, (tuple, list)):
-                _f_list(_d, _prefix=f"{_prefix}/")
+                _f_sequence(_d, _prefix=f"{_prefix}")
             else:
                 rt[f"{_prefix}{index}"] = _d
             index += 1

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -372,7 +372,7 @@ class TestJsonDict(TestCase):
         _jd = JsonDict(self.JSON_DICT)
         self._do_assert(_jd)
 
-    def _do_assert(self, _jd):
+    def _do_assert(self, _jd: JsonDict) -> None:
         self.assertEqual(1, _jd.a)
         self.assertEqual([1, 2, 3], _jd.b)
         self.assertEqual(JsonDict, type(_jd.c))
@@ -396,6 +396,7 @@ class TestJsonDict(TestCase):
                             "owner": data_store.UNKNOWN,
                             "offset": data_store.INT64,
                             "size": data_store.INT64,
+                            "data_type": data_store.UNKNOWN,
                             "with_local_fs_data": data_store.BOOL,
                             "_local_fs_uri": data_store.STRING,
                             "_signed_uri": data_store.STRING,

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -349,6 +349,7 @@ class TestDatasetCopy(BaseTestCase):
                                 {"name": "scheme", "type": "STRING"},
                                 {"name": "offset", "type": "INT64"},
                                 {"name": "size", "type": "INT64"},
+                                {"name": "data_type", "type": "UNKNOWN"},
                                 {"name": "with_local_fs_data", "type": "BOOL"},
                                 {"name": "_local_fs_uri", "type": "STRING"},
                                 {"name": "_signed_uri", "type": "STRING"},
@@ -756,13 +757,12 @@ class TestDatasetBuildExecutor(BaseTestCase):
         tdb = TabularDataset(name="mnist", version="112233", project="self")
         meta = list(tdb.scan(start=0, end=1))[0]
         assert meta.id == 0
-        assert meta.data["data"].link.offset == 32
         assert meta.data["data"].link.extra_info["bin_offset"] == 0
+        assert meta.data["data"].link.offset == 32
         assert meta.data["data"].link.extra_info["bin_size"] == 864
         assert meta.data["data"].link.uri in data_files_sign
         assert meta.data["data"].type == ArtifactType.Image
         assert meta.data["data"].mime_type == MIMEType.GRAYSCALE
-        assert meta.data["data"].shape == [28, 28, 1]
 
         assert list(tdb.info) == ["int", "dict", "list", "list_dict"]
         assert tdb.info["list_dict"] == [{"a": 1}, {"b": 2}]
@@ -838,9 +838,8 @@ class TestDatasetType(TestCase):
         b = Binary(b"test")
         assert b.to_bytes() == b"test"
         assert b.astype() == {
-            "type": ArtifactType.Binary,
-            "mime_type": MIMEType.UNDEFINED,
-            "shape": (),
+            "type": ArtifactType.Binary.value,
+            "mime_type": MIMEType.UNDEFINED.value,
             "encoding": "",
             "display_name": "",
         }
@@ -990,11 +989,14 @@ class TestDatasetType(TestCase):
         link = Link(
             uri="s3://minioadmin:minioadmin@10.131.0.1:9000/users/path/to/file",
             owner="mnist/version/latest",
+            data_type=Image(display_name="test"),
         )
         as_type = link.astype()
         assert as_type["type"] == "link"
-
+        assert as_type["data_type"]["type"] == ArtifactType.Image.value
+        assert as_type["data_type"]["display_name"] == "test"
         raw_content = b"123"
+
         m_boto3.return_value = MagicMock(
             **{
                 "Object.return_value": MagicMock(

--- a/client/tests/sdk/test_track.py
+++ b/client/tests/sdk/test_track.py
@@ -1,0 +1,921 @@
+from __future__ import annotations
+
+import io
+import sys
+import json
+import time
+import queue
+import threading
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from starwhale.api import track
+from starwhale.utils import now_str, load_yaml
+from starwhale.base.uri import URI
+from starwhale.utils.fs import ensure_dir, ensure_file
+from starwhale.base.type import URIType
+from starwhale.utils.log import StreamWrapper
+from starwhale.utils.error import NotFoundError, NoSupportError
+from starwhale.utils.process import check_call
+from starwhale.core.dataset.type import Link, Audio, Image
+from starwhale.api._impl.data_store import TableDesc, TableWriter
+from starwhale.api._impl.track.base import (
+    _TrackType,
+    TrackRecord,
+    _TrackSource,
+    ParamsRecord,
+    MetricsRecord,
+    ArtifactsRecord,
+    MetricsTabularRow,
+    ArtifactsTabularRow,
+)
+from starwhale.api._impl.track.hooker import ConsoleLogHook
+from starwhale.api._impl.track.handler import HandlerThread
+from starwhale.api._impl.track.tracker import Tracker
+from starwhale.api._impl.track.collector import CollectorThread
+
+from .test_base import BaseTestCase
+
+
+class TestTrackBase(BaseTestCase):
+    def test_metrics_record(self) -> None:
+        start_time = time.monotonic()
+        mr = MetricsRecord(
+            data={"loss": 0.99},
+            step=1,
+            start_time=start_time,
+        )
+
+        assert mr.typ == _TrackType.METRICS
+        assert mr.relative_time < 100
+        assert isinstance(mr.relative_time, float)
+        assert mr.source == _TrackSource.USER
+        assert isinstance(mr.clock_time, str)
+
+    def test_artifacts_tabular_row(self) -> None:
+        atr = ArtifactsTabularRow(
+            name="test_image",
+            index=1,
+            created_at=now_str(),
+            data=Link.from_local_artifact(
+                data=Image(fp=b"123"), store_dir=Path(self.local_storage)
+            ),
+            link_wrapper=True,
+        )
+        ret_dict = atr.asdict()
+        assert atr.key == ret_dict["__key"] == "test_image-0001"
+        assert ret_dict["__link_wrapper"]
+
+        atr = ArtifactsTabularRow.from_datastore(
+            name="test_image",
+            index=0,
+            created_at=now_str(),
+            data=Link(),
+            __link_wrapper=False,
+        )
+        assert isinstance(atr, ArtifactsTabularRow)
+        assert atr.key == "test_image-0000"
+        assert not atr._link_wrapper
+
+    def test_artifacts_tabular_row_exceptions(self) -> None:
+        with self.assertRaisesRegex(TypeError, "is not Link type"):
+            ArtifactsTabularRow(
+                name="test_image",
+                index=1,
+                created_at=now_str(),
+                data=Image(),  # type: ignore
+                link_wrapper=True,
+            )
+
+        with self.assertRaisesRegex(ValueError, "must be non negative integer number"):
+            ArtifactsTabularRow(
+                name="test_image",
+                index=-1,
+                created_at=now_str(),
+                data=Link(),
+                link_wrapper=True,
+            )
+
+    def test_metrics_tabular_row(self) -> None:
+        now = now_str()
+        mtd = MetricsTabularRow(
+            step=0,
+            clock_time=now,
+            relative_time=10,
+            metrics={"loss": 0.99},
+        )
+        ret_dict = mtd.asdict()
+        assert ret_dict == {
+            "loss": 0.99,
+            "__step": 0,
+            "__clock_time": now,
+            "__relative_time": 10.0,
+        }
+
+        mtd = MetricsTabularRow.from_record(
+            record=MetricsRecord(
+                step=1,
+                data={"loss": 0.99, "acc": 0.98},
+            )
+        )
+        ret_dict = mtd.asdict()
+        assert ret_dict == {
+            "loss": 0.99,
+            "acc": 0.98,
+            "__step": 1,
+            "__clock_time": mtd.clock_time,
+            "__relative_time": mtd.relative_time,
+        }
+
+        mtd = MetricsTabularRow.from_datastore(
+            __step=1, __clock_time=now, __relative_time=1.0, loss=0.99, acc=0.98
+        )
+        assert mtd.step == 1
+        assert mtd.clock_time == now
+        assert mtd.relative_time == 1.0
+        assert mtd.metrics == {"loss": 0.99, "acc": 0.98}
+        assert mtd.asdict() == json.loads(json.dumps(mtd.asdict()))
+
+    def test_metrics_tabular_row_exceptions(self) -> None:
+        now = now_str()
+        with self.assertRaisesRegex(TypeError, "should be non-negative integer number"):
+            MetricsTabularRow(
+                step=-1,
+                clock_time=now,
+                relative_time=10,
+                metrics={"loss": 0.99},
+            )
+
+        with self.assertRaisesRegex(TypeError, "should be str key and float value"):
+            MetricsTabularRow(
+                step=1,
+                clock_time=now,
+                relative_time=10,
+                metrics={"loss": "test"},  # type: ignore
+            )
+
+        with self.assertRaisesRegex(TypeError, "should be str key and float value"):
+            MetricsTabularRow(
+                step=1,
+                clock_time=now,
+                relative_time=10,
+                metrics={1: 1.1},  # type: ignore
+            )
+
+
+class TestTracker(BaseTestCase):
+    def tearDown(self) -> None:
+        Tracker._instance = None
+        super().tearDown()
+
+    def test_start_with_default(self) -> None:
+        code_dir = Path(self.local_storage) / "code"
+        ensure_dir(code_dir)
+        t = Tracker.start(saved_dir=code_dir)
+        assert isinstance(t, Tracker)
+        assert t == Tracker._instance
+        assert t.name != ""
+        assert t.id != ""
+
+        assert t._collector_thread is not None
+        assert t._collector_thread.is_alive()
+
+        assert t._syncer_thread is not None
+
+        assert t._handler_thread is not None
+        assert t._handler_thread.is_alive()
+
+        assert len(t._threads) == 3
+        assert t._log_hook is not None
+        assert isinstance(sys.stdout, StreamWrapper)
+        assert isinstance(sys.stderr, StreamWrapper)
+
+        assert (t._saved_dir / ".starwhale" / "track" / f"0-{t.id}").exists()
+        t.end()
+
+    def test_start_with_custom(self) -> None:
+        with Tracker.start(
+            saved_dir=self.local_storage,
+            name="test_tracker",
+            project_uri=URI("test_project", expected_type=URIType.PROJECT),
+        ) as t:
+            assert t.name == "test_tracker"
+            assert t.project_uri.project == "test_project"
+
+        with Tracker.start(
+            saved_dir=self.local_storage,
+            name="test_tracker",
+            project_uri="test_project",
+            mode="offline",
+        ) as t:
+            assert t.project_uri.instance == "local"
+            assert t.project_uri.project == "test_project"
+            assert t._syncer_thread is None
+            assert t._handler_thread is not None
+            assert t._handler_thread.sync_queue is None  # type: ignore
+
+    def test_re_start_exception(self) -> None:
+        t1 = Tracker.start(saved_dir=self.local_storage)
+        assert Tracker._instance == t1
+
+        with self.assertRaisesRegex(RuntimeError, "has already been initialized"):
+            Tracker.start(saved_dir=self.local_storage)
+
+        t1.end()
+
+    @patch("os.environ", {})
+    def test_start_for_cloud(self) -> None:
+        with Tracker.start(
+            saved_dir=self.local_storage,
+            project_uri="http://1.1.1.1/project/test",
+            access_token="abcd",
+        ) as t:
+            assert t.project_uri.project == "test"
+
+        with self.assertRaisesRegex(
+            ValueError, "access_token is required for cloud instance"
+        ):
+            Tracker.start(
+                saved_dir=self.local_storage,
+                project_uri="http://0.0.0.0/project/test",
+            )
+
+    def test_start_exceptions(self) -> None:
+        with self.assertRaisesRegex(TypeError, "type is unexpected, only accepts str"):
+            Tracker.start(saved_dir=self.local_storage, project_uri=1)  # type: ignore
+
+    def test_end(self) -> None:
+        assert Tracker._instance is None
+        Tracker.end()
+
+        t = Tracker.start(saved_dir=self.local_storage)
+        assert t._handler_thread and t._handler_thread.is_alive()
+        assert t._collector_thread and t._collector_thread.is_alive()
+        assert Tracker._instance is not None
+        assert isinstance(sys.stdout, StreamWrapper)
+
+        Tracker.end()
+        assert t._handler_thread and not t._handler_thread.is_alive()
+        assert t._collector_thread and not t._collector_thread.is_alive()
+        assert Tracker._instance is None
+        assert isinstance(sys.stdout, io.TextIOWrapper)
+
+        assert t._workdir and (t._workdir / "_manifest.yaml").exists()
+
+        Tracker.end()
+
+    def test_render_manifest(self) -> None:
+        t = Tracker.start(saved_dir=self.local_storage)
+        t.end()
+        assert t._workdir
+        manifest = load_yaml(t._workdir / "_manifest.yaml")
+
+        assert manifest["auto"] == {
+            "console_log_redirect": True,
+            "framework_hook": True,
+            "run_collect": True,
+        }
+        assert manifest["collector_interval"] == {"report": 30.0, "sample": 1.0}
+        assert manifest["mode"] == "online"
+        assert manifest["project_uri"] == "local/project/self"
+
+    def test_log_non_init(self) -> None:
+        msg = "Tracker instance has not been"
+        assert Tracker._instance is None
+
+        with self.assertRaisesRegex(RuntimeError, msg):
+            track.metrics(loss=0.99)
+
+        with self.assertRaisesRegex(RuntimeError, msg):
+            track.params(mode="offline")
+
+        with self.assertRaisesRegex(RuntimeError, msg):
+            track.artifacts(image=Image())
+
+    def test_metrics(self) -> None:
+        code_dir = Path(self.local_storage) / "track"
+        t = track.start(saved_dir=code_dir)
+
+        track.metrics()
+        track.metrics({})
+        track.metrics(loss=0.99, commit=False)
+        track.metrics(loss=0.98, acc=0.1)
+        track.metrics(loss=0.97, acc=0.2)
+        track.metrics({"loss": 0.96, "acc": 0.3})
+        track.metrics({"loss": 0.95, "acc": 0.4}, {"gradient": 0.0})
+        track.metrics(loss=0.94, acc=0.5, step=10)
+        track.metrics({"indict": {"indict": {"loss": 1}}})
+        track.end()
+
+        assert isinstance(t._handler_thread, HandlerThread)
+        records = list(
+            t._handler_thread._data_store.scan_tables([TableDesc("metrics/user")])
+        )
+        assert len(records) == 6
+        assert records[0]["__step"] == 0
+        assert records[1]["__step"] == 1
+        assert records[4]["__step"] == 10
+        assert records[0]["loss"] == 0.98
+        assert records[0]["acc"] == 0.1
+        assert records[4]["loss"] == 0.94
+        assert records[5]["indict/indict/loss"] == 1.0
+
+    def test_metrics_exceptions(self) -> None:
+        track.start(saved_dir=self.local_storage)
+
+        with self.assertRaisesRegex(ValueError, "could not convert string to float"):
+            track.metrics({"test": "test"})
+
+        track.end()
+
+    def test_params(self) -> None:
+        code_dir = Path(self.local_storage) / "track"
+        with track.start(saved_dir=code_dir) as t:
+            track.params()
+            track.params({})
+            track.params(p1=0, p2="2", p3=3.0, p4={"k": "v"}, p5=[1, 2, 3])
+            track.params(p1=1)
+            track.params({"p2": "2.0"})
+        assert isinstance(t._handler_thread, HandlerThread)
+        user_m_path = t._handler_thread._workdir / "params" / "user.json"
+        assert user_m_path.exists()
+        user_m_content = json.loads(user_m_path.read_text())
+        assert user_m_content == {
+            "p1": 1,
+            "p2": "2.0",
+            "p3": 3.0,
+            "p4": {"k": "v"},
+            "p5": [1, 2, 3],
+        }
+        system_m_path = t._handler_thread._workdir / "params" / "_system.json"
+        assert system_m_path.exists()
+
+    def test_params_exceptions(self) -> None:
+        track.start(saved_dir=self.local_storage)
+
+        with self.assertRaisesRegex(TypeError, "keys should be string type"):
+            track.params({1: "test"})  # type: ignore
+
+        with self.assertRaisesRegex(
+            TypeError, "Object of type bytes is not JSON serializable"
+        ):
+            track.params(a=b"test")
+
+        track.end()
+
+    def test_artifacts(self) -> None:
+        code_dir = Path(self.local_storage) / "track"
+        t = track.start(saved_dir=code_dir)
+        t.artifacts()
+        t.artifacts({})
+        t.artifacts(image=Image(b"123"))
+        t.artifacts(image=Image(b"345"), audio=Audio(b"123"))
+        t.artifacts(
+            category={"image": Image(b"567"), "audio": [Audio(b"234"), Audio(b"345")]}
+        )
+        t.end()
+
+        assert isinstance(t._handler_thread, HandlerThread)
+        records = list(
+            t._handler_thread._data_store.scan_tables([TableDesc("artifacts/user")])
+        )
+        assert len(records) == 6
+        assert records[0]["__key"] == "audio-0000"
+        assert records[0]["data"].size == 3
+        assert records[0]["data"].data_type["type"] == "audio"
+        assert records[1]["__key"] == "category/audio/0-0000"
+        assert records[2]["__key"] == "category/audio/1-0000"
+        assert records[3]["__key"] == "category/image-0000"
+        assert records[4]["__key"] == "image-0000"
+        assert records[5]["__key"] == "image-0001"
+        assert records[4]["index"] == 0
+        assert records[5]["index"] == 1
+
+    def test_artifacts_exceptions(self) -> None:
+        t = track.start(saved_dir=self.local_storage)
+        with self.assertRaisesRegex(NoSupportError, "not support for artifacts"):
+            t.artifacts({"a": 1})
+        t.end()
+
+    def test_multi_track(self) -> None:
+        code_dir = Path(self.local_storage) / "track"
+        assert not (code_dir / ".starwhale").exists()
+
+        t1 = track.start(saved_dir=code_dir)
+        track.metrics(loss=0.99)
+        track.params(model="mnist")
+        track.artifacts(image=Image(b"123"))
+        track.end()
+
+        t2 = track.start(saved_dir=code_dir)
+        track.metrics(loss=0.98)
+        track.params(model="nn")
+        track.artifacts(image=Image(b"234"))
+        track.end()
+
+        assert t1 != t2
+        track_dirs = list((code_dir / ".starwhale" / "track").iterdir())
+        assert len(track_dirs) == 2
+        assert {"0", "1"} == {n.name.split("-")[0] for n in track_dirs}
+
+        ensure_file(code_dir / ".starwhale" / "track" / "tmp", content="test")
+        ensure_dir(code_dir / ".starwhale" / "track" / "test")
+
+        track.start(saved_dir=code_dir)
+        track.metrics(loss=0.98)
+        track.params(model="nn")
+        track.artifacts(image=Image(b"234"))
+        track.end()
+
+
+class TestHandler(BaseTestCase):
+    def test_handle_metrics(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        h = HandlerThread(workdir, queue.Queue())
+        h._handle_metrics(
+            MetricsRecord(
+                data={"loss": 0.98},
+                step=1,
+            )
+        )
+
+        h._handle_metrics(
+            MetricsRecord(
+                data={"loss": 0.99, "acc": 0.99},
+                step=2,
+            )
+        )
+
+        assert "metrics/user" in h._table_writers
+        assert isinstance(h._table_writers["metrics/user"], TableWriter)
+
+        h.flush()
+        parquet_path = workdir / "metrics" / "user" / "base-0.parquet"
+        assert parquet_path.exists()
+        assert parquet_path.is_file()
+
+        records = list(h._data_store.scan_tables([TableDesc("metrics/user")]))
+        assert len(records) == 2
+        assert records[0]["__step"] == 1
+        assert records[1]["__step"] == 2
+        assert records[0]["loss"] == 0.98
+        assert "acc" not in records[0]
+        assert records[1]["loss"] == 0.99
+        assert records[1]["acc"] == 0.99
+
+        assert records[0]["__relative_time"] > 0
+        assert records[0]["__clock_time"] != ""
+
+    def test_handle_params(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        h = HandlerThread(workdir, queue.Queue())
+        assert len(h._params) == 0
+        h._handle_params(ParamsRecord(data={"tag": ["test"], "model": "mnist"}))
+        h._handle_params(
+            ParamsRecord(data={"version": "0.1"}, source=_TrackSource.SYSTEM)
+        )
+        assert "user" in h._params
+        assert "_system" in h._params
+
+        h.flush()
+        user_params_path = workdir / "params" / "user.json"
+        system_params_path = workdir / "params" / "_system.json"
+        framework_params_path = workdir / "params" / "_framework.json"
+
+        assert user_params_path.exists()
+        assert system_params_path.exists()
+        assert not framework_params_path.exists()
+
+        user_params = json.loads(user_params_path.read_text())
+        system_params = json.loads(system_params_path.read_text())
+        assert user_params == {"tag": ["test"], "model": "mnist"}
+        assert system_params == {"version": "0.1"}
+
+    def test_handle_artifacts(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        h = HandlerThread(workdir, queue.Queue())
+        h._handle_artifacts(
+            ArtifactsRecord(data={"image": Image(fp=b"123"), "audio": Audio(fp=b"345")})
+        )
+        h._handle_artifacts(ArtifactsRecord(data={"image": Image(fp=b"000")}))
+
+        assert "artifacts/user" in h._table_writers
+        assert isinstance(h._table_writers["artifacts/user"], TableWriter)
+        assert h._artifacts_counter["image"] == 2
+        assert h._artifacts_counter["audio"] == 1
+
+        h.flush()
+
+        parquet_path = workdir / "artifacts" / "user" / "base-0.parquet"
+        assert parquet_path.exists()
+        assert parquet_path.is_file()
+
+        files_dir = workdir / "artifacts" / "_files"
+        assert files_dir.exists()
+        records = list(h._data_store.scan_tables([TableDesc("artifacts/user")]))
+        assert len(records) == 3
+        assert records[0]["__key"] == "audio-0000"
+        assert records[1]["__key"] == "image-0000"
+        assert records[2]["__key"] == "image-0001"
+        assert records[0]["__link_wrapper"]
+        assert records[0]["name"] == "audio"
+        assert records[0]["index"] == 0
+
+        audio_link = records[0]["data"]
+        assert isinstance(audio_link, Link)
+        assert audio_link.data_type["type"] == "audio"  # type: ignore
+        uri_path = Path(audio_link.uri)
+        assert uri_path.exists() and uri_path.is_file()
+        assert uri_path.read_bytes() == b"345"
+
+        assert Path(records[1]["data"].uri).read_bytes() == b"123"
+        assert Path(records[2]["data"].uri).read_bytes() == b"000"
+
+    def test_run(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        handle_queue = queue.Queue()
+
+        handle_queue.put(ParamsRecord(data={"params": 1}))
+        handle_queue.put(
+            ParamsRecord(data={"cpu_cores": 1}, source=_TrackSource.SYSTEM)
+        )
+        handle_queue.put(ParamsRecord(data={}, source=_TrackSource.FRAMEWORK))
+        handle_queue.put(MetricsRecord(data={"metrics": 0.99}, step=0))
+        handle_queue.put(MetricsRecord(data={"metrics": 0.98}, step=1))
+        handle_queue.put(
+            MetricsRecord(data={"cpu_freq": 0.98}, step=0, source=_TrackSource.SYSTEM)
+        )
+        handle_queue.put(None)
+        handle_queue.put(ArtifactsRecord(data={"image": Image(fp=b"123")}))
+
+        h = HandlerThread(workdir, handle_queue)
+        h.start()
+        h.close()
+
+        assert handle_queue.qsize() == 0
+        assert "metrics/user" in h._table_writers
+        assert "metrics/_system" in h._table_writers
+        assert "artifacts/user" in h._table_writers
+
+        assert (workdir / "metrics" / "user" / "base-0.parquet").exists()
+        assert (workdir / "metrics" / "_system" / "base-0.parquet").exists()
+        assert (workdir / "artifacts" / "_files").exists()
+        assert len(list((workdir / "artifacts" / "_files").iterdir())) != 0
+        assert (workdir / "params" / "user.json").exists()
+        assert (workdir / "params" / "_system.json").exists()
+        assert not (workdir / "params" / "_framework.json").exists()
+
+    def test_close(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        handle_queue = queue.Queue()
+
+        handle_queue.put(MetricsRecord(data={"metrics": 0.99}, step=0))
+        h = HandlerThread(workdir, handle_queue)
+        assert not h.is_alive()
+        h.start()
+        assert h.is_alive()
+        h.close()
+        assert not h.is_alive()
+        assert handle_queue.qsize() == 0
+
+        assert h._table_writers["metrics/user"]._stopped
+
+        h.close()
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_raise_exception(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        handle_queue = queue.Queue()
+
+        handle_queue.put(TrackRecord(typ=_TrackType.METRICS, source=_TrackSource.USER))
+        h = HandlerThread(workdir, handle_queue)
+        h.start()
+
+        with self.assertRaisesRegex(
+            threading.ThreadError, "no support to handle TrackRecord"
+        ):
+            h.close()
+
+
+class TestCollector(BaseTestCase):
+    def test_init_exceptions(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+
+        with self.assertRaisesRegex(NotFoundError, "Collector workdir"):
+            CollectorThread(tracker=MagicMock(), workdir=workdir)
+
+        ensure_dir(workdir)
+        with self.assertRaisesRegex(ValueError, "sample interval seconds"):
+            CollectorThread(tracker=MagicMock(), workdir=workdir, sample_interval=0)
+
+        with self.assertRaisesRegex(ValueError, "sample interval seconds"):
+            CollectorThread(
+                tracker=MagicMock(),
+                workdir=workdir,
+                sample_interval=100,
+                report_interval=300,
+            )
+
+        with self.assertRaisesRegex(ValueError, "should be less than report interval"):
+            CollectorThread(
+                tracker=MagicMock(),
+                workdir=workdir,
+                sample_interval=10,
+                report_interval=1,
+            )
+
+        with self.assertRaisesRegex(ValueError, "report interval seconds"):
+            CollectorThread(
+                tracker=MagicMock(),
+                workdir=workdir,
+                sample_interval=1,
+                report_interval=500,
+            )
+
+    def test_inspect_code_without_git(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        ensure_dir(workdir)
+        ret = CollectorThread(
+            tracker=MagicMock(),
+            workdir=workdir,
+        )._inspect_code()
+
+        assert ret == {"code": {"git": {}, "workdir": str(workdir)}}
+
+    def test_inspect_code_with_git(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        ensure_dir(workdir)
+        ensure_file(workdir / "code.file", content="test")
+        commands = [
+            "git init -b main",
+            "git add code.file",
+            'git commit -m "test"',
+            "git remote add origin http://remote.git",
+        ]
+
+        [check_call(cmd, shell=True, cwd=str(workdir)) for cmd in commands]
+
+        ret = CollectorThread(
+            tracker=MagicMock(),
+            workdir=workdir,
+        )._inspect_code()
+
+        code_info = ret["code"]
+        git_info = code_info["git"]
+        assert code_info["workdir"] == str(workdir)
+        assert git_info["commit_sha"] != ""
+        assert git_info["message"] == "test\n"
+        assert not git_info["is_dirty"]
+        assert git_info["branch"] == "main"
+        assert git_info["remote_urls"] == ["http://remote.git"]
+
+    def test_inspect_python_run(self) -> None:
+        ret = CollectorThread(
+            tracker=MagicMock(),
+            workdir=Path(self.local_storage),
+        )._inspect_python_run()
+        assert ret["python"]["version"].startswith("3.")
+        assert "python" in ret["python"]["bin_path"]
+        assert ret["python"]["env_mode"] in ("conda", "venv", "system")
+
+    def test_inspect_system_specs(self) -> None:
+        ret = CollectorThread(
+            tracker=MagicMock(),
+            workdir=Path(self.local_storage),
+        )._inspect_system_specs()
+        assert ret["system"]["hostname"] != ""
+        assert ret["hardware"]["cpu"]["cores"] > 0
+        assert (
+            ret["hardware"]["cpu"]["cores_logical"] >= ret["hardware"]["cpu"]["cores"]
+        )
+        assert ret["hardware"]["memory"]["total_bytes"] > 0
+        assert (
+            ret["hardware"]["disk"]["total_bytes"]
+            > ret["hardware"]["disk"]["used_bytes"]
+            > 0
+        )
+
+    def test_inspect_process_specs(self) -> None:
+        ret = CollectorThread(
+            tracker=MagicMock(),
+            workdir=Path(self.local_storage),
+        )._inspect_process_specs()
+        assert ret["process"]["pid"] != 0
+        assert ret["process"]["cwd"] != ""
+        cmdline = ret["process"]["cmdline"]
+        assert isinstance(cmdline, str)
+        assert "pytest" in cmdline or "python" in cmdline
+
+    def test_inspect_environments(self) -> None:
+        ret = CollectorThread(
+            tracker=MagicMock(),
+            workdir=Path(self.local_storage),
+        )._inspect_environments()
+        assert "PATH" in ret["environments"]
+        assert "SW_VERSION" in ret["environments"]
+
+    def test_inspect_metrics(self) -> None:
+        ret = CollectorThread(
+            tracker=MagicMock(),
+            workdir=Path(self.local_storage),
+        )._inspect_metrics()
+        assert ret["system"]["cpu"]["usage_percent"] >= 0
+        assert ret["process"]["cpu"]["usage_percent"] >= 0
+        assert ret["process"]["num_threads"] >= 1
+
+    def test_run(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        ensure_dir(workdir)
+
+        sample_interval = 0.1
+        report_interval = 0.5
+
+        mock_tracker = MagicMock()
+        c = CollectorThread(
+            tracker=mock_tracker,
+            workdir=workdir,
+            sample_interval=sample_interval,
+            report_interval=report_interval,
+        )
+        c.start()
+        time.sleep(1.5)
+        c.close()
+
+        assert mock_tracker._log_params.call_count == 5
+        log_p_call = mock_tracker._log_params.call_args_list
+        assert log_p_call[0][1]["source"] == _TrackSource.SYSTEM
+        subjects = {k for args in log_p_call for k in args[0][0]}
+        assert subjects == {
+            "code",
+            "python",
+            "system",
+            "hardware",
+            "process",
+            "environments",
+        }
+
+        assert mock_tracker._log_metrics.call_count == c._metrics_step
+        assert c._metrics_step >= 1
+
+        log_m_call = mock_tracker._log_metrics.call_args_list[0][1]
+        assert set(log_m_call["data"].keys()) == {
+            "system/cpu/usage_percent/last",
+            "system/cpu/usage_percent/avg",
+            "process/cpu/usage_percent/last",
+            "process/cpu/usage_percent/avg",
+            "process/num_threads/last",
+            "process/num_threads/avg",
+        }
+
+        for v in log_m_call["data"].values():
+            assert isinstance(v, float)
+
+        assert log_m_call["step"] == 0
+        assert log_m_call["commit"]
+        assert log_m_call["source"] == _TrackSource.SYSTEM
+        assert len(c._staging_metrics) == 0
+
+        assert (
+            c._metrics_inspect_cnt / (sample_interval / report_interval)
+            >= c._metrics_step
+        )
+
+    def test_close(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        ensure_dir(workdir)
+        c = CollectorThread(
+            tracker=MagicMock(),
+            workdir=workdir,
+            sample_interval=0.1,
+            report_interval=0.2,
+        )
+        assert c._stopped
+        assert not c._stop_event.is_set()
+        c.start()
+        assert not c._stopped
+        assert c.is_alive()
+        time.sleep(0.2)
+        c.close()
+
+        assert c._stopped
+        assert not c.is_alive()
+        assert c._stop_event.is_set()
+
+        c.close()
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_raise_exceptions(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        ensure_dir(workdir)
+
+        mock_tracker = MagicMock()
+        mock_tracker._log_params.side_effect = RuntimeError("mock log params exception")
+        mock_tracker._log_metrics.side_effect = RuntimeError(
+            "mock log metrics exception"
+        )
+
+        c = CollectorThread(
+            tracker=mock_tracker,
+            workdir=workdir,
+            sample_interval=0.1,
+            report_interval=0.1,
+            run_exceptions_limits=1,
+        )
+        c.start()
+
+        cnt = 0
+        while not c._run_exceptions and cnt < 10:
+            time.sleep(0.5)
+            cnt += 1
+
+        with self.assertRaisesRegex(threading.ThreadError, "run raise"):
+            c.close()
+        assert len(c._run_exceptions) != 0
+
+    def test_report_metrics(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        ensure_dir(workdir)
+
+        mock_tracker = MagicMock()
+
+        c = CollectorThread(
+            tracker=mock_tracker,
+            workdir=workdir,
+        )
+        c._staging_metrics = {}
+        c._report_metrics()
+        assert mock_tracker._log_metrics.call_count == 0
+        assert c._metrics_step == 0
+
+        c._staging_metrics = {
+            "cpu": [1, 2, 3],
+            "mem": [1, 2, 3],
+            "none": [],
+        }
+        c._report_metrics()
+        assert mock_tracker._log_metrics.call_count == 1
+        assert c._metrics_step == 1
+        assert mock_tracker._log_metrics.call_args[1]["data"] == {
+            "cpu/last": 3.0,
+            "cpu/avg": 2.0,
+            "mem/last": 3.0,
+            "mem/avg": 2.0,
+        }
+
+
+class TestHooker(BaseTestCase):
+    def test_install(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        h = ConsoleLogHook(log_dir=workdir, track_id="track_id_test")
+        _stdout = sys.stdout
+        _stderr = sys.stderr
+        assert isinstance(_stdout, io.TextIOWrapper)
+        assert isinstance(_stderr, io.TextIOWrapper)
+        assert not h._stderr_changed
+        assert not h._stdout_changed
+        h.install()
+        assert isinstance(h._log_handler_id, int)
+        assert h._logger is not None
+
+        assert isinstance(sys.stdout, StreamWrapper)
+        assert isinstance(sys.stderr, StreamWrapper)
+        assert sys.stdout != _stdout
+        assert sys.stderr != _stderr
+        assert h._original_stdout == _stdout
+        assert h._original_stderr == _stderr
+        assert h._stderr_changed
+        assert h._stdout_changed
+
+        print("stdout test", file=sys.stdout)
+        print("stderr test", file=sys.stderr)
+
+        logs_path = [f for f in workdir.iterdir() if f.name.startswith("console-")]
+        assert len(logs_path) == 1
+        log_content = logs_path[0].read_text()
+        assert "stdout test" in log_content
+        assert "stderr test" in log_content
+        assert "track_id_test" in log_content
+
+        h.uninstall()
+
+    def test_uninstall(self) -> None:
+        workdir = Path(self.local_storage) / "track"
+        h = ConsoleLogHook(log_dir=workdir, track_id="track_id_test")
+        h.uninstall()
+
+        h.install()
+
+        assert not isinstance(sys.stderr, io.TextIOWrapper)
+        assert not isinstance(sys.stdout, io.TextIOWrapper)
+
+        h.uninstall()
+        assert not h._stdout_changed
+        assert not h._stderr_changed
+        assert h._original_stdout is None
+        assert h._original_stderr is None
+        assert isinstance(sys.stdout, io.TextIOWrapper)
+        assert isinstance(sys.stderr, io.TextIOWrapper)
+
+        h.uninstall()

--- a/client/tests/utils/test_dict.py
+++ b/client/tests/utils/test_dict.py
@@ -1,0 +1,26 @@
+import unittest
+
+from starwhale.utils.dict import flatten
+
+
+class TestDict(unittest.TestCase):
+    def test_flatten(self) -> None:
+        cases = [
+            ({"a": 1}, {"a": 1}, {"a": 1}),
+            ({"a": {"b": 1, "c": 2}}, {"a/b": 1, "a/c": 2}, {"a/b": 1, "a/c": 2}),
+            (
+                {"a": {"b": 1, "c": 2, "d": [1, 2, 3]}},
+                {"a/b": 1, "a/c": 2, "a/d/0": 1, "a/d/1": 2, "a/d/2": 3},
+                {"a/b": 1, "a/c": 2, "a/d": [1, 2, 3]},
+            ),
+            ({"a": {"b": {"c": {"d": 1}}}}, {"a/b/c/d": 1}, {"a/b/c/d": 1}),
+            (
+                {"a": [1, {"b": 1}, 2]},
+                {"a/0": 1, "a/b": 1, "a/2": 2},
+                {"a": [1, {"b": 1}, 2]},
+            ),
+        ]
+
+        for in_data, seq_out_data, out_data in cases:
+            assert flatten(in_data, extract_sequence=True) == seq_out_data
+            assert flatten(in_data) == out_data


### PR DESCRIPTION
## Description
- basic track SDK code skeleton:
   - only supports five core functions: `track.start, track.end, track.metrics, track.artifacts, track.params`.
   - only store results in local storage.
- mnist example:
  - [![asciicast](https://asciinema.org/a/555472.svg)](https://asciinema.org/a/555472)

## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
