### PR TITLE
fix(controller): explicitlly set charset of offline log

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/TaskService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/TaskService.java
@@ -32,6 +32,7 @@ import com.github.pagehelper.PageHelper;
 import com.github.pagehelper.PageInfo;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -89,7 +90,7 @@ public class TaskService {
         String logDir = resultPath.logDir();
         try (InputStream inputStream = storageAccessService.get(
                 logDir + PATH_SPLITERATOR + logFileName)) {
-            return new String(inputStream.readAllBytes());
+            return new String(inputStream.readAllBytes(), Charset.forName("UTF-8"));
         } catch (IOException e) {
             throw new SwProcessException(ErrorType.DB,
                     MessageFormat.format("read log path from db failed {}", taskId),


### PR DESCRIPTION
## Description
explicitlly set charset of offline log
![image](https://user-images.githubusercontent.com/89630947/220539246-7bd5d3f3-d61c-4d02-a295-18f13790a3c5.png)

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
