### PR TITLE
fix(e2e): fix server build issue in e2e

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -88,6 +88,15 @@ build-server:
 build-server-all: build-console build-jar
 	$(call build-image,server,${RELEASE_VERSION})
 
+build-server-for-local-usage:
+	docker build \
+		--network=host \
+		--build-arg BASE_IMAGE=$(GHCR_BASE_IMAGE) \
+		--build-arg SW_SERVER_VERSION=$(RELEASE_VERSION) \
+		--build-arg GIT_INFO=$(GIT_INFO) \
+		-t starwhaleai/server:latest \
+		-f Dockerfile.server .
+
 build-nodejs:
 	$(call build-image,nodejs,${FIXED_VERSION_NODEJS_IMAGE})
 

--- a/scripts/publish/pub.sh
+++ b/scripts/publish/pub.sh
@@ -74,7 +74,7 @@ build() {
         popd
     fi
     pushd ../../docker
-    make build-server
+    make build-server-for-local-usage
     if ! docker tag starwhaleai/server:latest $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/server:$SERVER_RELEASE_VERSION ; then echo "[ERROR] Something wrong while pushing , press CTL+C to interrupt execution if needed"; fi
     if ! docker push $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/server:$SERVER_RELEASE_VERSION ; then echo "[ERROR] Something wrong while pushing , press CTL+C to interrupt execution if needed"; fi
     popd


### PR DESCRIPTION
## Description

The `buildx` can not support build to local image atm, add `build-server-for-local-usage` target for e2e usage

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
