### PR TITLE
fix(dataset): fix user local fs data can't be fetched by server instance

### DIFF
--- a/client/starwhale/api/_impl/dataset/builder.py
+++ b/client/starwhale/api/_impl/dataset/builder.py
@@ -138,7 +138,10 @@ class SWDSBinWriter:
             artifacts_with_bin = False
             for v in artifacts:
                 if not v.link and isinstance(v.fp, (str, Path)):
+                    # convert user local file path to Starwhale link
                     v.link = Link(v.fp, with_local_fs_data=True)
+                    #  BaseArtifact reads from BaseArtifact.fp prior to any other sources like link
+                    #  When BaseArtifact.fp is user local file path , it is unreliable and should be removed.
                     v.fp = ""
                 if v.link and v.link.with_local_fs_data:
                     v.link.uri = self._copy_file(v.link.uri, False)

--- a/client/starwhale/api/_impl/dataset/builder.py
+++ b/client/starwhale/api/_impl/dataset/builder.py
@@ -139,6 +139,7 @@ class SWDSBinWriter:
             for v in artifacts:
                 if not v.link and isinstance(v.fp, (str, Path)):
                     v.link = Link(v.fp, with_local_fs_data=True)
+                    v.fp = ""
                 if v.link and v.link.with_local_fs_data:
                     v.link.uri = self._copy_file(v.link.uri, False)
                 if (

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -580,6 +580,11 @@ class TestDatasetBuildExecutor(BaseTestCase):
             volume_bytes_size=100,
         ) as e:
             summary = e.make_swds()
+            scan = e.tabular_dataset.scan()
+            for row in scan:
+                assert isinstance(row.data.get("original_data"), Binary)
+                assert not row.data.get("original_data").fp
+                assert row.data.get("original_data").link.uri
 
         assert summary.rows == 10
 


### PR DESCRIPTION
## Description
when BaseArtifact.fp is user local file path , it is unreliable and should be removed.
- remove BaseArtifact.fp after being built by dataset if it is user local file path
![image](https://user-images.githubusercontent.com/89630947/217139266-e9153f5f-cc73-457d-9739-4f8981bee258.png)

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
