### PR TITLE
feat(controller): populate pypi/docker startup envs to system setting

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/StarwhaleControllerApplication.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/StarwhaleControllerApplication.java
@@ -17,6 +17,7 @@
 package ai.starwhale.mlops;
 
 import ai.starwhale.mlops.configuration.ControllerProperties;
+import ai.starwhale.mlops.configuration.DockerSetting;
 import ai.starwhale.mlops.configuration.RunTimeProperties;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -27,7 +28,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableScheduling
 @MapperScan({"ai.starwhale.mlops.domain.**.mapper"})
-@EnableConfigurationProperties({ControllerProperties.class, RunTimeProperties.class})
+@EnableConfigurationProperties({ControllerProperties.class, RunTimeProperties.class, DockerSetting.class})
 public class StarwhaleControllerApplication {
 
     public static void main(String[] args) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/configuration/DockerSetting.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/configuration/DockerSetting.java
@@ -24,24 +24,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@ConfigurationProperties(prefix = "sw.runtime")
-public class RunTimeProperties {
+@ConfigurationProperties(prefix = "sw.docker")
+public class DockerSetting {
 
-    String imageDefault;
-    Pypi pypi;
+    String registry;
 
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class Pypi {
-
-        String indexUrl;
-        String extraIndexUrl;
-        String trustedHost;
-
-        public static Pypi empty() {
-            return new Pypi("", "", "");
-        }
+    public static DockerSetting empty() {
+        return new DockerSetting("");
     }
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/SystemSetting.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/SystemSetting.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.domain.system;
 
+import ai.starwhale.mlops.configuration.DockerSetting;
+import ai.starwhale.mlops.configuration.RunTimeProperties.Pypi;
 import ai.starwhale.mlops.domain.system.resourcepool.bo.ResourcePool;
 import ai.starwhale.mlops.storage.autofit.StorageConnectionToken;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -32,14 +34,10 @@ public class SystemSetting {
 
     DockerSetting dockerSetting;
 
+    Pypi pypiSetting;
+
     List<ResourcePool> resourcePoolSetting;
 
     Set<StorageConnectionToken> storageSetting;
-
-    @Data
-    public static class DockerSetting {
-
-        String registry;
-    }
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/listener/DockerSettingListener.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/listener/DockerSettingListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.system.listener;
+
+import ai.starwhale.mlops.configuration.DockerSetting;
+import ai.starwhale.mlops.domain.system.SystemSetting;
+import ai.starwhale.mlops.domain.system.SystemSettingListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DockerSettingListener implements SystemSettingListener {
+
+    private final DockerSetting dockerSetting;
+
+    public DockerSettingListener(DockerSetting dockerSetting) {
+        this.dockerSetting = dockerSetting;
+    }
+
+    @Override
+    public void onUpdate(SystemSetting systemSetting) {
+        this.dockerSetting.setRegistry(systemSetting.getDockerSetting().getRegistry());
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/listener/RunTimePropertiesListener.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/listener/RunTimePropertiesListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.system.listener;
+
+import ai.starwhale.mlops.configuration.RunTimeProperties;
+import ai.starwhale.mlops.configuration.RunTimeProperties.Pypi;
+import ai.starwhale.mlops.domain.system.SystemSetting;
+import ai.starwhale.mlops.domain.system.SystemSettingListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RunTimePropertiesListener implements SystemSettingListener {
+
+    private final RunTimeProperties runTimeProperties;
+
+    public RunTimePropertiesListener(RunTimeProperties runTimeProperties) {
+        this.runTimeProperties = runTimeProperties;
+    }
+
+    @Override
+    public void onUpdate(SystemSetting systemSetting) {
+        Pypi pypiSetting = systemSetting.getPypiSetting();
+        this.runTimeProperties.setPypi(pypiSetting);
+    }
+}

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
 sw:
   version: ${SW_VERSION_CONTROLLER:0.1.0:8c82767b60686f3e2bfea9dafe8c8cce5dd34f52}
   docker:
-    registry: ${SW_DOCKER_REGISTRY_URL:docker-registry.starwhale.cn}
+    registry: ${SW_DOCKER_REGISTRY_URL:}
   runtime:
     pypi:
       index-url: ${SW_PYPI_INDEX_URL:}

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -12,11 +12,13 @@ spring:
       static-locations: file:/opt/starwhale.java/static/, classpath:/static/
 sw:
   version: ${SW_VERSION_CONTROLLER:0.1.0:8c82767b60686f3e2bfea9dafe8c8cce5dd34f52}
+  docker:
+    registry: ${SW_DOCKER_REGISTRY_URL:docker-registry.starwhale.cn}
   runtime:
     pypi:
-      index-url: ${SW_PYPI_INDEX_URL:}
-      extra-index-url: ${SW_PYPI_EXTRA_INDEX_URL:}
-      trusted-host: ${SW_PYPI_TRUSTED_HOST:}
+      index-url: ${SW_PYPI_INDEX_URL:abcd}
+      extra-index-url: ${SW_PYPI_EXTRA_INDEX_URL:12}
+      trusted-host: ${SW_PYPI_TRUSTED_HOST:c}
   jwt:
     secret: ${SW_JWT_SECRET:wdxlG3UK66m6uTUgxXFjizli}
     issuer: ${SW_JWT_ISSUER:starwhale}

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -16,9 +16,9 @@ sw:
     registry: ${SW_DOCKER_REGISTRY_URL:docker-registry.starwhale.cn}
   runtime:
     pypi:
-      index-url: ${SW_PYPI_INDEX_URL:abcd}
-      extra-index-url: ${SW_PYPI_EXTRA_INDEX_URL:12}
-      trusted-host: ${SW_PYPI_TRUSTED_HOST:c}
+      index-url: ${SW_PYPI_INDEX_URL:}
+      extra-index-url: ${SW_PYPI_EXTRA_INDEX_URL:}
+      trusted-host: ${SW_PYPI_TRUSTED_HOST:}
   jwt:
     secret: ${SW_JWT_SECRET:wdxlG3UK66m6uTUgxXFjizli}
     issuer: ${SW_JWT_ISSUER:starwhale}


### PR DESCRIPTION
## Description
populate pypi/docker startup envs to system setting
- pypi setting in startup env is synced to system setting on startup if user doesn't set them
- system setting have higher priority than startup env
- if user delete them in system setting they will be set to empty and also have higher priority than startup env
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
