### PR TITLE
fix(datastore): lazy to init table name for eval & replace name with id

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -24,7 +24,7 @@ from typing import (
     Iterator,
     Optional,
 )
-from functools import cache
+from functools import lru_cache
 
 import dill
 import numpy as np
@@ -1428,7 +1428,7 @@ def gen_table_name(project: Union[str, int], table: str, instance_uri: str = "")
         )
 
 
-@cache
+@lru_cache(maxsize=None)
 @http_retry
 def _get_remote_project_id(instance_uri: str, project: Union[str, int]) -> Any:
     resp = requests.get(

--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -24,7 +24,6 @@ from typing import (
     Iterator,
     Optional,
 )
-from functools import lru_cache
 
 import dill
 import numpy as np
@@ -1408,42 +1407,6 @@ def get_data_store(instance_uri: str = "", token: str = "") -> DataStore:
             instance_uri=_instance_uri,
             token=token,
         )
-
-
-def table_name_generator(project: Union[str, int], table: str) -> str:
-    return f"project/{project}/{table}"
-
-
-def gen_table_name(project: Union[str, int], table: str, instance_uri: str = "") -> str:
-    _instance_uri = instance_uri or os.getenv(SWEnv.instance_uri)
-    if (
-        _instance_uri is None
-        or _instance_uri == STANDALONE_INSTANCE
-        or type(project) == int
-    ):
-        return table_name_generator(project, table)
-    else:
-        return table_name_generator(
-            _get_remote_project_id(_instance_uri, project), table
-        )
-
-
-@lru_cache(maxsize=None)
-@http_retry
-def _get_remote_project_id(instance_uri: str, project: Union[str, int]) -> Any:
-    resp = requests.get(
-        urllib.parse.urljoin(instance_uri, f"/api/v1/project/{project}"),
-        headers={
-            "Content-Type": "application/json; charset=utf-8",
-            "Authorization": (
-                SWCliConfigMixed().get_sw_token(instance=instance_uri)
-                or os.getenv(SWEnv.instance_token, "")
-            ),
-        },
-        timeout=60,
-    )
-    resp.raise_for_status()
-    return resp.json().get("data", {})["id"]
 
 
 def _flatten(record: Dict[str, Any]) -> Dict[str, Any]:

--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -10,6 +10,7 @@ import binascii
 import importlib
 import threading
 from abc import ABCMeta, abstractmethod
+from functools import cache
 from http import HTTPStatus
 from typing import (
     Any,
@@ -1427,6 +1428,7 @@ def gen_table_name(project: Union[str, int], table: str, instance_uri: str = "")
         )
 
 
+@cache
 @http_retry
 def _get_remote_project_id(instance_uri: str, project: Union[str, int]) -> Any:
     resp = requests.get(

--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -10,7 +10,6 @@ import binascii
 import importlib
 import threading
 from abc import ABCMeta, abstractmethod
-from functools import cache
 from http import HTTPStatus
 from typing import (
     Any,
@@ -25,6 +24,7 @@ from typing import (
     Iterator,
     Optional,
 )
+from functools import cache
 
 import dill
 import numpy as np

--- a/client/starwhale/api/_impl/wrapper.py
+++ b/client/starwhale/api/_impl/wrapper.py
@@ -172,7 +172,7 @@ class Evaluation(Logger):
         return {}
 
     def get(self, table_name: str) -> Iterator[Dict[str, Any]]:
-        return self.get(self._eval_table_name(table_name))
+        return self._get(self._eval_table_name(table_name))
 
     def flush_result(self) -> None:
         self._flush(self._eval_table_name("results"))

--- a/client/starwhale/api/_impl/wrapper.py
+++ b/client/starwhale/api/_impl/wrapper.py
@@ -1,7 +1,7 @@
 import re
 import threading
 from enum import Enum, unique
-from typing import Any, Dict, List, Union, Iterator, Optional
+from typing import Any, Dict, List, Union, Callable, Iterator, Optional
 
 import dill
 from loguru import logger
@@ -86,7 +86,9 @@ class Evaluation(Logger):
         self.project = project
         self.instance = instance
         self._tables: Dict[str, str] = {}
-        self._eval_table_name = (
+        self._eval_table_name: Callable[
+            [str], str
+        ] = (
             lambda name: f"eval/{self.eval_id[:VERSION_PREFIX_CNT]}/{self.eval_id}/{name}"
         )
         self._eval_summary_table_name = "eval/summary"
@@ -95,8 +97,6 @@ class Evaluation(Logger):
 
     def _fetch_table_name(self, table: str) -> str:
         with self._lock:
-            if table not in self._tables:
-                self._tables.setdefault(table)
             _table_name = self._tables.get(table)
             if _table_name is None:
                 _table_name = data_store.gen_table_name(

--- a/client/starwhale/api/_impl/wrapper.py
+++ b/client/starwhale/api/_impl/wrapper.py
@@ -85,12 +85,10 @@ class Evaluation(Logger):
         self.eval_id = eval_id
         self.project = project
         self.instance = instance
-        self._results_table_name = self._get_datastore_table_name("results")
-        self._summary_table_name = data_store.gen_table_name(
-            project=self.project, table="eval/summary", instance_uri=self.instance
-        )
+        self._results_table_name = None
+        self._summary_table_name = None
         self._data_store = data_store.get_data_store(instance_uri=instance)
-        self._init_writers([self._results_table_name, self._summary_table_name])
+        self._init_writers([])
 
     def _get_datastore_table_name(self, name: str) -> str:
         return data_store.gen_table_name(
@@ -109,6 +107,9 @@ class Evaluation(Logger):
         record = {"id": data_id, "result": _serialize(result) if serialize else result}
         for k, v in kwargs.items():
             record[k.lower()] = _serialize(v) if serialize else v
+
+        if not self._results_table_name:
+            self._results_table_name = self._get_datastore_table_name("results")
         self._log(self._results_table_name, record)
 
     def log_metrics(
@@ -124,6 +125,11 @@ class Evaluation(Logger):
         else:
             for k, v in kwargs.items():
                 record[k.lower()] = v
+
+        if not self._summary_table_name:
+            self._summary_table_name = data_store.gen_table_name(
+                project=self.project, table="eval/summary", instance_uri=self.instance
+            )
         self._log(self._summary_table_name, record)
 
     def log(self, table_name: str, **kwargs: Any) -> None:

--- a/client/starwhale/api/_impl/wrapper.py
+++ b/client/starwhale/api/_impl/wrapper.py
@@ -1,14 +1,21 @@
+import os
 import re
+import urllib
 import threading
 from enum import Enum, unique
 from typing import Any, Dict, List, Union, Callable, Iterator, Optional
+from functools import lru_cache
 
 import dill
+import requests
 from loguru import logger
 
-from starwhale.consts import VERSION_PREFIX_CNT
+from starwhale.consts import VERSION_PREFIX_CNT, STANDALONE_INSTANCE
 
 from . import data_store
+from ...consts.env import SWEnv
+from ...utils.retry import http_retry
+from ...utils.config import SWCliConfigMixed
 
 
 class Logger:
@@ -71,6 +78,45 @@ def _deserialize(data: bytes) -> Any:
     return dill.loads(data)
 
 
+table_name_formatter: Callable[
+    [Union[str, int], str], str
+] = lambda project, table: f"project/{project}/{table}"
+
+
+def _gen_storage_table_name(
+    project: Union[str, int], table: str, instance_uri: str = ""
+) -> str:
+    _instance_uri = instance_uri or os.getenv(SWEnv.instance_uri)
+    if (
+        _instance_uri is None
+        or _instance_uri == STANDALONE_INSTANCE
+        or isinstance(project, int)
+    ):
+        return table_name_formatter(project, table)
+    else:
+        return table_name_formatter(
+            _get_remote_project_id(_instance_uri, project), table
+        )
+
+
+@lru_cache(maxsize=None)
+@http_retry
+def _get_remote_project_id(instance_uri: str, project: str) -> Any:
+    resp = requests.get(
+        urllib.parse.urljoin(instance_uri, f"/api/v1/project/{project}"),
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "Authorization": (
+                SWCliConfigMixed().get_sw_token(instance=instance_uri)
+                or os.getenv(SWEnv.instance_token, "")
+            ),
+        },
+        timeout=60,
+    )
+    resp.raise_for_status()
+    return resp.json().get("data", {})["id"]
+
+
 class Evaluation(Logger):
     def __init__(self, eval_id: str, project: str, instance: str = ""):
         if not eval_id:
@@ -99,7 +145,7 @@ class Evaluation(Logger):
         with self._lock:
             _table_name = self._tables.get(table)
             if _table_name is None:
-                _table_name = data_store.gen_table_name(
+                _table_name = _gen_storage_table_name(
                     project=self.project,
                     table=table,
                     instance_uri=self.instance,
@@ -208,7 +254,7 @@ class Dataset(Logger):
         self.dataset_id = dataset_id
         self.project = project
         self._kind = kind
-        self._table_name = data_store.gen_table_name(
+        self._table_name = _gen_storage_table_name(
             project=project,
             table=f"dataset/{self.dataset_id}/{kind.value}",
             instance_uri=instance_name,

--- a/client/tests/sdk/test_data_store.py
+++ b/client/tests/sdk/test_data_store.py
@@ -2382,25 +2382,6 @@ class TestRemoteDataStore(unittest.TestCase):
             timeout=60,
         )
 
-    @patch("starwhale.api._impl.data_store.requests.get")
-    def test_gen_table_name(self, mock_get: Mock) -> None:
-        table_name = data_store.gen_table_name(project="starwhale", table="test")
-        assert table_name == "project/starwhale/test"
-
-        instance_uri = "http://1.1.1.1:8182"
-        data_store.gen_table_name(
-            project="starwhale", table="test", instance_uri=instance_uri
-        )
-
-        mock_get.assert_called_with(
-            f"{instance_uri}/api/v1/project/starwhale",
-            headers={
-                "Content-Type": "application/json; charset=utf-8",
-                "Authorization": "",
-            },
-            timeout=60,
-        )
-
 
 class TestTableWriter(BaseTestCase):
     def setUp(self) -> None:

--- a/client/tests/sdk/test_wrapper.py
+++ b/client/tests/sdk/test_wrapper.py
@@ -33,7 +33,7 @@ class TestEvaluation(BaseTestCase):
         result_table_name = eval._eval_table_name("results")
         assert result_table_name == "eval/12/123456/results"
 
-        table_name_1 = eval._fetch_table_name("table-1")
+        table_name_1 = eval._get_storage_table_name("table-1")
         assert table_name_1 == "project/project-test/table-1"
 
         eval = wrapper.Evaluation(
@@ -41,11 +41,11 @@ class TestEvaluation(BaseTestCase):
         )
 
         result_table = eval._eval_table_name("results")
-        result_table_name = eval._fetch_table_name(result_table)
+        result_table_name = eval._get_storage_table_name(result_table)
         assert result_table == "eval/12/123456/results"
         assert result_table_name == "project/1/eval/12/123456/results"
 
-        table_name_1 = eval._fetch_table_name("table-1")
+        table_name_1 = eval._get_storage_table_name("table-1")
         assert table_name_1 == "project/1/table-1"
 
     def test_log_results_and_scan(self) -> None:

--- a/client/tests/sdk/test_wrapper.py
+++ b/client/tests/sdk/test_wrapper.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 from requests_mock import Mocker
 
@@ -9,6 +10,7 @@ from starwhale.consts.env import SWEnv
 from .test_base import BaseTestCase
 
 
+@patch.dict(os.environ, {"SW_TOKEN": "sw_token"})
 class TestEvaluation(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -17,6 +19,34 @@ class TestEvaluation(BaseTestCase):
         super().tearDown()
         os.environ.pop(SWEnv.instance_uri, None)
         os.environ.pop(SWEnv.instance_token, None)
+
+    @Mocker()
+    def test_gen_table_name(self, request_mock: Mocker) -> None:
+        request_mock.request(
+            HTTPMethod.GET,
+            "http://localhost:80/api/v1/project/project-test",
+            json={"data": {"id": 1, "name": "project-test"}},
+        )
+
+        eval = wrapper.Evaluation("123456", "project-test", instance="local")
+
+        result_table_name = eval._eval_table_name("results")
+        assert result_table_name == "eval/12/123456/results"
+
+        table_name_1 = eval._fetch_table_name("table-1")
+        assert table_name_1 == "project/project-test/table-1"
+
+        eval = wrapper.Evaluation(
+            "123456", "project-test", instance="http://localhost:80"
+        )
+
+        result_table = eval._eval_table_name("results")
+        result_table_name = eval._fetch_table_name(result_table)
+        assert result_table == "eval/12/123456/results"
+        assert result_table_name == "project/1/eval/12/123456/results"
+
+        table_name_1 = eval._fetch_table_name("table-1")
+        assert table_name_1 == "project/1/table-1"
 
     def test_log_results_and_scan(self) -> None:
         eval = wrapper.Evaluation("tt", "test")

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/storage/JobRepo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/storage/JobRepo.java
@@ -97,22 +97,22 @@ public class JobRepo {
     private List<String> tableNames() {
         var projects = projectMapper.list(null, null, null);
         return projects.stream()
-            .map(ProjectEntity::getProjectName)
+            .map(ProjectEntity::getId)
             .map(this::tableName)
             .collect(Collectors.toList());
     }
 
-    private String tableName(String projectName) {
+    private String tableName(Long projectId) {
         /*
          * such as project/starwhale/eval/summary
          */
         String tableNameFormat = "project/%s/eval/summary";
-        return String.format(tableNameFormat, projectName);
+        return String.format(tableNameFormat, projectId);
     }
 
     public int addJob(JobFlattenEntity jobEntity) {
         store.update(
-                this.tableName(jobEntity.getProject().getProjectName()),
+                this.tableName(jobEntity.getProject().getId()),
                 tableSchemaDesc,
                 List.of(convertToRecord(jobEntity))
         );
@@ -265,7 +265,7 @@ public class JobRepo {
     private List<JobFlattenEntity> getJobEntities(ProjectEntity project, TableQueryFilter filter) {
         var results = new ArrayList<JobFlattenEntity>();
 
-        var table = this.tableName(project.getProjectName());
+        var table = this.tableName(project.getId());
         var it = new Iterator<List<JobFlattenEntity>>() {
             boolean finished = false;
             final DataStoreQueryRequest request = DataStoreQueryRequest.builder()
@@ -314,7 +314,7 @@ public class JobRepo {
         if (Objects.isNull(job)) {
             return;
         }
-        this.updateByUuid(this.tableName(job.getProject().getProjectName()),
+        this.updateByUuid(this.tableName(job.getProject().getId()),
                 job.getJobUuid(), JobStatusColumn, STRING, jobStatus.name());
     }
 
@@ -323,7 +323,7 @@ public class JobRepo {
         if (Objects.isNull(job)) {
             return;
         }
-        this.updateByUuid(this.tableName(job.getProject().getProjectName()),
+        this.updateByUuid(this.tableName(job.getProject().getId()),
                 job.getJobUuid(), FinishTimeColumn, INT64,
                 (String) ColumnTypeScalar.INT64.encode(finishedTime.getTime(), false));
     }
@@ -333,7 +333,7 @@ public class JobRepo {
         if (Objects.isNull(job)) {
             return 0;
         }
-        return this.updateByUuid(this.tableName(job.getProject().getProjectName()),
+        return this.updateByUuid(this.tableName(job.getProject().getId()),
                 job.getJobUuid(), CommentColumn, STRING, comment);
     }
 
@@ -342,7 +342,7 @@ public class JobRepo {
         if (Objects.isNull(job)) {
             return 0;
         }
-        return this.updateByUuid(this.tableName(job.getProject().getProjectName()),
+        return this.updateByUuid(this.tableName(job.getProject().getId()),
                 uuid, CommentColumn, STRING, comment);
     }
 
@@ -351,7 +351,7 @@ public class JobRepo {
         if (Objects.isNull(job)) {
             return 0;
         }
-        return this.updateByUuid(this.tableName(job.getProject().getProjectName()),
+        return this.updateByUuid(this.tableName(job.getProject().getId()),
                 job.getJobUuid(), IsDeletedColumn, INT32, "1");
     }
 
@@ -360,7 +360,7 @@ public class JobRepo {
         if (Objects.isNull(job)) {
             return 0;
         }
-        return this.updateByUuid(this.tableName(job.getProject().getProjectName()),
+        return this.updateByUuid(this.tableName(job.getProject().getId()),
                 uuid, IsDeletedColumn, INT32, "1");
     }
 
@@ -369,7 +369,7 @@ public class JobRepo {
         if (Objects.isNull(job)) {
             return 0;
         }
-        return this.updateByUuid(this.tableName(job.getProject().getProjectName()),
+        return this.updateByUuid(this.tableName(job.getProject().getId()),
                 job.getJobUuid(), IsDeletedColumn, INT32, "0");
     }
 
@@ -378,7 +378,7 @@ public class JobRepo {
         if (Objects.isNull(job)) {
             return 0;
         }
-        return this.updateByUuid(this.tableName(job.getProject().getProjectName()),
+        return this.updateByUuid(this.tableName(job.getProject().getId()),
                 uuid, IsDeletedColumn, INT32, "0");
     }
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/storage/JobRepoTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/storage/JobRepoTest.java
@@ -81,7 +81,7 @@ public class JobRepoTest {
     @Test
     public void testAddJob() {
         Mockito.when(projectMapper.find(1L))
-                .thenReturn(ProjectEntity.builder().projectName("test-project").build());
+                .thenReturn(ProjectEntity.builder().id(1L).projectName("test-project").build());
 
         JobFlattenEntity jobEntity = JobFlattenEntity.builder()
                 .id(1L)
@@ -108,7 +108,7 @@ public class JobRepoTest {
         jobRepo.addJob(jobEntity);
 
         verify(dataStore, times(1))
-                .update(eq("project/test-project/eval/summary"), any(), anyList());
+                .update(eq("project/1/eval/summary"), any(), anyList());
 
         assertThat("convert",
                 jobRepo.convertToDatastoreValue(jobEntity.getDatasetIdVersionMap()),
@@ -119,7 +119,7 @@ public class JobRepoTest {
     @Test
     public void testListJobs() {
         Mockito.when(projectMapper.find(1L))
-                .thenReturn(ProjectEntity.builder().projectName("test-project").build());
+                .thenReturn(ProjectEntity.builder().id(1L).projectName("test-project").build());
         Mockito.when(modelVersionMapper.findByNameAndModelId(any(), any()))
                 .thenReturn(ModelVersionEntity.builder().id(1L).versionName("1z2x3c4v5b6n").build());
 
@@ -155,7 +155,7 @@ public class JobRepoTest {
     @Test
     public void testFindByStatusIn() {
         Mockito.when(projectMapper.list(null, null, null))
-                .thenReturn(List.of(ProjectEntity.builder().projectName("test-project").build()));
+                .thenReturn(List.of(ProjectEntity.builder().id(1L).projectName("test-project").build()));
         Mockito.when(modelVersionMapper.findByNameAndModelId(any(), any()))
                 .thenReturn(ModelVersionEntity.builder().id(1L).versionName("1z2x3c4v5b6n").build());
 
@@ -198,12 +198,12 @@ public class JobRepoTest {
         Mockito.when(jobMapper.findJobById(jobId)).thenReturn(JobEntity.builder()
                 .id(jobId)
                 .jobUuid("1q2w3e4r5t6y")
-                .project(ProjectEntity.builder().projectName("test-project").build())
+                .project(ProjectEntity.builder().id(1L).projectName("test-project").build())
                 .build()
         );
 
         jobRepo.updateJobStatus(jobId, JobStatus.SUCCESS);
         verify(dataStore, times(1))
-                .update(eq("project/test-project/eval/summary"), any(), anyList());
+                .update(eq("project/1/eval/summary"), any(), anyList());
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/storage/JobRepoTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/storage/JobRepoTest.java
@@ -27,12 +27,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import ai.starwhale.mlops.datastore.DataStore;
+import ai.starwhale.mlops.datastore.DataStoreQueryRequest;
 import ai.starwhale.mlops.datastore.RecordList;
 import ai.starwhale.mlops.domain.job.JobType;
 import ai.starwhale.mlops.domain.job.mapper.JobMapper;
@@ -148,7 +150,8 @@ public class JobRepoTest {
 
         List<JobFlattenEntity> jobEntities = jobRepo.listJobs(1L, null);
         Assertions.assertEquals(2, jobEntities.size());
-        Mockito.verify(dataStore, times(2)).query(any());
+        Mockito.verify(dataStore, times(2)).query(
+                argThat((DataStoreQueryRequest request) -> request.getTableName().equals("project/1/eval/summary")));
         jobEntities.forEach(job -> Assertions.assertEquals(job.getJobStatus(), JobStatus.RUNNING));
     }
 
@@ -184,7 +187,8 @@ public class JobRepoTest {
 
         List<JobFlattenEntity> jobEntities = jobRepo.findJobByStatusIn(List.of(JobStatus.PAUSED));
         Assertions.assertEquals(2, jobEntities.size());
-        Mockito.verify(dataStore, times(2)).query(any());
+        Mockito.verify(dataStore, times(2)).query(
+                argThat((DataStoreQueryRequest request) -> request.getTableName().equals("project/1/eval/summary")));
         jobEntities.forEach(job -> Assertions.assertEquals(job.getJobStatus(), JobStatus.RUNNING));
     }
 


### PR DESCRIPTION
## Description

1. lazy to init table name for eval on the client
2. fix bug: replace name with id for eval summary table name 

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
