### PR TITLE
chore(charts): refactor helm values for the hostpath pv

### DIFF
--- a/docker/charts/templates/controller-deployment.yaml
+++ b/docker/charts/templates/controller-deployment.yaml
@@ -12,11 +12,13 @@ spec:
     metadata:
       labels: {{ include "chart.controller.labels" . | nindent 8}}
     spec:
+      {{- if .Values.devMode.createConsoleHostPathVolume.enabled }}
       volumes:
-        - name: controller-storage
+        - name: console-hostpath-volume
           hostPath:
-            path: {{ .Values.storage.agentHostPathRoot }}/controller
+            path: {{ .Values.devMode.createConsoleHostPathVolume.rootPath }}/controller/console
             type: DirectoryOrCreate
+      {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       {{- else }}
@@ -27,10 +29,11 @@ spec:
           image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.server.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           ports:
             - containerPort: {{ .Values.controller.containerPort }}
+          {{- if .Values.devMode.createConsoleHostPathVolume.enabled }}
           volumeMounts:
-            - name: controller-storage
+            - name: console-hostpath-volume
               mountPath: "/opt/starwhale.java/static"
-              subPath: static
+          {{- end }}
           {{- if not .Values.minikube.enabled }}
           resources:
             {{- toYaml .Values.resources.controller | nindent 12}}
@@ -88,7 +91,7 @@ spec:
             - name: SW_K8S_NAME_SPACE
               value: {{ .Release.Namespace }}
             - name: SW_K8S_HOST_PATH_FOR_CACHE
-              value: {{ .Values.storage.agentHostPathRoot }}/job
+              value: {{ .Values.controller.job.cacheDirHostPath }}/job
             - name: SW_INSTANCE_URI
               value: "http://controller:{{ .Values.controller.containerPort }}"
             {{- if .Values.minio.enabled }}

--- a/docker/charts/values.yaml
+++ b/docker/charts/values.yaml
@@ -82,9 +82,8 @@ controller:
     ingressClassName: nginx
     host: console.pre.intra.starwhale.ai
     path: /
-
-storage:
-  agentHostPathRoot: "/mnt/data/starwhale"
+  job:
+    cacheDirHostPath: /mnt/data/starwhale
 
 nodeSelector:
   controller: {}
@@ -130,4 +129,8 @@ devMode:
     # Node selector matchExpressions in kubernetes.io/hostname
     host: ""
     # Local path for test PV
+    rootPath: /var/starwhale
+  # For console debugging with hostPath volume
+  createConsoleHostPathVolume:
+    enabled: false
     rootPath: /var/starwhale


### PR DESCRIPTION
## Description
- remove the outdated `agentHostPathRoot` description
- provide `devMode.createConsoleHostPathPV` fields to config console debug volume
- provide `controller.job.cacheDirHostPath` field to describe job pod cache volume

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
