### PR TITLE
fix(client): do not wait for stdin so that the remote side can stop immediately when the command quits

### DIFF
--- a/client/starwhale/cli/assistance/remote.py
+++ b/client/starwhale/cli/assistance/remote.py
@@ -79,9 +79,6 @@ class CommandRunner(TaskRunner):
                 while not self.stopped and stderr_writer.is_alive():
                     stderr_writer.join(0.5)
         finally:
-            if stdin_reader is not None:
-                stdin_reader.stop()
-                stdin_reader.join()
             if stdin_writer is not None:
                 stdin_writer.stop()
                 stdin_writer.join()


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [X] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
