### PR TITLE
fix(controller):datastore api return empty results when query multi times for type of bytes

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnTypeScalar.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnTypeScalar.java
@@ -133,7 +133,9 @@ public class ColumnTypeScalar extends ColumnType {
                     || this == STRING) {
                 return value.toString();
             } else if (this == BYTES) {
-                return StandardCharsets.UTF_8.decode((ByteBuffer) value).toString();
+                return StandardCharsets.UTF_8.decode(
+                        ((ByteBuffer) value).duplicate()
+                ).toString();
             }
         } else {
             if (this == BOOL) {
@@ -153,8 +155,9 @@ public class ColumnTypeScalar extends ColumnType {
             } else if (this == STRING) {
                 return value;
             } else if (this == BYTES) {
-                var base64 = Base64.getEncoder().encode(((ByteBuffer) value).duplicate());
-                return StandardCharsets.UTF_8.decode(base64).toString();
+                return StandardCharsets.UTF_8.decode(
+                        Base64.getEncoder().encode(((ByteBuffer) value).duplicate())
+                ).toString();
             }
         }
         throw new IllegalArgumentException("invalid type " + this);


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
