### PR TITLE
chore(client): make sure model.yaml exists when use custom config file

### DIFF
--- a/client/starwhale/base/bundle.py
+++ b/client/starwhale/base/bundle.py
@@ -133,7 +133,6 @@ class BaseBundle(metaclass=ABCMeta):
         raise NotImplementedError
 
     def build(self, *args: t.Any, **kwargs: t.Any) -> None:
-        # TODO: remove yaml_name in build function
         self.store.building = True  # type: ignore
 
         # use a temp dir to build resources

--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -689,6 +689,12 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
         for _fname in _mc.config:
             copy_file(workdir_fs, _fname, snapshot_src_fs, _fname)
 
+        # rename model config if not default to make sure model.yaml exists
+        # prevent using the wrong config when running in the cloud
+        if yaml_name != DefaultYAMLName.MODEL:
+            d = self.store.src_dir
+            os.rename(d / yaml_name, d / DefaultYAMLName.MODEL)
+
         # TODO link models to unified storage
         for _fname in _mc.model:
             copy_file(workdir_fs, _fname, snapshot_src_fs, _fname)


### PR DESCRIPTION
## Description

We do not specify the config file name when tasks run in the cluster
- The task run will fail if users do not provide the `model.yaml` config file
- The task will use the wrong config file when users use the custom file and the `model.yaml` exists

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
