### PR TITLE
enhance(cli): make copy command compatible with no `cloud://` prefix uri

### DIFF
--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -74,8 +74,15 @@ class BundleCopy(CloudRequestMixed):
         else:
             project = None
 
-        self.dest_resource = Resource(dest_uri, typ=ResourceType[typ], project=project)
-        self.dest_uri = self.dest_resource.to_uri()
+        try:
+            self.dest_uri = Resource(
+                dest_uri, typ=ResourceType[typ], project=project
+            ).to_uri()
+        except Exception as e:
+            if str(e).startswith("invalid uri"):
+                self.dest_uri = Project(dest_uri).to_uri()
+            else:
+                raise
 
         self.typ = typ
         self.force = force

--- a/client/starwhale/base/uricomponents/project.py
+++ b/client/starwhale/base/uricomponents/project.py
@@ -46,16 +46,23 @@ class Project:
         # TODO check if project exists for local and remote
 
     @classmethod
-    def parse(cls, uri: str, ignore_rc_type: bool) -> "Project":
+    def parse_from_full_uri(cls, uri: str, ignore_rc_type: bool) -> "Project":
         """
         Parse project from full uri.
         we do not parse instance and project info from uri less than 5 parts.
-        we prefer that users use `dataset copy mnist -p project` rather than `dataset copy project/dataset/mnist`.
+        we prefer that users use `dataset copy mnist -dlp project` rather than `dataset copy project/dataset/mnist`.
         the second is difficult to write correctly at once and the semantics are not very clear.
         and the long uri usually copied from the website.
         """
-        # TODO ignore '//' if uri like https://foo.com/bar/xxx
-        parts = uri.split("/")
+        if "://" in uri:
+            no_schema_uri = uri.split("://", 1)[-1]
+        else:
+            no_schema_uri = uri
+
+        if "//" in no_schema_uri:
+            raise Exception(f"wrong format uri({uri}) with '//'")
+
+        parts = no_schema_uri.split("/")
         exp = len("local/project/self/dataset/mnist".split("/"))
         if ignore_rc_type:
             # ignore type in uri like dataset

--- a/client/starwhale/base/uricomponents/resource.py
+++ b/client/starwhale/base/uricomponents/resource.py
@@ -80,10 +80,18 @@ class Resource:
             self.project = project
         else:
             try:
-                self.project = Project.parse(uri, ignore_rc_type=typ is not None)
+                self.project = Project.parse_from_full_uri(
+                    uri, ignore_rc_type=typ is not None
+                )
                 uri = self.project.path
             except UriTooShortException:
                 self.project = Project()
+
+        if "://" in uri:
+            uri = uri.split("://", 1)[-1]
+
+        if "//" in uri:
+            raise Exception(f"wrong uri({uri}) format with '//'")
 
         parts = len(uri.split("/"))
         # 3 == len('mnist/version/latest'.split(/))
@@ -124,7 +132,7 @@ class Resource:
             self.version = parts[-1]
         else:
             if parts[1] != "version":
-                raise Exception(f"invalid uri {uri}")
+                raise Exception(f"invalid uri without version field: {uri}")
             self.name = parts[0]
             self.version = parts[-1]
 

--- a/client/starwhale/core/dataset/cli.py
+++ b/client/starwhale/core/dataset/cli.py
@@ -265,6 +265,10 @@ def _copy(src: str, dest: str, force: bool, dest_local_project: str) -> None:
             swcli dataset cp mnist-local/version/latest cloud://pre-k8s/project/mnist
 
         \b
+        - copy standalone instance(local) default project(self)'s mnist-local dataset to cloud instance(pre-k8s) mnist project without 'cloud://' prefix
+            swcli dataset cp mnist-local/version/latest pre-k8s/project/mnist
+
+        \b
         - copy standalone instance(local) project(myproject)'s mnist-local dataset to cloud instance(pre-k8s) mnist project with standalone instance dataset name 'mnist-local'
             swcli dataset cp local/project/myproject/dataset/mnist-local/version/latest cloud://pre-k8s/project/mnist
     """

--- a/client/starwhale/core/dataset/copy.py
+++ b/client/starwhale/core/dataset/copy.py
@@ -109,7 +109,8 @@ class DatasetCopy(BundleCopy):
             name=self.bundle_name,
             version=self.bundle_version,
             project=self._get_remote_project_name(
-                self.dest_resource.project.instance.to_uri(), self.dest_uri.project
+                self.dest_uri,
+                self.dest_uri.project,
             ),
             instance_name=self.dest_uri.instance,
         ) as remote:

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -91,6 +91,10 @@ def _copy(src: str, dest: str, force: bool, dest_local_project: str) -> None:
             swcli model cp mnist-local/version/latest cloud://pre-k8s/project/mnist
 
         \b
+        - copy standalone instance(local) default project(self)'s mnist-local model to cloud instance(pre-k8s) mnist project without 'cloud://' prefix
+            swcli model cp mnist-local/version/latest pre-k8s/project/mnist
+
+        \b
         - copy standalone instance(local) project(myproject)'s mnist-local model to cloud instance(pre-k8s) mnist project with standalone instance model name 'mnist-local'
             swcli model cp local/project/myproject/model/mnist-local/version/latest cloud://pre-k8s/project/mnist
     """

--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -367,6 +367,10 @@ def _copy(src: str, dest: str, force: bool, dest_local_project: str) -> None:
             swcli runtime cp mnist-local/version/latest cloud://pre-k8s/project/mnist
 
         \b
+        - copy standalone instance(local) default project(self)'s mnist-local runtime to cloud instance(pre-k8s) mnist project without 'cloud://' prefix
+            swcli runtime cp mnist-local/version/latest pre-k8s/project/mnist
+
+        \b
         - copy standalone instance(local) project(myproject)'s mnist-local runtime to cloud instance(pre-k8s) mnist project with standalone instance runtime name 'mnist-local'
             swcli runtime cp local/project/myproject/runtime/mnist-local/version/latest cloud://pre-k8s/project/mnist
     """

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -137,7 +137,17 @@ class TestBundleCopy(TestCase):
         cases = [
             {
                 "src_uri": f"local/project/self/mnist/version/{version}",
-                "dest_uri": "cloud://pre-bare/mnist",
+                "dest_uri": "cloud://pre-bare/project/mnist",
+                "dest_runtime": "mnist",
+            },
+            {
+                "src_uri": f"local/project/self/mnist/version/{version}",
+                "dest_uri": "pre-bare/project/mnist",
+                "dest_runtime": "mnist",
+            },
+            {
+                "src_uri": f"local/project/self/mnist/version/{version}",
+                "dest_uri": "http://1.1.1.1:8182/project/mnist",
                 "dest_runtime": "mnist",
             },
             {
@@ -147,7 +157,7 @@ class TestBundleCopy(TestCase):
             },
             {
                 "src_uri": "mnist",
-                "dest_uri": "cloud://pre-bare/mnist",
+                "dest_uri": "cloud://pre-bare/project/mnist",
                 "dest_runtime": "mnist",
             },
             {
@@ -163,6 +173,16 @@ class TestBundleCopy(TestCase):
             {
                 "src_uri": f"mnist/{version[:5]}",
                 "dest_uri": "cloud://pre-bare/project/mnist",
+                "dest_runtime": "mnist",
+            },
+            {
+                "src_uri": f"mnist/{version[:5]}",
+                "dest_uri": "pre-bare/project/mnist",
+                "dest_runtime": "mnist",
+            },
+            {
+                "src_uri": f"mnist/{version[:5]}",
+                "dest_uri": "http://1.1.1.1:8182/project/mnist",
                 "dest_runtime": "mnist",
             },
             {
@@ -351,17 +371,32 @@ class TestBundleCopy(TestCase):
         cases = [
             {
                 "src_uri": f"local/project/self/mnist/version/{version}",
-                "dest_uri": "cloud://pre-bare/mnist",
+                "dest_uri": "cloud://pre-bare/project/mnist",
+                "dest_model": "mnist",
+            },
+            {
+                "src_uri": f"local/project/self/mnist/version/{version}",
+                "dest_uri": "pre-bare/project/mnist",
                 "dest_model": "mnist",
             },
             {
                 "src_uri": f"local/project/self/model/mnist/version/{version}",
-                "dest_uri": "cloud://pre-bare/mnist",
+                "dest_uri": "cloud://pre-bare/project/mnist",
+                "dest_model": "mnist",
+            },
+            {
+                "src_uri": f"local/project/self/model/mnist/version/{version}",
+                "dest_uri": "pre-bare/project/mnist",
                 "dest_model": "mnist",
             },
             {
                 "src_uri": "mnist",
                 "dest_uri": "cloud://pre-bare/project/mnist",
+                "dest_model": "mnist",
+            },
+            {
+                "src_uri": "mnist",
+                "dest_uri": "http://1.1.1.1:8182/project/mnist",
                 "dest_model": "mnist",
             },
             {
@@ -371,7 +406,7 @@ class TestBundleCopy(TestCase):
             },
             {
                 "src_uri": f"mnist/version/{version[:5]}",
-                "dest_uri": "cloud://pre-bare/mnist",
+                "dest_uri": "cloud://pre-bare/project/mnist",
                 "dest_model": "mnist",
             },
             {
@@ -570,17 +605,27 @@ class TestBundleCopy(TestCase):
         cases = [
             {
                 "src_uri": f"local/project/self/mnist/version/{version}",
-                "dest_uri": "cloud://pre-bare/mnist",
+                "dest_uri": "cloud://pre-bare/project/mnist",
                 "dest_dataset": "mnist",
             },
             {
-                "src_uri": f"local/project/self/dataset/mnist/version/{version}",
+                "src_uri": f"local/project/self/mnist/version/{version}",
+                "dest_uri": "pre-bare/project/mnist",
+                "dest_dataset": "mnist",
+            },
+            {
+                "src_uri": f"local/project/self/mnist/version/{version}",
+                "dest_uri": "http://1.1.1.1:8182/project/mnist",
+                "dest_dataset": "mnist",
+            },
+            {
+                "src_uri": "mnist",
                 "dest_uri": "cloud://pre-bare/project/mnist",
                 "dest_dataset": "mnist",
             },
             {
                 "src_uri": "mnist",
-                "dest_uri": "cloud://pre-bare/mnist",
+                "dest_uri": "pre-bare/project/mnist",
                 "dest_dataset": "mnist",
             },
             {
@@ -590,7 +635,7 @@ class TestBundleCopy(TestCase):
             },
             {
                 "src_uri": f"mnist/version/{version[:5]}",
-                "dest_uri": "cloud://pre-bare/mnist",
+                "dest_uri": "cloud://pre-bare/project/mnist",
                 "dest_dataset": "mnist",
             },
             {
@@ -601,6 +646,16 @@ class TestBundleCopy(TestCase):
             {
                 "src_uri": "mnist/v1",
                 "dest_uri": "cloud://pre-bare/project/mnist/mnist-new-alias",
+                "dest_dataset": "mnist-new-alias",
+            },
+            {
+                "src_uri": "mnist/v1",
+                "dest_uri": "pre-bare/project/mnist/mnist-new-alias",
+                "dest_dataset": "mnist-new-alias",
+            },
+            {
+                "src_uri": "mnist/v1",
+                "dest_uri": "http://1.1.1.1:8182/project/mnist/mnist-new-alias",
                 "dest_dataset": "mnist-new-alias",
             },
             {

--- a/client/tests/base/uricomponents/test_instance.py
+++ b/client/tests/base/uricomponents/test_instance.py
@@ -58,3 +58,7 @@ class TestInstance(TestCase):
         ins = Instance(uri="local/baz/foo")
         assert ins.alias == "local"
         assert ins.path == "baz/foo"
+
+        ins = Instance(uri="foo/baz")
+        assert ins.alias == "foo"
+        assert ins.path == "baz"


### PR DESCRIPTION
## Description
we cannot execute `swcli runtime cp pytorch-starwhale-main/version/latest pre-k8s/project/mnist ` command without `cloud:// prefix`, following by the user [doc](https://github.com/star-whale/starwhale/blob/main/docs/i18n/zh/docusaurus-plugin-content-docs/current/guides/uri.md#1-instance-uri). 
- before:
  - ![image](https://user-images.githubusercontent.com/590748/217454010-ed92b6ff-2e66-4c34-af6a-d6b5b092afad.png)
- after:
  - ![image](https://user-images.githubusercontent.com/590748/217748819-161da2a3-d8eb-471a-8277-17c8d73c030c.png)


## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
