### PR TITLE
chore(doc): add a temp flag to keep the first archived versions dir

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -84,6 +84,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build
+          # when https://github.com/star-whale/starwhale/pull/1862 pr is merged, we could delete the keep_files flag.
+          keep_files: true
           user_name: github-actions[bot]
           cname: doc.starwhale.ai
           user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Description
when  the [pr](https://github.com/star-whale/starwhale/pull/1862) is merged, we could delete the keep_files flag.

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
