### PR TITLE
chore(doc): update doc registry with the avaiable address

### DIFF
--- a/docs/docs/guides/config/server_admin.md
+++ b/docs/docs/guides/config/server_admin.md
@@ -19,7 +19,7 @@ You could customize system to make it easier to use by leverage of `System setti
 ```yaml
 ---
 dockerSetting:
-  registry: "docker-registry.starwhale.ai" 
+  registry: "docker-registry.starwhale.cn"
 resourcePoolSetting:
   - name: pool1
     nodeSelector:
@@ -40,10 +40,10 @@ resourcePoolSetting:
       - name: cpu
         max: 2
         min: 1
-        defaults: 
+        defaults:
 storageSetting:
   - type: s3
-    tokens: 
+    tokens:
       - bucket: starwhale
         ak: access_key
         sk: scret_key
@@ -52,7 +52,7 @@ storageSetting:
         hugeFileThreshold: 10485760
         hugeFilePartSize: 5242880
   - type: minio
-    tokens: 
+    tokens:
       - bucket: starwhale
         ak: access_key
         sk: scret_key
@@ -71,7 +71,7 @@ We offer a convenience to overwrite the registry of a runtime: Put the YAML belo
 
 ```yaml
 dockerSetting:
-  registry: "docker-registry.starwhale.ai"
+  registry: "docker-registry.starwhale.cn"
 ```
 
 The priority of the system setting is the highest. Fine-grained setting is not provided yet.
@@ -87,7 +87,7 @@ The `storageSetting` allows you to manage the storages the server could access.
 ```yaml
 storageSetting:
   - type: s3
-    tokens: 
+    tokens:
       - bucket: starwhale # required
         ak: access_key # required
         sk: scret_key # required
@@ -96,7 +96,7 @@ storageSetting:
         hugeFileThreshold: 10485760 #  bigger than 10MB will use multiple part upload
         hugeFilePartSize: 5242880 #  5MB part size for multiple part upload
   - type: minio
-    tokens: 
+    tokens:
       - bucket: starwhale # required
         ak: access_key # required
         sk: scret_key # required
@@ -105,7 +105,7 @@ storageSetting:
         hugeFileThreshold: 10485760 #  bigger than 10MB will use multiple part upload
         hugeFilePartSize: 5242880 #  5MB part size for multiple part upload
   - type: aliyun
-    tokens: 
+    tokens:
       - bucket: starwhale # required
         ak: access_key # required
         sk: scret_key # required

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/guides/config/server_admin.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/guides/config/server_admin.md
@@ -19,7 +19,7 @@ update user_info set user_pwd='ee9533077d01d2d65a4efdb41129a91e', user_pwd_salt=
 ```yaml
 ---
 dockerSetting:
-  registry: "docker-registry.starwhale.ai"
+  registry: "docker-registry.starwhale.cn"
 resourcePoolSetting:
   - name: pool1
     nodeSelector:
@@ -80,7 +80,7 @@ Server下发的Tasks都是基于docker镜像实现的。如果你的网络不太
 ```yaml
 storageSetting:
   - type: s3
-    tokens: 
+    tokens:
       - bucket: starwhale # required
         ak: access_key # required
         sk: scret_key # required
@@ -89,7 +89,7 @@ storageSetting:
         hugeFileThreshold: 10485760 #  bigger than 10MB will use multiple part upload
         hugeFilePartSize: 5242880 #  5MB part size for multiple part upload
   - type: minio
-    tokens: 
+    tokens:
       - bucket: starwhale # required
         ak: access_key # required
         sk: scret_key # required
@@ -98,7 +98,7 @@ storageSetting:
         hugeFileThreshold: 10485760 #  bigger than 10MB will use multiple part upload
         hugeFilePartSize: 5242880 #  5MB part size for multiple part upload
   - type: aliyun
-    tokens: 
+    tokens:
       - bucket: starwhale # required
         ak: access_key # required
         sk: scret_key # required


### PR DESCRIPTION
## Description
`docker-registry.starwhale.ai` has an expired certificate. Before returning to normal, we use an available address.

```
❯ curl -I https://docker-registry.starwhale.ai
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.se/docs/sslcerts.html
```

```
❯ curl -I https://docker-registry.starwhale.cn
HTTP/1.1 200 OK
Server: nginx/1.23.0
Date: Wed, 08 Feb 2023 03:22:40 GMT
Content-Type: text/html
Content-Length: 16975
Last-Modified: Wed, 28 Sep 2022 08:28:11 GMT
Connection: keep-alive
ETag: "6334059b-424f"
Accept-Ranges: bytes
```

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [x] add necessary doc
