### PR TITLE
chore(client): show console url of the remote bundle after copy done

### DIFF
--- a/client/starwhale/base/uricomponents/resource.py
+++ b/client/starwhale/base/uricomponents/resource.py
@@ -20,10 +20,10 @@ from starwhale.base.uricomponents.exceptions import (
 url_regex = re.compile(
     r"(?P<scheme>https*)://"
     r"(?P<host>.*)/projects/"
-    r"(?P<project>\d+)/"
+    r"(?P<project>.+)/"
     r"(?P<rc_type>models|datasets|runtimes|evaluations)"
-    r"(/(?P<rc_id>\d+)/versions)?"  # optional
-    r"(/(?P<rc_version>\d+)/.*)?",  # optional
+    r"(/(?P<rc_id>.+)/versions)?"  # optional
+    r"(/(?P<rc_version>.+)/.*)?",  # optional
     re.UNICODE,
 )
 


### PR DESCRIPTION
## Description

Closes #1637

- Show console url for the remote bundle after copy done
- sw xx cp support console url with resource name like `.../projects/starwhale/models/mnist/versions/foobarbaz`

It is convenient for users to open the console by clicking the link.

![remote](https://user-images.githubusercontent.com/3217223/223068184-8293b1ae-e2d8-4e6a-87fa-33ff43489191.png)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
