### PR TITLE
chore(controller): resolve docker image without registry

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
@@ -73,6 +73,9 @@ public class DockerImage {
         if (!StringUtils.hasText(newRegistry)) {
             newRegistry = this.registry;
         }
+        if (!StringUtils.hasText(newRegistry)) {
+            return image;
+        }
         return StringUtils.trimTrailingCharacter(newRegistry, '/') + SLASH + image;
     }
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/DockerImageTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/DockerImageTest.java
@@ -165,4 +165,8 @@ public class DockerImageTest {
 
     }
 
+    @Test
+    public void resolveWithoutRegistry() {
+        Assertions.assertEquals("starwhale:latest", new DockerImage("starwhale:latest").resolve(""));
+    }
 }


### PR DESCRIPTION
## Description

Before:  resolve "starwhale:latest" without any system settings of docker registry will get "/starwhale:latest"
After: "starwhale:latest" => "starwhale:latest"

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
