### PR TITLE
feat(controller): online eval support resource params

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/JobController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/JobController.java
@@ -201,7 +201,8 @@ public class JobController implements JobApi {
                 projectUrl,
                 request.getModelVersionUrl(),
                 request.getRuntimeVersionUrl(),
-                request.getResourcePool()
+                request.getResourcePool(),
+                request.getSpec()
         );
 
         return ResponseEntity.ok(Code.success.asResponse(resp));

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/ModelServingRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/ModelServingRequest.java
@@ -39,4 +39,7 @@ public class ModelServingRequest implements Serializable {
     @Deprecated
     @JsonProperty("ttlInSeconds")
     private long ttlInSeconds;
+
+    @JsonProperty("spec")
+    private String spec;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapper.java
@@ -42,16 +42,13 @@ public interface ModelServingMapper {
             "runtime_version_id",
             "resource_pool",
             "last_visit_time",
+            "spec",
     };
     String TABLE = "model_serving_info";
 
     @InsertProvider(value = SqlProviderAdapter.class, method = "insert")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void add(ModelServingEntity entity);
-
-    @InsertProvider(value = SqlProviderAdapter.class, method = "insertIgnore")
-    @Options(useGeneratedKeys = true, keyProperty = "id")
-    void insertIgnore(ModelServingEntity entity);
 
     @Select("select * from " + TABLE + " where id=#{id}")
     ModelServingEntity find(long id);
@@ -79,14 +76,6 @@ public interface ModelServingMapper {
                     INTO_VALUES(values);
                 }
             }.toString();
-        }
-
-        public String insertIgnore() {
-            var values = Arrays.stream(COLUMNS)
-                    .map(i -> "#{" + CaseUtils.toCamelCase(i, false, '_') + "}")
-                    .toArray(String[]::new);
-            return String.format("insert ignore into %s(%s) values (%s)",
-                    TABLE, String.join(", ", COLUMNS), String.join(", ", values));
         }
 
         public String listByConditions(

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/ModelServingEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/ModelServingEntity.java
@@ -41,5 +41,6 @@ public class ModelServingEntity extends BaseEntity {
     private Long runtimeVersionId;
     private Integer isDeleted;
     private String resourcePool;
+    private String spec;
     private Date lastVisitTime;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/spec/ModelServingSpec.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/spec/ModelServingSpec.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.job.spec;
+
+import ai.starwhale.mlops.domain.runtime.RuntimeResource;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.util.Comparator;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ModelServingSpec {
+    private List<RuntimeResource> resources;
+
+    public static ModelServingSpec fromYamlString(String content) throws JsonProcessingException {
+        var yamlMapper = new YAMLMapper();
+        ModelServingSpec obj =  yamlMapper.readValue(content, new TypeReference<>() {
+        });
+
+        // sort by type, order resource list
+        obj.resources.sort(Comparator.comparing(RuntimeResource::getType));
+        return obj;
+    }
+
+    public String dumps() throws JsonProcessingException {
+        return new YAMLMapper().writeValueAsString(this);
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/exception/SwValidationException.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/exception/SwValidationException.java
@@ -73,7 +73,8 @@ public class SwValidationException extends StarwhaleException {
         SETTING("011", "System Setting"),
         TRASH("012", "TRASH"),
         OBJECT_STORE("013", "Object Store"),
-        PLUGIN("014", "Plugin");
+        PLUGIN("014", "Plugin"),
+        ONLINE_EVAL("015", "Online Eval");
         final String code;
         final String tipSubject;
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
@@ -115,7 +115,12 @@ public class K8sJobTemplate {
         return job;
     }
 
-    public V1StatefulSet renderModelServingOrch(Map<String, String> envs, String image, String name) {
+    public V1StatefulSet renderModelServingOrch(
+            String name,
+            String image,
+            Map<String, String> envs,
+            ResourceOverwriteSpec resource
+    ) {
         var ss = Yaml.loadAs(this.modelServingJobTemplate, V1StatefulSet.class);
         Objects.requireNonNull(ss.getMetadata());
 
@@ -143,6 +148,7 @@ public class K8sJobTemplate {
         // add readiness probe
         var readiness = new V1Probe();
         cos.setReadinessProbe(readiness);
+        cos.setResourceOverwriteSpec(resource);
         readiness.failureThreshold(3);
         var httpGet = new V1HTTPGetAction();
         readiness.httpGet(httpGet);

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/ResourceOverwriteSpec.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/ResourceOverwriteSpec.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Getter
+@EqualsAndHashCode
 public class ResourceOverwriteSpec {
 
     V1ResourceRequirements resourceSelector;

--- a/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_009__add_spec.sql
+++ b/server/controller/src/main/resources/db/migration/v0_3_2/V0_3_2_009__add_spec.sql
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# add spec column for model serving and make it member of unique index
+ALTER TABLE `model_serving_info`
+    ADD spec TEXT NULL;
+
+DROP INDEX `model_serving_info_uniq` on `model_serving_info`;
+
+CREATE INDEX `model_serving_info_index`
+    ON `model_serving_info` (project_id, model_version_id, runtime_version_id, resource_pool);

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/JobControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/JobControllerTest.java
@@ -226,7 +226,7 @@ public class JobControllerTest {
     @Test
     public void testCreateModelServing() {
         var vo = ModelServingVo.builder().id("8").baseUri("/gateway/model-serving/8").build();
-        given(modelServingService.create("foo", "bar", "baz", "default")).willReturn(vo);
+        given(modelServingService.create("foo", "bar", "baz", "default", null)).willReturn(vo);
         var req = new ModelServingRequest();
         req.setModelVersionUrl("bar");
         req.setRuntimeVersionUrl("baz");

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/mapper/ModelServingMapperTest.java
@@ -47,17 +47,10 @@ public class ModelServingMapperTest extends MySqlContainerHolder {
                 .jobStatus(JobStatus.RUNNING)
                 .lastVisitTime(new Date(System.currentTimeMillis() / 1000 * 1000))
                 .build();
-        modelServingMapper.insertIgnore(entity);
+        modelServingMapper.add(entity);
         var id = entity.getId();
         var result = modelServingMapper.find(id);
         Assertions.assertEquals(entity, result);
-
-        entity.setId(null);
-        // insert if not exists (ignore)
-        modelServingMapper.insertIgnore(entity);
-        // no insertion
-        Assertions.assertNull(entity.getId());
-        entity.setId(id);
 
         var another = ModelServingEntity.builder()
                 .modelVersionId(2L)

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/spec/ModelServingSpecTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/spec/ModelServingSpecTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.job.spec;
+
+import ai.starwhale.mlops.domain.runtime.RuntimeResource;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ModelServingSpecTest {
+    private static final String ONE_RC_CONTENT = "---\n"
+            + "resources:\n"
+            + "- type: \"a\"\n"
+            + "  request: 7.0\n"
+            + "  limit: 8.0\n";
+
+    private static final String MULTIPLE_RC_CONTENT = "---\n"
+            + "resources:\n"
+            + "- type: \"b\"\n"
+            + "  request: 9.0\n"
+            + "  limit: 10.0\n"
+            + "- type: \"a\"\n"
+            + "  request: 7.0\n"
+            + "  limit: 8.0\n";
+
+    @Test
+    public void testParseAndDumps() throws JsonProcessingException {
+        var spec = ModelServingSpec.fromYamlString(ONE_RC_CONTENT);
+        var rc = RuntimeResource.builder()
+                .type("a")
+                .request(7f)
+                .limit(8f)
+                .build();
+        Assertions.assertEquals(ModelServingSpec.builder().resources(List.of(rc)).build(), spec);
+        Assertions.assertEquals(spec.dumps(), ONE_RC_CONTENT);
+
+        spec = ModelServingSpec.fromYamlString(MULTIPLE_RC_CONTENT);
+        var rc2 = RuntimeResource.builder()
+                .type("b")
+                .request(9f)
+                .limit(10f)
+                .build();
+        Assertions.assertEquals(List.of(rc, rc2), spec.getResources());
+
+        var rcWithNatureOrder = "---\n"
+                + "resources:\n"
+                + "- type: \"a\"\n"
+                + "  request: 7.0\n"
+                + "  limit: 8.0\n"
+                + "- type: \"b\"\n"
+                + "  request: 9.0\n"
+                + "  limit: 10.0\n";
+        Assertions.assertEquals(spec.dumps(), rcWithNatureOrder);
+    }
+}


### PR DESCRIPTION
## Description

Add spec field for the `create serving` api
http://jialei.pre.intra.starwhale.ai/swagger-ui/index.html#/Job/createModelServing
 
spec string demo

```
resources:
- type: CPU
  request: 7
  limit: 8
```

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
