### PR TITLE
chore(e2e): enlarge pip timeout in e2e runtime

### DIFF
--- a/docker/external/config-e2e-pypi-repo.sh
+++ b/docker/external/config-e2e-pypi-repo.sh
@@ -10,6 +10,7 @@ if [ "$1" = "1" ] ; then
     echo "overwrite pip config..."
     mkdir /root/.pip
     echo "[global]
+timeout = 600
 index-url=http://$2:$3/repository/pypi-hosted/simple
 extra-index-url=$4
 

--- a/scripts/publish/pub.sh
+++ b/scripts/publish/pub.sh
@@ -149,6 +149,7 @@ EOF
 
     cat >$HOME/.pip/pip.conf <<EOF
 [global]
+timeout = 600
 index-url=http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple
 extra-index-url=$SW_PYPI_EXTRA_INDEX_URL
 


### PR DESCRIPTION
## Description
enlarge pip timeout in e2e runtime
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
