### PR TITLE
chore(doc): publish build files into subdir to avoid empty .archived_versions dir

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -84,6 +84,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build
+          destination_dir: ./publish
           user_name: github-actions[bot]
           cname: doc.starwhale.ai
           user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Description
the `.archived_versions` will be empty by the `gh-pages` action by default.

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
