### PR TITLE
feat(sdk): support `DataRow.features` attribute-like usage

### DIFF
--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -26,14 +26,34 @@ _DEFAULT_LOADER_CACHE_SIZE = 20
 
 @total_ordering
 class DataRow:
+    class _Features(dict):
+        def __setattr__(self, name: str, value: t.Any) -> None:
+            self[name] = value
+
+        def __getattr__(self, name: str) -> t.Any:
+            if name in self:
+                return self[name]
+            else:
+                raise AttributeError(f"No found attribute: {name}")
+
+        def __delattr__(self, name: str) -> None:
+            if name in self:
+                del self[name]
+            else:
+                raise AttributeError(f"No found attribute: {name}")
+
     def __init__(
         self,
         index: t.Union[str, int],
         features: t.Dict,
     ) -> None:
+        if not isinstance(index, (str, int)):
+            raise TypeError(f"index({index}) is not int or str type")
         self.index = index
-        self.features = features
-        self._do_validate()
+
+        if not isinstance(features, dict):
+            raise TypeError(f"features({features}) is not dict type")
+        self.features: t.Dict = DataRow._Features(features)
 
     def __str__(self) -> str:
         return f"{self.index}"
@@ -49,13 +69,6 @@ class DataRow:
 
     def __len__(self) -> int:
         return len(self.__dict__)
-
-    def _do_validate(self) -> None:
-        if not isinstance(self.index, (str, int)):
-            raise TypeError(f"index({self.index}) is not int or str type")
-
-        if not isinstance(self.features, dict):
-            raise TypeError(f"content({self.features}) is not dict type")
 
     def __lt__(self, obj: DataRow) -> bool:
         return str(self.index) < str(obj.index)

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -563,6 +563,23 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         assert isinstance(items, list)
         assert len(items) == 2
 
+    def test_get_item_features(self) -> None:
+        existed_ds_uri = self._init_simple_dataset()
+        ds = dataset(existed_ds_uri)
+        features = ds[0].features  # type: ignore
+        assert isinstance(features, dict)
+        assert isinstance(features, DataRow._Features)
+        assert features["label"] == features.label == 0
+        with self.assertRaises(AttributeError):
+            _ = features.not_found
+
+        features.new_label = 2
+        assert features["new_label"] == 2
+
+        del features.new_label
+        with self.assertRaises(AttributeError):
+            _ = features.new_label
+
     def test_tags(self) -> None:
         existed_ds_uri = self._init_simple_dataset_with_str_id()
         ds = dataset(existed_ds_uri)

--- a/example/mnist/mnist/dataset_read.py
+++ b/example/mnist/mnist/dataset_read.py
@@ -14,7 +14,5 @@ def show_image(image: typing.Any) -> None:
 ds_name = "mnist/version/latest"
 ds = dataset(ds_name)
 row = ds.fetch_one()
-data = row.features["img"]
-label = row.features["label"]
-show_image(np.frombuffer(data.to_bytes(), dtype=np.uint8).reshape(data.shape))  # type: ignore
-print(label)
+show_image(np.frombuffer(row.features.img.to_bytes(), dtype=np.uint8).reshape(row.features.img.shape))  # type: ignore
+print(row.features.label)  # type: ignore

--- a/example/notebooks/dataset-sdk.ipynb
+++ b/example/notebooks/dataset-sdk.ipynb
@@ -289,7 +289,8 @@
    "outputs": [],
    "source": [
     "# get pillow object\n",
-    "ds[0].data.get(\"image\").to_pil()"
+    "ds[0].features.image.to_pil()\n",
+    "# or ds[0].features[\"image\"].to_pil()"
    ]
   },
   {


### PR DESCRIPTION
## Description
- depend pr: https://github.com/star-whale/starwhale/pull/1943 , please review [015a2c](https://github.com/star-whale/starwhale/pull/1948/commits/015a2ce5c8b8eab656470914f71be9a3ba26a6d3) commit.
- Code Example:
  ```python
  from starwhale import dataset
  
  ds = dataset("mnist/version/latest")
  print(ds[0].features.label)
  ds[0].features.label = 1
  del ds[0].features.label
  ```
- related issue: https://github.com/star-whale/starwhale/issues/1940

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
