### PR TITLE
fix(datastore): fix end_inclusive error when only one row in parquet file

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -714,7 +714,8 @@ def _scan_parquet_file(
 
     for i in range(f.num_row_groups):
         stats = f.metadata.row_group(i).column(key_index).statistics
-        if (end is not None and stats.min >= end) or (
+        _end_check: Callable = lambda x, y: x > y if end_inclusive else x >= y
+        if (end is not None and _end_check(stats.min, end)) or (
             start is not None and stats.max < start
         ):
             continue
@@ -725,7 +726,6 @@ def _scan_parquet_file(
         n_cols = len(names)
         for j in range(n_rows):
             key = types[0].deserialize(table[0][j].as_py())
-            _end_check: Callable = lambda x, y: x > y if end_inclusive else x >= y
             if (start is not None and key < start) or (
                 end is not None and _end_check(key, end)
             ):

--- a/client/tests/sdk/test_data_store.py
+++ b/client/tests/sdk/test_data_store.py
@@ -171,6 +171,49 @@ class TestBasicFunctions(BaseTestCase):
             "keep none",
         )
 
+    def test_only_one_end_inclusive(self) -> None:
+        path = os.path.join(self.datastore_root, "base-10.parquet")
+        data_store._write_parquet_file(
+            path,
+            pa.Table.from_pydict(
+                {
+                    "a": [0],
+                    "b": ["x"],
+                    "c": [10],
+                    "-": [None],
+                    "~c": [False],
+                },
+                metadata={
+                    "schema": str(
+                        data_store.TableSchema(
+                            "a",
+                            [
+                                data_store.ColumnSchema("a", data_store.INT64),
+                                data_store.ColumnSchema("b", data_store.STRING),
+                                data_store.ColumnSchema("c", data_store.INT64),
+                                data_store.ColumnSchema("-", data_store.BOOL),
+                                data_store.ColumnSchema("~c", data_store.BOOL),
+                            ],
+                        )
+                    )
+                },
+            ),
+        )
+        self.assertEqual(
+            1,
+            len(
+                list(
+                    data_store._scan_parquet_file(
+                        path,
+                        start=0,
+                        end=0,
+                        end_inclusive=True,
+                    )
+                )
+            ),
+            "end inclusive and end is max",
+        )
+
     def test_merge_scan(self) -> None:
         self.assertEqual([], list(data_store._merge_scan([], False)), "no iter")
         self.assertEqual(


### PR DESCRIPTION
## Description
dataset info returns none when retriving from parquet file.
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
