### PR TITLE
chore(controller): validate and patch runtime resource when eval

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeResource.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeResource.java
@@ -23,7 +23,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 public class RuntimeResource {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/resourcepool/bo/Resource.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/resourcepool/bo/Resource.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.domain.system.resourcepool.bo;
 
+import ai.starwhale.mlops.domain.runtime.RuntimeResource;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -32,5 +33,30 @@ public class Resource {
 
     public Resource(String name) {
         this.name = name;
+    }
+
+    public void validate(RuntimeResource runtimeResource) {
+        if (runtimeResource == null) {
+            return;
+        }
+        var req = runtimeResource.getRequest();
+        if (req == null) {
+            return;
+        }
+        if (max != null && req > max) {
+            throw new IllegalArgumentException(String.format("request value is too large, max is %.1f", max));
+        }
+        if (min != null && req < min) {
+            throw new IllegalArgumentException(String.format("value is too small, min is %.1f", min));
+        }
+    }
+
+    public void patch(RuntimeResource runtimeResource) {
+        if (runtimeResource == null) {
+            return;
+        }
+        if (runtimeResource.getRequest() == null) {
+            runtimeResource.setRequest(defaults);
+        }
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/WatchableTask.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/WatchableTask.java
@@ -25,7 +25,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * make task status change watchalbe
+ * make task status change watchable
  */
 @Slf4j
 public class WatchableTask extends Task implements TaskWrapper {

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sTaskScheduler.java
@@ -174,6 +174,10 @@ public class K8sTaskScheduler implements SwTaskScheduler {
 
     private ResourceOverwriteSpec getResourceSpec(Task task) {
         List<RuntimeResource> runtimeResources = task.getTaskRequest().getRuntimeResources();
+        var pool = task.getStep().getJob().getResourcePool();
+        if (pool != null) {
+            runtimeResources = pool.patchResources(runtimeResources);
+        }
         if (!CollectionUtils.isEmpty(runtimeResources)) {
             return new ResourceOverwriteSpec(runtimeResources);
         }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/ResourceOverwriteSpec.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/ResourceOverwriteSpec.java
@@ -44,7 +44,7 @@ public class ResourceOverwriteSpec {
 
     static final String RESOURCE_GPU = "nvidia.com/gpu";
 
-    public static Set<String> SUPPORTED_DEVICES = Set.of(RESOURCE_CPU, RESOURCE_GPU);
+    public static Set<String> SUPPORTED_DEVICES = Set.of(RESOURCE_CPU, RESOURCE_GPU, RESOURCE_MEMORY);
 
     private Float normalizeNonK8sResources(Float amount) {
         return (float) Math.ceil(amount);
@@ -52,12 +52,14 @@ public class ResourceOverwriteSpec {
 
     public ResourceOverwriteSpec(List<RuntimeResource> runtimeResources) {
         Map<String, Quantity> resourceRequestMap = runtimeResources.stream()
+                .filter(runtimeResource -> runtimeResource.getRequest() != null)
                 .collect(Collectors.toMap(
                     RuntimeResource::getType,
                     runtimeResource -> convertToQuantity(runtimeResource.getType(), runtimeResource.getRequest())
                 ));
         this.resourceSelector = new V1ResourceRequirements().requests(resourceRequestMap);
         Map<String, Quantity> resourceLimitMap = runtimeResources.stream()
+                .filter(runtimeResource -> runtimeResource.getLimit() != null)
                 .collect(Collectors.toMap(
                     RuntimeResource::getType,
                     runtimeResource -> convertToQuantity(runtimeResource.getType(), runtimeResource.getLimit())

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobServiceTest.java
@@ -44,6 +44,7 @@ import ai.starwhale.mlops.domain.job.cache.JobLoader;
 import ai.starwhale.mlops.domain.job.converter.JobBoConverter;
 import ai.starwhale.mlops.domain.job.converter.JobConverter;
 import ai.starwhale.mlops.domain.job.po.JobFlattenEntity;
+import ai.starwhale.mlops.domain.job.spec.JobSpecParser;
 import ai.starwhale.mlops.domain.job.split.JobSpliterator;
 import ai.starwhale.mlops.domain.job.status.JobStatus;
 import ai.starwhale.mlops.domain.job.status.JobUpdateHelper;
@@ -57,6 +58,7 @@ import ai.starwhale.mlops.domain.runtime.RuntimeService;
 import ai.starwhale.mlops.domain.runtime.bo.Runtime;
 import ai.starwhale.mlops.domain.runtime.bo.RuntimeVersion;
 import ai.starwhale.mlops.domain.storage.StoragePathCoordinator;
+import ai.starwhale.mlops.domain.system.SystemSettingService;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.mapper.TaskMapper;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
@@ -89,6 +91,8 @@ public class JobServiceTest {
     private DatasetService datasetService;
     private RuntimeService runtimeService;
     private TrashService trashService;
+    private SystemSettingService systemSettingService;
+    private JobSpecParser jobSpecParser;
 
     @BeforeEach
     public void setUp() {
@@ -116,12 +120,14 @@ public class JobServiceTest {
         datasetService = mock(DatasetService.class);
         runtimeService = mock(RuntimeService.class);
         trashService = mock(TrashService.class);
+        systemSettingService = mock(SystemSettingService.class);
+        jobSpecParser = mock(JobSpecParser.class);
 
         service = new JobService(
                 taskMapper, jobConverter, jobBoConverter, runtimeService, jobSpliterator,
                 hotJobHolder, projectService, jobDao, jobLoader, modelService,
                 resultQuerier, datasetService, storagePathCoordinator, userService, mock(JobUpdateHelper.class),
-                trashService);
+                trashService, systemSettingService, jobSpecParser);
     }
 
     @Test

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -153,7 +153,7 @@ public class ModelServingServiceTest {
 
         var spec = "---\n"
                 + "resources:\n"
-                + "- type: \"foo\"\n"
+                + "- type: \"cpu\"\n"
                 + "  request: 7.0\n"
                 + "  limit: 8.0\n";
 
@@ -162,7 +162,7 @@ public class ModelServingServiceTest {
         when(k8sClient.deployStatefulSet(any())).thenReturn(ss);
         svc.create("2", "9", "8", resourcePool, spec);
 
-        var rc = RuntimeResource.builder().type("foo").request(7f).limit(8f).build();
+        var rc = RuntimeResource.builder().type("cpu").request(7f).limit(8f).build();
         var expectedResource = new ResourceOverwriteSpec(List.of(rc));
         var expectedEnvs = Map.of(
                 "SW_PYPI_TRUSTED_HOST", "trusted-host",

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/system/resourcepool/bo/ResourcePoolTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/system/resourcepool/bo/ResourcePoolTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.system.resourcepool.bo;
+
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.starwhale.mlops.domain.runtime.RuntimeResource;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ResourcePoolTest {
+    private ResourcePool resourcePool;
+
+    @BeforeEach
+    void setUp() {
+        var resources = List.of(new Resource("cpu", 3f, 1f, 2f), new Resource("memory", 7f, 5f, 6f));
+        resourcePool = ResourcePool.builder().resources(resources).build();
+    }
+
+    @Test
+    void validateResources() {
+        var rr = RuntimeResource.builder().type("cpu").request(2f).build();
+        resourcePool.validateResource(rr);
+
+        // cpu more than max
+        rr.setRequest(4f);
+        assertThrows(IllegalArgumentException.class, () -> resourcePool.validateResource(rr));
+        // cpu less than min
+        rr.setRequest(0f);
+        assertThrows(IllegalArgumentException.class, () -> resourcePool.validateResource(rr));
+
+        rr.setType("memory");
+        rr.setRequest(6f);
+        resourcePool.validateResource(rr);
+
+        // memory more than max
+        rr.setRequest(8f);
+        assertThrows(IllegalArgumentException.class, () -> resourcePool.validateResource(rr));
+        // memory less than min
+        rr.setRequest(4f);
+        assertThrows(IllegalArgumentException.class, () -> resourcePool.validateResource(rr));
+
+        // unsupported resource type
+        rr.setType("foo");
+        assertThrows(IllegalArgumentException.class, () -> resourcePool.validateResource(rr));
+        rr.setType("gpu");
+        assertThrows(IllegalArgumentException.class, () -> resourcePool.validateResource(rr));
+    }
+
+    @Test
+    void patchResources() {
+        var rr = RuntimeResource.builder().type("cpu").request(2f).build();
+        var resources = List.of(rr);
+
+        // request set (what ever it is) should not be patched
+        var ret = resourcePool.patchResources(resources);
+        Assertions.assertEquals(List.of(RuntimeResource.builder().type("cpu").request(2f).build(),
+                RuntimeResource.builder().type("memory").request(6f).build()), ret);
+        rr.setRequest(4f);
+        ret = resourcePool.patchResources(resources);
+        Assertions.assertEquals(List.of(RuntimeResource.builder().type("cpu").request(4f).build(),
+                RuntimeResource.builder().type("memory").request(6f).build()), ret);
+
+        // request not set should be patched with default value
+        rr.setRequest(null);
+        ret = resourcePool.patchResources(resources);
+        Assertions.assertNull(rr.getRequest());
+        Assertions.assertEquals(List.of(RuntimeResource.builder().type("cpu").request(2f).build(),
+                RuntimeResource.builder().type("memory").request(6f).build()), ret);
+
+        // null resources
+        ret = resourcePool.patchResources(null);
+        Assertions.assertEquals(List.of(RuntimeResource.builder().type("cpu").request(2f).build(),
+                RuntimeResource.builder().type("memory").request(6f).build()), ret);
+
+        // no default value in the resource pool settings
+        resourcePool = ResourcePool.builder().resources(List.of(new Resource("cpu"))).build();
+        ret = resourcePool.patchResources(null);
+        Assertions.assertTrue(ret.isEmpty());
+    }
+}


### PR DESCRIPTION
## Description

- Eval and Online Eval
  - Validate resources when creating
  - Use the default value in the corresponding resource pool as the default if no resource is specified
- Online Eval
  - Use the `default` resource pool if no resource pool is specified (server side) 

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
