### PR TITLE
fix(client): fix js compatible with multi args in online eval

### DIFF
--- a/client/starwhale/api/_impl/service.py
+++ b/client/starwhale/api/_impl/service.py
@@ -67,9 +67,7 @@ class Service:
     def _render_api(self, _api: Api, hijack_submit: bool) -> None:
         js_func: t.Optional[str] = None
         if hijack_submit:
-            js_func = (
-                "async(x) => { typeof wait === 'function' && await wait(); return x; }"
-            )
+            js_func = "async(...x) => { typeof wait === 'function' && await wait(); return x; }"
         with gradio.Row():
             with gradio.Column():
                 for i in _api.input:


### PR DESCRIPTION
## Description

#### The problem:
![image](https://user-images.githubusercontent.com/3217223/215255502-36249443-f479-4019-93ab-8056a14078b4.png)

#### The reason:

gradio will make sure the return value is a list

```js
dependencies.forEach((d) => {
if (d.js) {
	try {
		d.frontend_fn = new AsyncFunction(
			"__fn_args",
			`let result = await (${d.js})(...__fn_args);
			return ${d.outputs.length} === 1 ? [result] : result;`
		);
	} catch (e) {
		console.error("Could not parse custom js method.");
		console.error(e);
	}
}
});
```

ref: https://github.com/gradio-app/gradio/blob/v3.15.0/ui/packages/app/src/Blocks.svelte#L67

gradio expands the `payload.data.concat(output_data)` as fn_args

So, when there is only one output, nothing wrong, and when there are multiple outputs, we return the wrong response.

```js
if (frontend_fn !== undefined) {
	payload.data = await frontend_fn(payload.data.concat(output_data));
}
```
ref: https://github.com/gradio-app/gradio/blob/v3.15.0/ui/packages/app/src/api.ts#L102

gradio docs:
https://www.gradio.app/custom-CSS-and-JS/

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
