### PR TITLE
fix(docker): buildx can not work without init in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,6 +296,12 @@ jobs:
         with:
           strip_v: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build and push docker image
         working-directory: ./docker
         env:


### PR DESCRIPTION
## Description

tested in https://github.com/star-whale/starwhale/actions/runs/4411841925/jobs/7730733975

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
