### PR TITLE
chore(docker): build nodejs image automatically and add make cmd in the image

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -41,3 +41,7 @@ jobs:
       - name: Build and push server-base image
         working-directory: ./docker
         run: make build-release-base-server
+
+      - name: Build and push nodejs base image
+        working-directory: ./docker
+        run: make build-nodejs

--- a/docker/Dockerfile.nodejs
+++ b/docker/Dockerfile.nodejs
@@ -16,7 +16,7 @@ RUN set -xe
 
 # install nodejs packages
 RUN wget -qO- "https://deb.nodesource.com/setup_${NODE_VERSION}" | bash - \
- && apt-get install -y nodejs git \
+ && apt-get install -y nodejs git make \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ GHCR_IO_REPO := ghcr.io/star-whale
 # Please update base/nodejs/base_server image version by manual, DOT NOT USE RELEASE TAG.
 # These images versions are slow to release.
 FIXED_VERSION_BASE_IMAGE := 0.2.5
-FIXED_VERSION_NODEJS_IMAGE := 0.1.2
+FIXED_VERSION_NODEJS_IMAGE := 0.1.3
 FIXED_VERSION_BASE_SERVER_IMAGE := 0.1.2
 
 GHCR_BASE_IMAGE := ${GHCR_IO_REPO}/base:${FIXED_VERSION_BASE_IMAGE}
@@ -98,7 +98,8 @@ build-server-for-local-usage:
 		-f Dockerfile.server .
 
 build-nodejs:
-	$(call build-image,$(GHCR_BASE_IMAGE),Dockerfile.nodejs,nodejs:${FIXED_VERSION_NODEJS_IMAGE} nodejs:latest)
+	docker manifest inspect $(GHCR_IO_REPO)/nodejs:${FIXED_VERSION_NODEJS_IMAGE} || \
+	$(call build-image,,Dockerfile.nodejs,nodejs:${FIXED_VERSION_NODEJS_IMAGE} nodejs:latest)
 
 YARN_VOLUME=yarn-cache
 build-console: build-gradio-ui


### PR DESCRIPTION
## Description

- Add `make` cmd in the nodejs image for using the `Makefile`
- build nodejs image automatically 

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
