### PR TITLE
chore(client): move auto-generated file to the .starwhale dir

### DIFF
--- a/client/starwhale/api/_impl/job.py
+++ b/client/starwhale/api/_impl/job.py
@@ -200,7 +200,11 @@ class Parser:
         logger.debug("generate DAG")
         if Parser.check(_jobs):
             # dump to target
-            ensure_file(target_file, yaml.safe_dump(_jobs, default_flow_style=False))
+            ensure_file(
+                target_file,
+                yaml.safe_dump(_jobs, default_flow_style=False),
+                parents=True,
+            )
             logger.debug("generator DAG success!")
         else:
             logger.error("generator DAG error! reason: check is failed.")

--- a/client/starwhale/core/model/store.py
+++ b/client/starwhale/core/model/store.py
@@ -1,7 +1,7 @@
 import typing as t
 from pathlib import Path
 
-from starwhale.consts import VERSION_PREFIX_CNT, DEFAULT_MANIFEST_NAME
+from starwhale.consts import SW_AUTO_DIRNAME, VERSION_PREFIX_CNT, DEFAULT_MANIFEST_NAME
 from starwhale.base.type import URIType, BundleType
 from starwhale.base.store import BaseStorage
 
@@ -25,6 +25,10 @@ class ModelStorage(BaseStorage):
     @property
     def src_dir(self) -> Path:
         return self.snapshot_workdir / self.src_dir_name
+
+    @property
+    def hidden_sw_dir(self) -> Path:
+        return self.src_dir / SW_AUTO_DIRNAME
 
     @property
     def recover_loc(self) -> Path:

--- a/client/starwhale/utils/fs.py
+++ b/client/starwhale/utils/fs.py
@@ -25,8 +25,11 @@ def ensure_file(
     path: t.Union[str, Path],
     content: t.Union[str, bytes],
     mode: int = 0o644,
+    parents: bool = False,
 ) -> None:
     p = Path(path)
+    if parents:
+        p.parent.mkdir(parents=True, exist_ok=True)
     bin_mode = isinstance(content, bytes)
     try:
         with p.open("rb" if bin_mode else "r") as f:

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -16,6 +16,7 @@ from starwhale.consts import (
     FileFlag,
     HTTPMethod,
     DefaultYAMLName,
+    SW_AUTO_DIRNAME,
     VERSION_PREFIX_CNT,
     DEFAULT_MANIFEST_NAME,
     DEFAULT_EVALUATION_JOBS_FNAME,
@@ -97,7 +98,9 @@ class StandaloneModelTestCase(TestCase):
 
         assert bundle_path.exists()
         assert (bundle_path / "src").exists()
-        assert (bundle_path / "src" / DEFAULT_EVALUATION_JOBS_FNAME).exists()
+        assert (
+            bundle_path / "src" / SW_AUTO_DIRNAME / DEFAULT_EVALUATION_JOBS_FNAME
+        ).exists()
 
         _manifest = load_yaml(bundle_path / DEFAULT_MANIFEST_NAME)
         assert "name" not in _manifest

--- a/console/src/pages/Project/OnlineEval.tsx
+++ b/console/src/pages/Project/OnlineEval.tsx
@@ -152,7 +152,7 @@ export default function OnlineEval() {
             fetch(
                 `${api}?${qs.stringify({
                     Authorization: getToken(),
-                    partName: 'svc.json',
+                    partName: '.starwhale/svc.json',
                     signature: '',
                 })}`
             )

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
@@ -542,7 +542,7 @@ public class ModelService {
             jobContent = new String(
                     Objects.requireNonNull(
                             TarFileUtil.getContentFromTarFile(
-                                multipartFile.getInputStream(), "", "eval_jobs.yaml")
+                                multipartFile.getInputStream(), ".starwhale", "eval_jobs.yaml")
                     )
             );
             TarFileUtil.extract(inputStream, (name, size, in) ->


### PR DESCRIPTION
## Description

Move the auto-generated file to the `.starwhale` dir
- eval_jobs.yaml
- svc.json

The panel settings will be saved to this dir too later

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
