### PR TITLE
fix(controller): job status is  still fail after resuming job

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
@@ -51,12 +51,11 @@ public class JobLoader {
 
     public Job load(@NotNull Job job, Boolean resumePausedOrFailTasks) {
         job.getSteps().forEach(step -> {
-            List<Task> tasks = step.getTasks();
-            if (resumePausedOrFailTasks) {
-                resumeFrozenTasks(tasks);
-            }
-            List<Task> watchableTasks = watchableTaskFactory.wrapTasks(tasks);
+            List<Task> watchableTasks = watchableTaskFactory.wrapTasks(step.getTasks());
             step.setTasks(watchableTasks);
+            if (resumePausedOrFailTasks) {
+                resumeFrozenTasks(watchableTasks);
+            }
             scheduleReadyTasks(watchableTasks.parallelStream()
                     .filter(t -> t.getStatus() == TaskStatus.READY)
                     .collect(Collectors.toSet()));

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
@@ -51,6 +51,7 @@ public class JobLoader {
     }
 
     public Job load(@NotNull Job job, Boolean resumePausedOrFailTasks) {
+        jobHolder.adopt(job);
         job.getSteps().forEach(step -> {
             List<Task> watchableTasks = watchableTaskFactory.wrapTasks(step.getTasks());
             step.setTasks(watchableTasks);
@@ -61,7 +62,6 @@ public class JobLoader {
                     .filter(t -> t.getStatus() == TaskStatus.READY)
                     .collect(Collectors.toSet()));
         });
-        jobHolder.adopt(job);
         return job;
 
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
@@ -19,6 +19,7 @@ package ai.starwhale.mlops.domain.job.cache;
 import ai.starwhale.mlops.domain.job.bo.Job;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
+import ai.starwhale.mlops.domain.task.status.WatchableTask;
 import ai.starwhale.mlops.domain.task.status.WatchableTaskFactory;
 import ai.starwhale.mlops.schedule.SwTaskScheduler;
 import java.util.Collection;
@@ -69,7 +70,11 @@ public class JobLoader {
         tasks.parallelStream().filter(t -> t.getStatus() == TaskStatus.PAUSED
                         || t.getStatus() == TaskStatus.FAIL
                         || t.getStatus() == TaskStatus.CANCELED)
-                .forEach(t -> t.updateStatus(TaskStatus.READY));
+                .forEach(t -> {
+                    // FAIL -> ready is forbidden by status machine, so make it to CREATED at first
+                    ((WatchableTask) t).unwrap().updateStatus(TaskStatus.CREATED);
+                    t.updateStatus(TaskStatus.READY);
+                });
     }
 
     /**

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForJobStatus.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForJobStatus.java
@@ -84,7 +84,6 @@ public class TaskWatcherForJobStatus implements TaskStatusChangeWatcher {
             if (!stepStatusMachine.couldTransfer(step.getStatus(), stepNewStatus)) {
                 log.warn("step status change unexpectedly from {} to {} of id {} forbidden", step.getStatus(),
                         stepNewStatus, step.getId());
-                return;
             }
             updateStepStatus(step, stepNewStatus);
             jobUpdateHelper.updateJob(job);

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
@@ -71,7 +71,7 @@ public class JobLoaderTest {
         jobLoader.load(mockJob, false);
         verify(jobHolder, times(1)).adopt(mockJob);
         verify(watchableTaskFactory, times(mockJob.getSteps().size())).wrapTasks(anyCollection());
-        verify(swTaskScheduler, times(mockJob.getSteps().size())).schedule(Set.of(readyTask));
+        verify(swTaskScheduler).schedule(Set.of(readyTask));
         verify(failedTask, times(0)).updateStatus(TaskStatus.READY);
     }
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
@@ -28,6 +28,7 @@ import ai.starwhale.mlops.domain.job.cache.HotJobHolder;
 import ai.starwhale.mlops.domain.job.cache.JobLoader;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
+import ai.starwhale.mlops.domain.task.status.WatchableTask;
 import ai.starwhale.mlops.domain.task.status.WatchableTaskFactory;
 import ai.starwhale.mlops.schedule.SwTaskScheduler;
 import java.util.List;
@@ -76,11 +77,12 @@ public class JobLoaderTest {
 
     @Test
     public void testJobLoaderResume() {
-        Task mockTask = mock(Task.class);
-        when(mockTask.getStatus()).thenReturn(TaskStatus.FAIL);
-        mockJob.getSteps().get(0).getTasks().add(mockTask);
+        WatchableTask failedTask = mock(WatchableTask.class);
+        when(failedTask.getStatus()).thenReturn(TaskStatus.FAIL);
+        when(failedTask.unwrap()).thenReturn(new Task());
+        when(watchableTaskFactory.wrapTasks(anyCollection())).thenReturn(List.of(failedTask));
         jobLoader.load(mockJob, true);
-        verify(mockTask).updateStatus(TaskStatus.READY);
-        verify(jobHolder, times(1)).adopt(mockJob);
+        verify(failedTask, times(mockJob.getSteps().size())).updateStatus(TaskStatus.READY);
+        verify(jobHolder).adopt(mockJob);
     }
 }


### PR DESCRIPTION
## Bug Description
1. job status is  still fail after resuming job
2. cmp step could not be triggered after resumed ppl success
## verification 
http://e2e-20230221.pre.intra.starwhale.ai/projects/1/evaluations/9/results

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
