### PR TITLE
feat(console): auto fill runtime if possible in online eval page

### DIFF
--- a/console/src/domain/model/components/CreateOnlineEvalForm.tsx
+++ b/console/src/domain/model/components/CreateOnlineEvalForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import useTranslation from '@/hooks/useTranslation'
 import { createForm } from '@/components/Form'
 import RuntimeSelector from '@runtime/components/RuntimeSelector'
@@ -12,6 +12,7 @@ import { createUseStyles } from 'react-jss'
 import FlatResourceSelector, { Dict } from '@/domain/setting/components/FlatResourceSelector'
 import { ISystemResourcePool } from '@/domain/setting/schemas/system'
 import { Toggle } from '@starwhale/ui/Select'
+import { useFetchRuntimeVersionSuggestion } from '@runtime/hooks/useFetchRuntimeVersionSuggestion'
 
 interface ICreateOnlineEvalProps {
     modelId: string
@@ -58,6 +59,16 @@ function CreateOnlineEvalForm({ onSubmit }: ICreateOnlineEvalFormProps, formRef:
     const [runtimeId, setRuntimeId] = useState('')
     const [resourcePool, setResourcePool] = React.useState<ISystemResourcePool | undefined>()
     const [showAdvanced, setShowAdvanced] = useState(false)
+
+    // get runtime suggestion
+    const runtimes = useFetchRuntimeVersionSuggestion(projectId, $modelVersionId).data?.runtimes
+    useEffect(() => {
+        if (runtimes !== undefined && runtimes?.length !== 0) {
+            const { id, runtimeId: $runtimeId } = runtimes[0]
+            form.setFieldsValue({ runtimeId: $runtimeId, runtimeVersionUrl: id })
+            setRuntimeId($runtimeId)
+        }
+    }, [form, runtimes])
 
     const handleValuesChange = useCallback(
         (changes, values) => {

--- a/console/src/domain/runtime/hooks/useFetchRuntimeVersionSuggestion.ts
+++ b/console/src/domain/runtime/hooks/useFetchRuntimeVersionSuggestion.ts
@@ -1,0 +1,12 @@
+import { useQuery } from 'react-query'
+import { fetchRuntimeVersionSuggestion } from '../services/runtimeVersion'
+
+export function useFetchRuntimeVersionSuggestion(projectId: string, modelId: string) {
+    return useQuery(
+        ['fetchRuntimeVersionSuggestion', projectId, modelId],
+        () => fetchRuntimeVersionSuggestion(projectId, modelId),
+        {
+            refetchOnWindowFocus: false,
+        }
+    )
+}

--- a/console/src/domain/runtime/schemas/runtimeVersion.tsx
+++ b/console/src/domain/runtime/schemas/runtimeVersion.tsx
@@ -9,6 +9,7 @@ export interface IRuntimeVersionSchema extends IResourceSchema {
     owner?: IUserSchema
     alias: string
     image: string
+    runtimeId: string
 }
 
 export interface IRuntimeVersionListSchema extends IResourceSchema {
@@ -35,4 +36,8 @@ export interface ICreateRuntimeVersionSchema {
 export interface IRuntimeVersionListQuerySchema extends IListQuerySchema {
     vName?: string
     vTag?: string
+}
+
+export interface IRuntimeVersionSuggestionSchema {
+    runtimes: IRuntimeVersionSchema[]
 }

--- a/console/src/domain/runtime/services/runtimeVersion.ts
+++ b/console/src/domain/runtime/services/runtimeVersion.ts
@@ -6,6 +6,7 @@ import {
     IUpdateRuntimeVersionSchema,
     IRuntimeVersionDetailSchema,
     IRuntimeVersionListQuerySchema,
+    IRuntimeVersionSuggestionSchema,
 } from '../schemas/runtimeVersion'
 
 export async function listRuntimeVersions(
@@ -69,4 +70,14 @@ export async function recoverRuntimeVersion(
         `/api/v1/project/${projectId}/runtime/${runtimeId}/version/${runtimeVersionId}/recover`
     )
     return resp.data
+}
+
+export async function fetchRuntimeVersionSuggestion(
+    projectId: string,
+    modelVersionId: string
+): Promise<IRuntimeVersionSuggestionSchema> {
+    const { data } = await axios.get<IRuntimeVersionSuggestionSchema>('/api/v1/job/suggestion/runtime', {
+        params: { projectId, modelVersionId },
+    })
+    return data
 }


### PR DESCRIPTION
## Description

Auto fill runtime if possible in online eval page

relates to #1805

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
