### PR TITLE
chore(client): tune gradio import to slove slow import issue

### DIFF
--- a/client/starwhale/api/_impl/service.py
+++ b/client/starwhale/api/_impl/service.py
@@ -2,13 +2,14 @@ import typing as t
 import functools
 from dataclasses import dataclass
 
-import gradio
-from gradio.components import Component
-
 from starwhale.utils import in_production
 
-Input = t.Union[Component, t.List[Component]]
-Output = t.Union[Component, t.List[Component]]
+if t.TYPE_CHECKING:
+    from gradio import Blocks
+    from gradio.components import Component
+
+Input = t.Union["Component", t.List["Component"]]
+Output = t.Union["Component", t.List["Component"]]
 Examples = t.Union[t.List[t.Any], str]
 
 
@@ -78,6 +79,8 @@ class Service:
         return server.app.openapi()
 
     def _render_api(self, _api: Api, hijack_submit: bool) -> None:
+        import gradio
+
         js_func: t.Optional[str] = None
         if hijack_submit:
             js_func = "async(...x) => { typeof wait === 'function' && await wait(); return x; }"
@@ -106,7 +109,9 @@ class Service:
 
     def _gen_gradio_server(
         self, hijack_submit: bool, title: t.Optional[str] = None
-    ) -> gradio.Blocks:
+    ) -> "Blocks":
+        import gradio
+
         apis = self.apis.values()
         with gradio.Blocks() as app:
             with gradio.Tabs():

--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import Future
 
 from cmds.eval_cmd import Evaluation
+from cmds.base.invoke import invoke
 from cmds.project_cmd import Project
 from cmds.instance_cmd import Instance
 from cmds.artifacts_cmd import Model, Dataset, Runtime
@@ -363,6 +364,17 @@ class TestCli:
             workdir_ = expl["workdir"]
             self.build_model(str(workdir_))
 
+    def smoke_commands(self) -> None:
+        commands = [
+            "timeout 2 swcli --help",
+            "swcli --version",
+        ]
+
+        for cmd in commands:
+            _code, _err = invoke(cmd.split())
+            if _code != 0:
+                raise RuntimeError(f"cmd[{cmd}] run failed, err: {_err}, code: {_code}")
+
 
 if __name__ == "__main__":
     with ThreadPoolExecutor(
@@ -383,3 +395,5 @@ if __name__ == "__main__":
             test_cli.debug()
         else:
             test_cli.test_expl(expl_name=example)
+
+        test_cli.smoke_commands()


### PR DESCRIPTION
## Description
- gradio import will slow the starwhale package import speed.
- for example: `swcli --help` command do nothing, but it will cost 3~8s because of radio.
  - before:  4s
    - ![image](https://user-images.githubusercontent.com/590748/215459745-41811dbf-b96b-4ab5-b36a-80fe49a6d572.png)
  - after: 0.9s 
    - ![image](https://user-images.githubusercontent.com/590748/215459209-53732c6e-7a42-40c8-ac36-35a440b2685c.png)

## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
