### PR TITLE
fix(controller): remove headers from model download api

### DIFF
--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -265,7 +265,7 @@ class BundleCopy(CloudRequestMixed):
                 instance_uri=self.src_uri,
                 params={
                     "desc": fd.file_desc.name,
-                    "partName": fd.name,
+                    "part_name": fd.name,
                     "signature": fd.signature,
                 },
                 progress=progress,
@@ -343,18 +343,17 @@ class BundleCopy(CloudRequestMixed):
 
             if progress is not None:
                 progress.update(_tid, visible=True)
-
             self.do_multipart_upload_file(
                 url_path=url_path,
                 file_path=fd.path,
                 instance_uri=self.dest_uri,
-                fields={
+                params={
                     self.field_flag: self.field_value,
+                    "phase": _UploadPhase.BLOB,
                     "uploadId": upload_id,
                     "partName": fd.name,
                     "signature": fd.signature,
                     "desc": fd.file_desc.name,
-                    "phase": _UploadPhase.BLOB,
                 },
                 use_raise=True,
                 progress=progress,
@@ -382,6 +381,7 @@ class BundleCopy(CloudRequestMixed):
                 executor.submit(_upload_blob, _tid, _file_desc)
                 for _tid, _file_desc in _p_map.items()
             ]
+            # TODO throw errors
             wait(futures)
 
     def _do_ubd_datastore(self) -> None:

--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -265,7 +265,7 @@ class BundleCopy(CloudRequestMixed):
                 instance_uri=self.src_uri,
                 params={
                     "desc": fd.file_desc.name,
-                    "part_name": fd.name,
+                    "partName": fd.name,
                     "signature": fd.signature,
                 },
                 progress=progress,
@@ -416,9 +416,9 @@ class BundleCopy(CloudRequestMixed):
             workdir=workdir,
             url_path=url_path,
         )
-        upload_id: str = res_data.get("upload_id", "")
+        upload_id: str = res_data.get("uploadId", "")
         if not upload_id:
-            raise Exception("upload_id is empty")
+            raise Exception("upload id is empty")
         exists_files: list = res_data.get("existed", [])
         try:
             self._do_ubd_datastore()

--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -266,14 +266,11 @@ class BundleCopy(CloudRequestMixed):
                 url_path=self._get_remote_instance_rc_url(),
                 dest_path=fd.path,
                 instance_uri=self.src_uri,
-                headers={
-                    "X-SW-DOWNLOAD-TYPE": fd.file_desc.name,
-                    "X-SW-DOWNLOAD-OBJECT-NAME": fd.name,
-                    "X-SW-DOWNLOAD-OBJECT-HASH": fd.signature,
-                },
                 params={
                     # for ds download
-                    "part_name": fd.signature,
+                    "desc": fd.file_desc.name,
+                    "name": fd.name,
+                    "signature": fd.signature,
                 },
                 progress=progress,
                 task_id=_tid,

--- a/client/starwhale/core/dataset/copy.py
+++ b/client/starwhale/core/dataset/copy.py
@@ -45,7 +45,7 @@ class DatasetCopy(BundleCopy):
             _path = workdir / "data" / _hash[: DatasetStorage.short_sign_cnt]
             yield FileNode(
                 path=_path,
-                name=os.path.basename(_path),
+                name=_hash,
                 size=_size,
                 file_desc=FileDesc.DATA,
                 signature=_hash,
@@ -79,7 +79,7 @@ class DatasetCopy(BundleCopy):
                 path=_dest,
                 signature=_hash,
                 size=_size,
-                name=_hash[: DatasetStorage.short_sign_cnt],
+                name=_hash,
                 file_desc=FileDesc.DATA,
             )
 

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -232,22 +232,12 @@ class TestBundleCopy(TestCase):
         )
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?part_name=",
-            headers={
-                "X-SW-DOWNLOAD-TYPE": FileDesc.MANIFEST.name,
-                "X-SW-DOWNLOAD-OBJECT-NAME": "_manifest.yaml",
-                "X-SW-DOWNLOAD-OBJECT-HASH": "",
-            },
+            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?desc=MANIFEST&name=_manifest.yaml&signature=",
             json={"resources": []},
         )
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?part_name=",
-            headers={
-                "X-SW-DOWNLOAD-TYPE": FileDesc.SRC_TAR.name,
-                "X-SW-DOWNLOAD-OBJECT-NAME": "src.tar",
-                "X-SW-DOWNLOAD-OBJECT-HASH": "",
-            },
+            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?desc=SRC_TAR&name=src.tar&signature=",
             content=b"mnist model content",
         )
         # m_load_yaml.return_value = {"resources": []}
@@ -450,15 +440,15 @@ class TestBundleCopy(TestCase):
         )
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/dataset/mnist/version/{version}/file?part_name=",
-            headers={
-                "X-SW-DOWNLOAD-TYPE": FileDesc.MANIFEST.name,
-                "X-SW-DOWNLOAD-OBJECT-NAME": "_manifest.yaml",
-                "X-SW-DOWNLOAD-OBJECT-HASH": "",
-            },
+            f"http://1.1.1.1:8182/api/v1/project/myproject/dataset/mnist/version/{version}/file?desc=MANIFEST&name=_manifest.yaml&signature=",
             json={
                 "signature": [],
             },
+        )
+        rm.request(
+            HTTPMethod.GET,
+            f"http://1.1.1.1:8182/api/v1/project/myproject/dataset/mnist/version/{version}/file?desc=SRC_TAR&name=archive.swds_meta&signature=",
+            content=b"mnist dataset content",
         )
         rm.request(
             HTTPMethod.POST,

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -232,12 +232,12 @@ class TestBundleCopy(TestCase):
         )
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?desc=MANIFEST&name=_manifest.yaml&signature=",
+            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?desc=MANIFEST&partName=_manifest.yaml&signature=",
             json={"resources": []},
         )
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?desc=SRC_TAR&name=src.tar&signature=",
+            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}/file?desc=SRC_TAR&partName=src.tar&signature=",
             content=b"mnist model content",
         )
         # m_load_yaml.return_value = {"resources": []}
@@ -440,14 +440,14 @@ class TestBundleCopy(TestCase):
         )
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/dataset/mnist/version/{version}/file?desc=MANIFEST&name=_manifest.yaml&signature=",
+            f"http://1.1.1.1:8182/api/v1/project/myproject/dataset/mnist/version/{version}/file?desc=MANIFEST&partName=_manifest.yaml&signature=",
             json={
                 "signature": [],
             },
         )
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/dataset/mnist/version/{version}/file?desc=SRC_TAR&name=archive.swds_meta&signature=",
+            f"http://1.1.1.1:8182/api/v1/project/myproject/dataset/mnist/version/{version}/file?desc=SRC_TAR&partName=archive.swds_meta&signature=",
             content=b"mnist dataset content",
         )
         rm.request(
@@ -627,7 +627,7 @@ class TestBundleCopy(TestCase):
                 src_uri=case["src_uri"], dest_uri=case["dest_uri"], typ=URIType.DATASET
             ).do()
             assert head_request.call_count == 1
-            assert upload_request.call_count == 3
+            assert upload_request.call_count == 2
 
         # TODO: support the flowing case
         with self.assertRaises(NoMockAddress):

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -627,7 +627,7 @@ class TestBundleCopy(TestCase):
                 src_uri=case["src_uri"], dest_uri=case["dest_uri"], typ=URIType.DATASET
             ).do()
             assert head_request.call_count == 1
-            assert upload_request.call_count == 2
+            assert upload_request.call_count == 3
 
         # TODO: support the flowing case
         with self.assertRaises(NoMockAddress):

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -397,7 +397,7 @@ class TestBundleCopy(TestCase):
                 HTTPMethod.POST,
                 f"http://1.1.1.1:8182/api/v1/project/mnist/model/{case['dest_model']}/version/{version}/file",
                 headers={"X-SW-UPLOAD-TYPE": FileDesc.MANIFEST.name},
-                json={"data": {"upload_id": "123"}},
+                json={"data": {"uploadId": "123"}},
             )
             ModelCopy(
                 src_uri=case["src_uri"], dest_uri=case["dest_uri"], typ=URIType.MODEL
@@ -621,7 +621,7 @@ class TestBundleCopy(TestCase):
             upload_request = rm.request(
                 HTTPMethod.POST,
                 f"http://1.1.1.1:8182/api/v1/project/mnist/dataset/{case['dest_dataset']}/version/{version}/file",
-                json={"data": {"upload_id": 1}},
+                json={"data": {"uploadId": 1}},
             )
             DatasetCopy(
                 src_uri=case["src_uri"], dest_uri=case["dest_uri"], typ=URIType.DATASET
@@ -640,7 +640,7 @@ class TestBundleCopy(TestCase):
             upload_request = rm.request(
                 HTTPMethod.POST,
                 f"http://1.1.1.1:8182/api/v1/project/mnist/dataset/mnist-alias/version/{version}/file",
-                json={"data": {"upload_id": 1}},
+                json={"data": {"uploadId": 1}},
             )
             BundleCopy(
                 src_uri="mnist/v1",
@@ -736,7 +736,7 @@ class TestBundleCopy(TestCase):
         rm.request(
             HTTPMethod.POST,
             "http://1.1.1.1:8182/api/v1/project/project/dataset/mnist/version/abcde/file",
-            json={"data": {"upload_id": 1}},
+            json={"data": {"uploadId": 1}},
         )
 
         dataset_dir = (

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -251,7 +251,7 @@ class TestDatasetCopy(BaseTestCase):
         rm.request(
             HTTPMethod.POST,
             f"{instance_uri}/api/v1/project/{cloud_project}/dataset/{dataset_name}/version/{dataset_version}/file",
-            json={"data": {"upload_id": 1}},
+            json={"data": {"uploadId": 1}},
         )
         rm.request(
             HTTPMethod.HEAD,

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -650,7 +650,7 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         upload_file_req = rm.request(
             HTTPMethod.POST,
             f"http://1.1.1.1/api/v1/project/self/dataset/mnist/version/{ds.version}/file",
-            json={"data": {"upload_id": "123"}},
+            json={"data": {"uploadId": "123"}},
         )
 
         _store = ds._Dataset__core_dataset.store  # type: ignore
@@ -907,7 +907,7 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         rm.request(
             HTTPMethod.POST,
             f"http://1.1.1.1/api/v1/project/self/dataset/mnist/version/{ds.version}/file",
-            json={"data": {"upload_id": "123"}},
+            json={"data": {"uploadId": "123"}},
         )
 
         ds.copy("cloud://test/project/self")

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
@@ -235,8 +235,8 @@ public interface DatasetApi {
             @PathVariable(name = "projectUrl") String projectUrl,
             @PathVariable(name = "datasetUrl") String datasetUrl,
             @PathVariable(name = "versionUrl") String versionUrl,
-            @Parameter(name = "part_name", description = "optional, _manifest.yaml is used if not specified")
-            @RequestParam(name = "part_name", required = false) String partName,
+            @Parameter(name = "signature", description = "optional, _manifest.yaml is used if not specified")
+            @RequestParam(name = "signature", required = false) String partName,
             HttpServletResponse httpResponse);
 
     @Operation(summary = "Pull Dataset uri file contents",

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetApi.java
@@ -51,7 +51,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -215,8 +214,6 @@ public interface DatasetApi {
             produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
     ResponseEntity<ResponseMessage<UploadResult>> uploadDs(
-            @RequestHeader(name = "X-SW-UPLOAD-ID", required = false) String uploadId,
-            @RequestHeader(name = "X-SW-UPLOAD-DATA-URI", required = false) String uri,
             @PathVariable(name = "projectUrl") String projectUrl,
             @Pattern(regexp = BUNDLE_NAME_REGEX, message = "Dataset name is invalid")
             @PathVariable(name = "datasetName") String datasetName,
@@ -235,8 +232,8 @@ public interface DatasetApi {
             @PathVariable(name = "projectUrl") String projectUrl,
             @PathVariable(name = "datasetUrl") String datasetUrl,
             @PathVariable(name = "versionUrl") String versionUrl,
-            @Parameter(name = "signature", description = "optional, _manifest.yaml is used if not specified")
-            @RequestParam(name = "signature", required = false) String partName,
+            @Parameter(name = "partName", description = "optional, _manifest.yaml is used if not specified")
+            @RequestParam(name = "partName", required = false) String partName,
             HttpServletResponse httpResponse);
 
     @Operation(summary = "Pull Dataset uri file contents",

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
@@ -170,11 +170,13 @@ public class DatasetController implements DatasetApi {
     }
 
     @Override
-    public ResponseEntity<ResponseMessage<UploadResult>> uploadDs(String uploadId, String uri,
+    public ResponseEntity<ResponseMessage<UploadResult>> uploadDs(
             String projectUrl, String datasetUrl, String versionUrl,
             MultipartFile dsFile, DatasetUploadRequest uploadRequest) {
         uploadRequest.setProject(projectUrl);
         uploadRequest.setSwds(datasetUrl + ":" + versionUrl);
+        Long uploadId = uploadRequest.getUploadId();
+        String uri = uploadRequest.getUri();
         switch (uploadRequest.getPhase()) {
             case MANIFEST:
                 String text;

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ModelApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ModelApi.java
@@ -50,7 +50,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -291,9 +290,6 @@ public interface ModelApi {
             produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
     ResponseEntity<ResponseMessage<Object>> upload(
-            @RequestHeader(name = "X-SW-UPLOAD-TYPE", required = false) FileDesc fileDesc,
-            @RequestHeader(name = "X-SW-UPLOAD-OBJECT-HASH", required = false) String signature,
-            @RequestHeader(name = "X-SW-UPLOAD-ID", required = false) Long uploadId,
             @Parameter(
                     in = ParameterIn.PATH,
                     description = "Project url",
@@ -317,7 +313,7 @@ public interface ModelApi {
     @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
     void pull(
             @RequestParam(name = "desc", required = false) FileDesc fileDesc,
-            @RequestParam(name = "name", required = false) String name,
+            @RequestParam(name = "partName", required = false) String name,
             @RequestParam(name = "path", required = false) String path,
             @RequestParam(name = "signature", required = false) String signature,
             @PathVariable("projectUrl") String projectUrl,

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ModelApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ModelApi.java
@@ -316,10 +316,10 @@ public interface ModelApi {
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
     void pull(
-            @RequestHeader(name = "X-SW-DOWNLOAD-TYPE", required = false) FileDesc fileDesc,
-            @RequestHeader(name = "X-SW-DOWNLOAD-OBJECT-NAME", required = false) String name,
-            @RequestHeader(name = "X-SW-DOWNLOAD-OBJECT-PATH", required = false) String path,
-            @RequestHeader(name = "X-SW-DOWNLOAD-OBJECT-HASH", required = false) String signature,
+            @RequestParam(name = "desc", required = false) FileDesc fileDesc,
+            @RequestParam(name = "name", required = false) String name,
+            @RequestParam(name = "path", required = false) String path,
+            @RequestParam(name = "signature", required = false) String signature,
             @PathVariable("projectUrl") String projectUrl,
             @Parameter(in = ParameterIn.PATH, required = true, schema = @Schema())
             @Pattern(regexp = BUNDLE_NAME_REGEX, message = "Model name is not invalid.")

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ModelController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ModelController.java
@@ -195,11 +195,13 @@ public class ModelController implements ModelApi {
 
     @Override
     public ResponseEntity<ResponseMessage<Object>> upload(
-            FileDesc fileDesc, String signature, Long uploadId,
             String projectUrl, String modelUrl, String versionUrl,
             MultipartFile file, ModelUploadRequest uploadRequest) {
         uploadRequest.setProject(projectUrl);
         uploadRequest.setSwmp(modelUrl + ":" + versionUrl);
+        FileDesc fileDesc = uploadRequest.getDesc();
+        String signature = uploadRequest.getSignature();
+        Long uploadId = uploadRequest.getUploadId();
         switch (uploadRequest.getPhase()) {
             case MANIFEST:
                 return ResponseEntity.ok(Code.success.asResponse(

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadRequest.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.api.protocol.upload;
 
+import ai.starwhale.mlops.api.protocol.storage.FileDesc;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.validation.annotation.Validated;
@@ -25,6 +26,12 @@ import org.springframework.validation.annotation.Validated;
 public abstract class UploadRequest {
 
     protected static final String SEPARATOR = ":";
+
+    Long uploadId;
+    String partName;
+    String signature;
+    String uri;
+    FileDesc desc;
 
     @NotNull
     UploadPhase phase;

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadResult.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadResult.java
@@ -29,6 +29,6 @@ import lombok.experimental.SuperBuilder;
 public class UploadResult {
 
     @JsonProperty("upload_id")
-    String uploadId;
+    Long uploadId;
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadResult.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/upload/UploadResult.java
@@ -16,7 +16,6 @@
 
 package ai.starwhale.mlops.api.protocol.upload;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -28,7 +27,6 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class UploadResult {
 
-    @JsonProperty("upload_id")
     Long uploadId;
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/upload/DatasetUploader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/upload/DatasetUploader.java
@@ -119,7 +119,7 @@ public class DatasetUploader {
         this.versionAliasConvertor = versionAliasConvertor;
     }
 
-    public void cancel(String uploadId) {
+    public void cancel(Long uploadId) {
         final DatasetVersionWithMeta swDatasetVersionEntityWithMeta = getDatasetVersion(uploadId);
         datasetVersionMapper.delete(swDatasetVersionEntityWithMeta.getDatasetVersion().getId());
         hotDatasetHolder.cancel(uploadId);
@@ -145,7 +145,7 @@ public class DatasetUploader {
         }
     }
 
-    public void uploadBody(String uploadId, MultipartFile file, String uri) {
+    public void uploadBody(Long uploadId, MultipartFile file, String uri) {
         final DatasetVersionWithMeta swDatasetVersionWithMeta = getDatasetVersion(uploadId);
         String filename = file.getOriginalFilename();
         try (InputStream inputStream = file.getInputStream()) {
@@ -187,7 +187,7 @@ public class DatasetUploader {
         return digest.equals(uploadedFileBlake2bs.get(filename));
     }
 
-    DatasetVersionWithMeta getDatasetVersion(String uploadId) {
+    DatasetVersionWithMeta getDatasetVersion(Long uploadId) {
         final Optional<DatasetVersionWithMeta> swDatasetVersionEntityOpt = hotDatasetHolder.of(uploadId);
         return swDatasetVersionEntityOpt
                 .orElseThrow(
@@ -212,7 +212,7 @@ public class DatasetUploader {
     }
 
     @Transactional
-    public String create(String yamlContent, String fileName, DatasetUploadRequest uploadRequest) {
+    public Long create(String yamlContent, String fileName, DatasetUploadRequest uploadRequest) {
         Manifest manifest;
         try {
             manifest = yamlMapper.readValue(yamlContent, Manifest.class);
@@ -284,7 +284,7 @@ public class DatasetUploader {
 
         hotDatasetHolder.manifest(DatasetVersion.fromEntity(datasetEntity, datasetVersionEntity));
 
-        return datasetVersionEntity.getVersionName();
+        return datasetVersionEntity.getId();
     }
 
     private DatasetVersionEntity from(String projectName, DatasetEntity datasetEntity, Manifest manifest) {
@@ -320,7 +320,7 @@ public class DatasetUploader {
         return currentUserDetail.getIdTableKey();
     }
 
-    public void end(String uploadId) {
+    public void end(Long uploadId) {
         final DatasetVersionWithMeta datasetVersionWithMeta = getDatasetVersion(uploadId);
         datasetVersionMapper.updateStatus(datasetVersionWithMeta.getDatasetVersion().getId(),
                 DatasetVersion.STATUS_AVAILABLE);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/upload/HotDatasetHolder.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/upload/HotDatasetHolder.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HotDatasetHolder {
 
-    Map<String, DatasetVersionWithMeta> datasetHolder;
+    Map<Long, DatasetVersionWithMeta> datasetHolder;
 
     final DatasetVersionWithMetaConverter datasetVersionWithMetaConverter;
 
@@ -36,19 +36,19 @@ public class HotDatasetHolder {
     }
 
     public void manifest(DatasetVersion datasetVersion) {
-        datasetHolder.put(datasetVersion.getVersionName(),
+        datasetHolder.put(datasetVersion.getId(),
                 datasetVersionWithMetaConverter.from(datasetVersion));
     }
 
-    public void cancel(String datasetId) {
+    public void cancel(Long datasetId) {
         datasetHolder.remove(datasetId);
     }
 
-    public void end(String datasetId) {
+    public void end(Long datasetId) {
         datasetHolder.remove(datasetId);
     }
 
-    public Optional<DatasetVersionWithMeta> of(String id) {
+    public Optional<DatasetVersionWithMeta> of(Long id) {
         return Optional.ofNullable(datasetHolder.get(id));
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
@@ -477,7 +477,7 @@ public class ModelService {
                     .revertVersionTo(modelVersionEntity.getModelId(), modelVersionEntity.getId());
         }
         return ModelUploadResult.builder()
-                .uploadId(modelVersionEntity.getId().toString())
+                .uploadId(modelVersionEntity.getId())
                 .existed(existed)
                 .build();
     }
@@ -579,6 +579,7 @@ public class ModelService {
                         // update correct attributes
                         name = Objects.isNull(name) ? file.getName() : name;
                         path = Objects.isNull(path) ? file.getPath() : path;
+                        signature = Objects.isNull(signature) ? file.getSignature() : signature;
                         break;
                     }
                 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/DatasetControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/DatasetControllerTest.java
@@ -182,42 +182,40 @@ public class DatasetControllerTest {
 
     @Test
     public void testUploadDs() {
+        given(datasetUploader.create(anyString(), anyString(), any(DatasetUploadRequest.class)))
+                .willAnswer((Answer<Long>) invocation -> 1L);
+
+        DatasetUploadRequest uploadRequest = new DatasetUploadRequest();
+        uploadRequest.setUploadId(1L);
+        uploadRequest.setPhase(UploadPhase.MANIFEST);
+
         MultipartFile file = new MockMultipartFile("dsFile", "originalName", null,
                 "file_content".getBytes());
-        given(datasetUploader.create(anyString(), anyString(), any(DatasetUploadRequest.class)))
-                .willAnswer((Answer<String>) invocation -> {
-                    String yamlContent = invocation.getArgument(0);
-                    String fileName = invocation.getArgument(1);
-                    DatasetUploadRequest request = invocation.getArgument(2);
-                    return String.format("%s-%s-%s-%s",
-                            yamlContent, fileName, request.getProject(), request.getSwds());
-                });
-        DatasetUploadRequest uploadRequest = new DatasetUploadRequest();
-        uploadRequest.setPhase(UploadPhase.MANIFEST);
-        var resp = controller.uploadDs("upload1", "", "p1", "d1", "v1", file, uploadRequest);
+        var resp = controller.uploadDs(
+                "p1", "d1", "v1", file, uploadRequest);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
         assertThat(Objects.requireNonNull(resp.getBody()).getData(), allOf(
                 notNullValue(),
-                hasProperty("uploadId", is("file_content-originalName-p1-d1:v1"))
+                hasProperty("uploadId", is(1L))
         ));
 
         uploadRequest.setPhase(UploadPhase.BLOB);
-        resp = controller.uploadDs("upload1", "", "p1", "d1", "v1", file, uploadRequest);
+        resp = controller.uploadDs("p1", "d1", "v1", file, uploadRequest);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
         assertThat(Objects.requireNonNull(resp.getBody()).getData(),
-                hasProperty("uploadId", is("upload1")));
+                hasProperty("uploadId", is(1L)));
 
         uploadRequest.setPhase(UploadPhase.CANCEL);
-        resp = controller.uploadDs("upload1", "", "p1", "d1", "v1", file, uploadRequest);
+        resp = controller.uploadDs("p1", "d1", "v1", file, uploadRequest);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
         assertThat(Objects.requireNonNull(resp.getBody()).getData(),
-                hasProperty("uploadId", is("upload1")));
+                hasProperty("uploadId", is(1L)));
 
         uploadRequest.setPhase(UploadPhase.END);
-        resp = controller.uploadDs("upload1", "", "p1", "d1", "v1", file, uploadRequest);
+        resp = controller.uploadDs("p1", "d1", "v1", file, uploadRequest);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
         assertThat(Objects.requireNonNull(resp.getBody()).getData(),
-                hasProperty("uploadId", is("upload1")));
+                hasProperty("uploadId", is(1L)));
     }
 
     @Test

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/ModelControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/ModelControllerTest.java
@@ -204,26 +204,31 @@ public class ModelControllerTest {
     public void testUpload() {
         var request = new ModelUploadRequest();
         request.setPhase(UploadPhase.MANIFEST);
+        request.setUploadId(1L);
+        request.setDesc(FileDesc.MANIFEST);
+        request.setSignature("");
         var resp = controller.upload(
-                FileDesc.MANIFEST, "", 1L, "p1", "m1", "v1", null, request);
+                "p1", "m1", "v1", null, request);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
 
         request.setPhase(UploadPhase.BLOB);
+        request.setDesc(FileDesc.SRC_TAR);
         resp = controller.upload(
-                FileDesc.SRC_TAR, "", 1L, "p1", "m1", "v1", null, request);
+                "p1", "m1", "v1", null, request);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
 
+        request.setDesc(FileDesc.MODEL);
         resp = controller.upload(
-                FileDesc.MODEL, "qwerty", 1L, "p1", "m1", "v1", null, request);
+                "p1", "m1", "v1", null, request);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
 
         request.setPhase(UploadPhase.CANCEL);
         assertThrows(StarwhaleApiException.class, () -> controller.upload(
-                null, "", 1L, "p1", "m1", "v1", null, request));
+                "p1", "m1", "v1", null, request));
 
         request.setPhase(UploadPhase.END);
         controller.upload(
-                null, "", 1L, "p1", "m1", "v1", null, request);
+                "p1", "m1", "v1", null, request);
         assertThat(resp.getStatusCode(), is(HttpStatus.OK));
     }
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/HotDatasetHolderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/HotDatasetHolderTest.java
@@ -121,7 +121,7 @@ public class HotDatasetHolderTest {
                 .build();
         hotDatasetHolder.manifest(datasetVersion);
 
-        Optional<DatasetVersionWithMeta> swdsVersionWithMetaOpt = hotDatasetHolder.of(versionName);
+        Optional<DatasetVersionWithMeta> swdsVersionWithMetaOpt = hotDatasetHolder.of(1L);
         Assertions.assertTrue(swdsVersionWithMetaOpt.isPresent());
         DatasetVersionWithMeta datasetVersionWithMeta = swdsVersionWithMetaOpt.get();
         VersionMeta versionMeta = datasetVersionWithMeta.getVersionMeta();
@@ -184,13 +184,13 @@ public class HotDatasetHolderTest {
                         + "75b473b5b73987ab6254feb91a3ede674936637e3e4f25a72d",
                 signatureMap.get(0));
 
-        hotDatasetHolder.end(versionName);
-        swdsVersionWithMetaOpt = hotDatasetHolder.of(versionName);
+        hotDatasetHolder.end(1L);
+        swdsVersionWithMetaOpt = hotDatasetHolder.of(1L);
         Assertions.assertTrue(swdsVersionWithMetaOpt.isEmpty());
 
         hotDatasetHolder.manifest(datasetVersion);
-        hotDatasetHolder.cancel(versionName);
-        swdsVersionWithMetaOpt = hotDatasetHolder.of(versionName);
+        hotDatasetHolder.cancel(1L);
+        swdsVersionWithMetaOpt = hotDatasetHolder.of(1L);
         Assertions.assertTrue(swdsVersionWithMetaOpt.isEmpty());
 
     }


### PR DESCRIPTION
## Description
Unified the upload/download api for model and dataset:
1. dataset
changed param from 'part_name' to 'partName' 
2. model
changed headers from `'X-SW-DOWNLOAD-TYPE','X-SW-DOWNLOAD-OBJECT-NAME','X-SW-DOWNLOAD-OBJECT-PATH','X-SW-DOWNLOAD-OBJECT-HASH'` to `'desc','partName','path','signature' `and the type from header to param.
3. Change upload id from String to Long 


## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
