### PR TITLE
fix(docker): do not use mirror when building nodejs multi-arch images

### DIFF
--- a/docker/Dockerfile.nodejs
+++ b/docker/Dockerfile.nodejs
@@ -1,7 +1,5 @@
 FROM ubuntu:20.04
 
-COPY external/sources.list /etc/apt/sources.list
-
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
 ENV TZ=Etc/UTC


### PR DESCRIPTION
## Description

Do not use mirror when building nodejs multi-arch images

related to: #1959

https://github.com/star-whale/starwhale/actions/runs/4414182044/jobs/7735563382

![image](https://user-images.githubusercontent.com/3217223/224966751-15376181-1df0-45fc-b5a0-99ee520805b5.png)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
