### PR TITLE
chore(controller): store manifest with oss instead of using db

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/converter/ModelVersionVoConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/converter/ModelVersionVoConverter.java
@@ -41,7 +41,7 @@ public class ModelVersionVoConverter {
         this.jobSpecParser = jobSpecParser;
     }
 
-    public ModelVersionVo convert(ModelVersionEntity entity)
+    public ModelVersionVo convert(ModelVersionEntity entity, String manifest)
             throws ConvertException {
         try {
             return ModelVersionVo.builder()
@@ -50,7 +50,7 @@ public class ModelVersionVoConverter {
                     .alias(versionAliasConvertor.convert(entity.getVersionOrder()))
                     .tag(entity.getVersionTag())
                     .meta(entity.getVersionMeta())
-                    .manifest(entity.getManifest())
+                    .manifest(manifest)
                     .createdTime(entity.getCreatedTime().getTime())
                     .stepSpecs(jobSpecParser.parseStepFromYaml(entity.getEvalJobs()))
                     .build();

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/mapper/ModelVersionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/mapper/ModelVersionMapper.java
@@ -34,7 +34,7 @@ import org.apache.ibatis.jdbc.SQL;
 public interface ModelVersionMapper {
 
     String COLUMNS = "id, version_order, model_id, owner_id, version_name, version_tag, version_meta,"
-            + " storage_path, manifest, created_time, modified_time, eval_jobs, status";
+            + " storage_path, created_time, modified_time, eval_jobs, status";
 
     @SelectProvider(value = ModelVersionProvider.class, method = "listSql")
     List<ModelVersionEntity> list(@Param("modelId") Long modelId,
@@ -63,9 +63,9 @@ public interface ModelVersionMapper {
     int updateVersionOrder(@Param("id") Long id, @Param("versionOrder") Long versionOrder);
 
     @Insert("insert into model_version (model_id, owner_id, version_name, version_tag, version_meta,"
-            + " storage_path, manifest, eval_jobs)"
+            + " storage_path, eval_jobs)"
             + " values (#{modelId}, #{ownerId}, #{versionName}, #{versionTag}, #{versionMeta},"
-            + " #{storagePath}, #{manifest}, #{evalJobs})")
+            + " #{storagePath}, #{evalJobs})")
     @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
     int insert(ModelVersionEntity version);
 
@@ -131,9 +131,6 @@ public interface ModelVersionMapper {
                     }
                     if (StrUtil.isNotEmpty(version.getEvalJobs())) {
                         SET("eval_jobs=#{evalJobs}");
-                    }
-                    if (StrUtil.isNotEmpty(version.getManifest())) {
-                        SET("manifest=#{manifest}");
                     }
                     if (Objects.nonNull(version.getStatus())) {
                         SET("status=#{status}");

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/po/ModelVersionEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/po/ModelVersionEntity.java
@@ -52,6 +52,9 @@ public class ModelVersionEntity extends BaseEntity implements BundleVersionEntit
 
     private String storagePath;
 
+    @Deprecated
+    // do not save the manifest to the database
+    // use oss instead
     private String manifest;
 
     private String evalJobs;

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/model/ModelVersionConverterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/model/ModelVersionConverterTest.java
@@ -53,9 +53,8 @@ public class ModelVersionConverterTest {
                 .versionOrder(2L)
                 .versionTag("tag1")
                 .versionMeta("meta1")
-                .manifest("manifest1")
                 .evalJobs("default:\n- concurrency: 2")
-                .build());
+                .build(), "manifest1");
         assertThat(res, allOf(
                 notNullValue(),
                 hasProperty("name", is("name1")),


### PR DESCRIPTION
## Description

Do not save the manifest file (may be too large) in the database, use the oss version instead.

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
