### PR TITLE
fix(client): datastore loss data on multithread

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -1085,6 +1085,7 @@ class LocalDataStore:
         self.root_path = root_path
         self.name_pattern = re.compile(r"^[A-Za-z0-9-_/: ]+$")
         self.tables: Dict[str, MemoryTable] = {}
+        self.lock = threading.Lock()
 
     def update_table(
         self,
@@ -1102,16 +1103,7 @@ class LocalDataStore:
                     raise RuntimeError(
                         f"invalid column name {k}, only letters(A-Z, a-z), digits(0-9), hyphen('-'), and underscore('_') are allowed"
                     )
-        table = self.tables.get(table_name, None)
-        if table is None:
-            table_path = _get_table_path(self.root_path, table_name)
-            if _get_table_files(table_path):
-                table_schema = _read_table_schema(table_path)
-                table_schema.merge(schema)
-            else:
-                table_schema = schema
-            table = MemoryTable(table_name, table_schema)
-            self.tables[table_name] = table
+        table = self._get_table(table_name, schema)
         if schema.key_column != table.schema.key_column:
             raise RuntimeError(
                 f"invalid key column, expected {table.schema.key_column}, actual {schema.key_column}"
@@ -1127,6 +1119,20 @@ class LocalDataStore:
                 table.delete([key])
             else:
                 table.insert(r)
+
+    def _get_table(self, table_name: str, schema: TableSchema) -> MemoryTable:
+        with self.lock:
+            table = self.tables.get(table_name, None)
+            if table is None:
+                table_path = _get_table_path(self.root_path, table_name)
+                if _get_table_files(table_path):
+                    table_schema = _read_table_schema(table_path)
+                    table_schema.merge(schema)
+                else:
+                    table_schema = schema
+                table = MemoryTable(table_name, table_schema)
+                self.tables[table_name] = table
+        return table
 
     def scan_tables(
         self,


### PR DESCRIPTION
## Description
fix #1706 
there will have multi writers on multithreading, so it will lead to race when these writers update the same table. one case is that they all create a table, but only the last would be recorded to the singleton datastore, and then would loss some data which are belongs to the previous table obj.

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
