### PR TITLE
fix(client): fix pip cache dir

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -9,7 +9,7 @@ fi
 ulimit -n 65535 || true
 
 CONDA_BIN="/opt/miniconda3/bin"
-PIP_CACHE_DIR=${SW_PIP_CACHE_DIR:=/"${SW_USER:-'root'}"/.cache/pip}
+PIP_CACHE_DIR=${SW_PIP_CACHE_DIR:=/"${SW_USER:-root}"/.cache/pip}
 VERBOSE="-vvvv"
 STEP=${SW_TASK_STEP:-""}
 TASK_INDEX=${SW_TASK_INDEX:-0}
@@ -111,7 +111,7 @@ welcome() {
     echo "Run: $1 "
     echo "Model Version: ${SW_MODEL_VERSION}"
     echo "Runtime Version: ${SW_RUNTIME_VERSION}"
-    echo "Local User: ${SW_USER:-'root'}"
+    echo "Local User: ${SW_USER:-root}"
     echo "===================================="
     if [ ! -z "${SW_USER}" ];
     then


### PR DESCRIPTION
## Description

The problem:

```bash
/path/to/venv/pip config get global.cache-dir
/'root'/.cache/pip
```

The single quote `'` makes:
- /'root'/ dir created
- double cache space usage when installing starwhale (if the global starwhale needs to reinstall)
- cache can not be reused between pods


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
