### PR TITLE
chore(controller): online eval rtt optimization

### DIFF
--- a/console/src/pages/Project/OnlineEval.tsx
+++ b/console/src/pages/Project/OnlineEval.tsx
@@ -98,13 +98,18 @@ export default function OnlineEval() {
                 window.gradio_config.root = `http://${location.host}${resp.data?.baseUri}/run/`
 
                 await new Promise((resolve) => {
-                    const id = setInterval(() => {
-                        axios.get(resp.data?.baseUri).then(() => {
-                            setIsLoading(false)
-                            clearInterval(id)
-                            resolve(null)
-                        })
-                    }, 2000)
+                    const check = () => {
+                        axios
+                            .get(resp.data?.baseUri)
+                            .then(() => {
+                                setIsLoading(false)
+                                resolve(null)
+                            })
+                            .catch(() => {
+                                setTimeout(check, 2000)
+                            })
+                    }
+                    check()
                 })
             } catch (e) {
                 setIsLoading(false)

--- a/console/src/pages/Project/OnlineEval.tsx
+++ b/console/src/pages/Project/OnlineEval.tsx
@@ -106,7 +106,7 @@ export default function OnlineEval() {
                                 resolve(null)
                             })
                             .catch(() => {
-                                setTimeout(check, 2000)
+                                setTimeout(check, 1000)
                             })
                     }
                     check()

--- a/server/controller/src/main/java/ai/starwhale/mlops/common/ProxyServlet.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/ProxyServlet.java
@@ -21,6 +21,7 @@ import static ai.starwhale.mlops.domain.job.ModelServingService.MODEL_SERVICE_PR
 import ai.starwhale.mlops.domain.job.ModelServingService;
 import ai.starwhale.mlops.domain.job.mapper.ModelServingMapper;
 import java.io.IOException;
+import java.net.NoRouteToHostException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
@@ -76,7 +77,7 @@ public class ProxyServlet extends HttpServlet {
         try {
             var response = httpClient.execute(host, request);
             generateResponse(response, res);
-        } catch (UnknownHostException | HttpHostConnectException e) {
+        } catch (UnknownHostException | NoRouteToHostException | HttpHostConnectException e) {
             // return 502 if host or port is unavailable
             res.setStatus(HttpServletResponse.SC_BAD_GATEWAY);
         }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
@@ -149,6 +149,16 @@ public class K8sClient {
         informerFactory.startAllRegisteredInformers();
     }
 
+    public void watchStatefulSet(ResourceEventHandler<V1StatefulSet> eventH, String selector) {
+        SharedIndexInformer<V1StatefulSet> jobInformer = informerFactory.sharedIndexInformerFor(
+                (CallGeneratorParams params) -> appsV1Api.listNamespacedStatefulSetCall(ns, null, null, null, null,
+                        selector, null, params.resourceVersion, null, params.timeoutSeconds, params.watch, null),
+                V1StatefulSet.class,
+                V1StatefulSetList.class);
+        jobInformer.addEventHandler(eventH);
+        informerFactory.startAllRegisteredInformers();
+    }
+
     public String logOfJob(String selector, List<String> containers) throws ApiException, IOException {
         V1Pod pod = podOfJob(selector);
         return logOfPod(pod, containers);

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
@@ -150,9 +150,11 @@ public class K8sJobTemplate {
         var readiness = new V1Probe();
         cos.setReadinessProbe(readiness);
         cos.setResourceOverwriteSpec(resource);
-        readiness.failureThreshold(3);
+        readiness.failureThreshold(60);
         var httpGet = new V1HTTPGetAction();
         readiness.httpGet(httpGet);
+        readiness.initialDelaySeconds(5);
+        readiness.periodSeconds(1);
         httpGet.path("/");
         httpGet.port(new IntOrString(ONLINE_EVAL_PORT_IN_POD));
         httpGet.scheme("HTTP");

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
@@ -40,6 +40,7 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.openapi.models.V1StatefulSetList;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
@@ -147,6 +148,18 @@ public class K8sClientTest {
                 eq(V1NodeList.class))).thenReturn(nodeInformer);
         ResourceEventHandler<V1Node> evh = mock(ResourceEventHandler.class);
         k8sClient.watchNode(evh);
+        verify(nodeInformer).addEventHandler(evh);
+        verify(informerFactory).startAllRegisteredInformers();
+    }
+
+    @Test
+    public void testWatchStatefulSet() {
+        SharedIndexInformer<V1StatefulSet> nodeInformer = mock(SharedIndexInformer.class);
+        when(informerFactory.sharedIndexInformerFor(any(),
+                eq(V1StatefulSet.class),
+                eq(V1StatefulSetList.class))).thenReturn(nodeInformer);
+        ResourceEventHandler<V1StatefulSet> evh = mock(ResourceEventHandler.class);
+        k8sClient.watchStatefulSet(evh, "selector");
         verify(nodeInformer).addEventHandler(evh);
         verify(informerFactory).startAllRegisteredInformers();
     }


### PR DESCRIPTION
## Description

UI
- Check server status immediately after getting the model serving URI
- Change the checking interval from 2s to 1s

Server
- Add cache for K8s workload list (prevent applying orchestration in every predict request)
- Handle `NoRouteToHostException` in proxy
- Change readiness probe interval from 10s to 1s

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
