### PR TITLE
chore(deploy): remove image pull policy config

### DIFF
--- a/docker/charts/templates/controller-deployment.yaml
+++ b/docker/charts/templates/controller-deployment.yaml
@@ -31,7 +31,6 @@ spec:
       containers:
         - name: controller
           image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.server.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{ .Values.controller.containerPort }}
           volumeMounts:

--- a/docker/charts/values.yaml
+++ b/docker/charts/values.yaml
@@ -12,7 +12,6 @@ image:
     repo: "starwhale"
   server:
     repo: "server"
-  pullPolicy: IfNotPresent
 
 mysql:
   enabled: true

--- a/server/controller/src/main/resources/template/job.yaml
+++ b/server/controller/src/main/resources/template/job.yaml
@@ -17,7 +17,6 @@ spec:
       containers:
         - name: 'worker'
           image: 'docker.io/library/busybox'
-          imagePullPolicy: IfNotPresent
           args:
             - ppl
           volumeMounts:

--- a/server/controller/src/main/resources/template/model-serving.yaml
+++ b/server/controller/src/main/resources/template/model-serving.yaml
@@ -16,7 +16,6 @@ spec:
       containers:
       - name: 'worker'
         image: 'docker.io/library/busybox'
-        imagePullPolicy: IfNotPresent
         args:
         - serve
         volumeMounts:

--- a/server/controller/src/test/resources/template/job.yaml
+++ b/server/controller/src/test/resources/template/job.yaml
@@ -11,7 +11,6 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: data-provider
-          imagePullPolicy: IfNotPresent
           image: ghcr.io/star-whale/base:latest
           volumeMounts:
             - mountPath: /opt/starwhale
@@ -31,7 +30,6 @@ spec:
       containers:
         - name: 'worker'
           image: 'docker.io/library/busybox'
-          imagePullPolicy: IfNotPresent
           args:
             - ppl
           volumeMounts:


### PR DESCRIPTION
## Description

#### Remove the `imagePullPolicy` field

We use the `latest` tag and `IfNotPresent` policy by default, the docker image can not update to the latest version when the image exists in the node the scheduler chooses.
I recommend using k8s default behavior like:

https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
> When you (or a controller) submit a new Pod to the API server, your cluster sets the imagePullPolicy field when specific conditions are met:
> - if you omit the imagePullPolicy field, and the tag for the container image is :latest, imagePullPolicy is automatically set to Always;
> - if you omit the imagePullPolicy field, and you don't specify the tag for the container image, imagePullPolicy is automatically set to Always;
> - if you omit the imagePullPolicy field, and you specify the tag for the container image that isn't :latest, the imagePullPolicy is automatically set to IfNotPresent.


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
