### PR TITLE
chore(controller): use version name of resource instead of using version id

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
@@ -272,8 +272,8 @@ public class ModelServingService {
         var md = modelMapper.find(model.getModelId());
 
         var envs = Map.of(
-                "SW_RUNTIME_VERSION", String.format("%s/version/%s", rt.getRuntimeName(), runtime.getId()),
-                "SW_MODEL_VERSION", String.format("%s/version/%s", md.getModelName(), model.getId()),
+                "SW_RUNTIME_VERSION", String.format("%s/version/%s", rt.getRuntimeName(), runtime.getVersionName()),
+                "SW_MODEL_VERSION", String.format("%s/version/%s", md.getModelName(), model.getVersionName()),
                 "SW_INSTANCE_URI", instanceUri,
                 "SW_TOKEN", modelServingTokenValidator.getToken(owner, id),
                 "SW_PROJECT", project,

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -141,9 +141,9 @@ public class ModelServingServiceTest {
                 .resourcePool(resourcePool)
                 .build();
         when(modelServingMapper.list(2L, 9L, 8L, resourcePool)).thenReturn(List.of(entity));
-        var runtimeVer = RuntimeVersionEntity.builder().id(8L).image("img").build();
+        var runtimeVer = RuntimeVersionEntity.builder().id(8L).versionName("rt-8").image("img").build();
         when(runtimeDao.getRuntimeVersion("8")).thenReturn(runtimeVer);
-        var modelVer = ModelVersionEntity.builder().id(9L).build();
+        var modelVer = ModelVersionEntity.builder().id(9L).versionName("mp-9").build();
         when(modelDao.getModelVersion("9")).thenReturn(modelVer);
         when(systemSettingService.queryResourcePool("default")).thenReturn(
                 ResourcePool.builder().nodeSelector(Map.of("foo", "bar")).build());
@@ -168,8 +168,8 @@ public class ModelServingServiceTest {
                 "SW_PROJECT", "2",
                 "SW_TOKEN", "token",
                 "SW_INSTANCE_URI", "inst",
-                "SW_MODEL_VERSION", "md/version/9",
-                "SW_RUNTIME_VERSION", "rt/version/8",
+                "SW_MODEL_VERSION", "md/version/mp-9",
+                "SW_RUNTIME_VERSION", "rt/version/rt-8",
                 "SW_MODEL_SERVING_BASE_URI", "/gateway/model-serving/7",
                 "SW_PRODUCTION", "1"
         );


### PR DESCRIPTION
## Description

swcli can not find xxx/version/id after #1870  merged
use the version name instead.

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
