### PR TITLE
chore(dataset): remove `build_from_handler` interface for dataset python sdk

### DIFF
--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -4,7 +4,6 @@ import typing as t
 import threading
 from http import HTTPStatus
 from types import TracebackType
-from pathlib import Path
 from functools import wraps
 from itertools import islice
 from contextlib import ExitStack
@@ -157,7 +156,6 @@ class Dataset:
         self.__data_loaders: t.Dict[str, DataLoader] = {}
         self._writer_lock = threading.Lock()
         self._row_writer: t.Optional[RowWriter] = None
-        self._enable_copy_src = False
         self._info_lock = threading.Lock()
         self._info_ds_wrapper: t.Optional[DatastoreWrapperDataset] = None
         self.__info: t.Optional[TabularDatasetInfo] = None
@@ -594,21 +592,6 @@ class Dataset:
     def extend(self, items: t.Sequence[t.Any]) -> None:
         for item in items:
             self.append(item)
-
-    @_check_readonly
-    def build_with_copy_src(
-        self,
-        src_dir: t.Union[str, Path],
-        include_files: t.Optional[t.List[str]] = None,
-        exclude_files: t.Optional[t.List[str]] = None,
-    ) -> Dataset:
-        self._enable_copy_src = True
-        self._build_src_dir = Path(src_dir)
-        self._build_include_files = include_files or []
-        self._build_exclude_files = exclude_files or []
-        return self
-
-    commit_with_copy_src = build_with_copy_src
 
     @_check_readonly
     def _do_build_from_interactive_code(self) -> None:

--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -23,7 +23,7 @@ from starwhale.utils.fs import move_dir, empty_dir
 from starwhale.base.type import InstanceType
 from starwhale.base.cloud import CloudRequestMixed
 from starwhale.utils.error import ExistedError, NotFoundError, NoSupportError
-from starwhale.core.dataset.type import DatasetConfig, DatasetSummary
+from starwhale.core.dataset.type import DatasetSummary
 from starwhale.core.dataset.model import Dataset as CoreDataset
 from starwhale.core.dataset.model import StandaloneDataset
 from starwhale.core.dataset.store import DatasetStorage
@@ -38,7 +38,7 @@ from starwhale.core.dataset.tabular import (
 )
 
 from .loader import DataRow, DataLoader, get_data_loader
-from .builder import RowWriter, BaseBuildExecutor
+from .builder import RowWriter
 
 if t.TYPE_CHECKING:
     import tensorflow as tf
@@ -46,7 +46,6 @@ if t.TYPE_CHECKING:
 
 _DType = t.TypeVar("_DType", bound="Dataset")
 _ItemType = t.Union[str, int, slice]
-_HandlerType = t.Optional[t.Union[t.Callable, BaseBuildExecutor]]
 _GItemType = t.Optional[t.Union[DataRow, t.List[DataRow]]]
 
 _DEFAULT_LOADER_WORKERS = 2
@@ -156,9 +155,6 @@ class Dataset:
         self._consumption: t.Optional[TabularDatasetSessionConsumption] = None
         self._lock = threading.Lock()
         self.__data_loaders: t.Dict[str, DataLoader] = {}
-        self.__build_handler: _HandlerType = None
-        self._trigger_handler_build = False
-        self._trigger_icode_build = False
         self._writer_lock = threading.Lock()
         self._row_writer: t.Optional[RowWriter] = None
         self._enable_copy_src = False
@@ -371,43 +367,6 @@ class Dataset:
 
         return _wrapper
 
-    def _forbid_handler_build(func: t.Callable):  # type: ignore
-        @wraps(func)
-        def _wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
-            self: Dataset = args[0]
-            if self._trigger_handler_build:
-                raise NoSupportError(
-                    "no support build from handler and from cache code at the same time, build from handler has already been activated"
-                )
-            return func(*args, **kwargs)
-
-        return _wrapper
-
-    def _forbid_icode_build(func: t.Callable):  # type: ignore
-        @wraps(func)
-        def _wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
-            self: Dataset = args[0]
-            if self._trigger_icode_build:
-                raise NoSupportError(
-                    "no support build from handler and from cache code at the same time, build from interactive code has already been activated"
-                )
-            return func(*args, **kwargs)
-
-        return _wrapper
-
-    @property
-    def build_handler(self) -> _HandlerType:
-        return self.__build_handler
-
-    @build_handler.setter
-    def build_handler(self, handler: _HandlerType) -> None:
-        if self._trigger_icode_build:
-            raise RuntimeError(
-                "dataset append by interactive code has already been called"
-            )
-        self._trigger_handler_build = True
-        self.__build_handler = handler
-
     @property
     def tags(self) -> _Tags:
         return _Tags(self.__core_dataset)
@@ -524,12 +483,10 @@ class Dataset:
         return to_tf_dataset(dataset=self, drop_index=drop_index)
 
     @_check_readonly
-    @_forbid_handler_build
     def __setitem__(
         self, key: t.Union[str, int], value: t.Union[DataRow, t.Tuple, t.Dict]
     ) -> None:
         # TODO: tune the performance of getitem by cache
-        self._trigger_icode_build = True
         _row_writer = self._get_row_writer()
 
         if not isinstance(key, (int, str)):
@@ -594,9 +551,7 @@ class Dataset:
     _init_row_writer = _get_row_writer
 
     @_check_readonly
-    @_forbid_handler_build
     def __delitem__(self, key: _ItemType) -> None:
-        self._trigger_icode_build = True
         self._init_row_writer()  # hack for del item as the first operation
 
         items: t.List
@@ -616,7 +571,6 @@ class Dataset:
             self._rows_cnt -= 1
 
     @_check_readonly
-    @_forbid_handler_build
     def append(self, item: t.Any) -> None:
         if isinstance(item, DataRow):
             self.__setitem__(item.index, item)
@@ -637,7 +591,6 @@ class Dataset:
             raise TypeError(f"value({item}) is not DataRow, list or tuple type")
 
     @_check_readonly
-    @_forbid_handler_build
     def extend(self, items: t.Sequence[t.Any]) -> None:
         for item in items:
             self.append(item)
@@ -658,7 +611,6 @@ class Dataset:
     commit_with_copy_src = build_with_copy_src
 
     @_check_readonly
-    @_forbid_handler_build
     def _do_build_from_interactive_code(self) -> None:
         if self._row_writer is None:
             raise RuntimeError("row writer is none, no data was written")
@@ -721,48 +673,8 @@ class Dataset:
             local_ds._make_swds_meta_tar()
 
     @_check_readonly
-    @_forbid_icode_build
-    def _do_build_from_handler(self) -> None:
-        # TODO: support build dataset for cloud uri directly
-        if self.project_uri.instance_type == InstanceType.CLOUD:
-            raise NoSupportError("no support to build cloud dataset directly")
-
-        if self.__info is not None and self._info_ds_wrapper is not None:
-            self.__info.save_to_datastore(self._info_ds_wrapper)
-
-        self._trigger_icode_build = True
-        config = DatasetConfig(
-            name=self.name,
-            handler=self.build_handler,
-            project_uri=self.project_uri.full_uri,
-            append=self._create_by_append,
-            append_from=self._append_from_version,
-        )
-
-        kw: t.Dict[str, t.Any] = {"disable_copy_src": not self._enable_copy_src}
-        if self._enable_copy_src:
-            config.pkg_data = self._build_include_files
-            config.exclude_pkg_data = self._build_exclude_files
-            kw["workdir"] = self._build_src_dir
-
-        # TODO: support DatasetAttr config for SDK
-        config.do_validate()
-        kw["config"] = config
-        # TODO: support build tmpdir, follow the swcli dataset build command behavior
-        self.__core_dataset.buildImpl(**kw)
-        _summary = self.__core_dataset.summary()
-        self._rows_cnt = _summary.rows if _summary else 0
-
-    @_check_readonly
-    def build(self) -> None:
-        if self._trigger_icode_build:
-            self._do_build_from_interactive_code()
-        elif self._trigger_handler_build and self.build_handler:
-            self._do_build_from_handler()
-        else:
-            raise RuntimeError("no data to build dataset")
-
-    commit = build
+    def commit(self) -> None:
+        self._do_build_from_interactive_code()
 
     def copy(
         self, dest_uri: str, force: bool = False, dest_local_project_uri: str = ""
@@ -792,7 +704,6 @@ class Dataset:
     def dataset(
         uri: t.Union[str, URI],
         create: bool = False,
-        create_from_handler: t.Optional[_HandlerType] = None,
     ) -> Dataset:
         if isinstance(uri, str):
             _uri = URI(uri, expected_type=URIType.DATASET)
@@ -807,10 +718,7 @@ class Dataset:
             name=_uri.object.name,
             version=_uri.object.version,
             project_uri=_uri,  # TODO: cut off dataset resource info?
-            create=create or bool(create_from_handler),
+            create=create,
         )
-
-        if create_from_handler:
-            ds.build_handler = create_from_handler
 
         return ds

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -5,7 +5,6 @@ import sys
 import typing as t
 from http import HTTPStatus
 from pathlib import Path
-from unittest.mock import MagicMock
 from concurrent.futures import as_completed, ThreadPoolExecutor
 
 import yaml
@@ -19,7 +18,6 @@ from requests_mock import Mocker
 from starwhale import dataset
 from starwhale.consts import HTTPMethod
 from starwhale.base.uri import URI
-from starwhale.utils.fs import ensure_dir, ensure_file
 from starwhale.base.type import URIType
 from starwhale.utils.error import ExistedError, NotFoundError, NoSupportError
 from starwhale.utils.config import SWCliConfigMixed
@@ -297,131 +295,14 @@ class TestDatasetSDK(_DatasetSDKTestBase):
 
     def test_build_no_data(self) -> None:
         ds = dataset("mnist", create=True)
-        msg = "no data to build dataset"
+        msg = "row writer is none, no data was written"
         with self.assertRaisesRegex(RuntimeError, msg):
-            ds.build()
+            ds.commit()
 
         existed_ds_uri = self._init_simple_dataset_with_str_id()
         ds = dataset(existed_ds_uri, create=True)
         with self.assertRaisesRegex(RuntimeError, msg):
-            ds.build()
-
-    def test_build_from_handler_empty(self) -> None:
-        def _handler() -> t.Generator:
-            for i in range(0, 100):
-                yield i, {"data": Binary(), "label": i}
-
-        ds = dataset("mnist", create=True)
-        ds.build_handler = _handler
-        ds.commit()
-        ds.close()
-
-        reopen_ds = dataset(ds.uri)
-        items = list(reopen_ds)
-        assert len(items) == len(reopen_ds) == 100
-        assert "label" in items[-1].features
-        assert isinstance(items[-1].index, int)
-
-    def test_build_from_handler_existed(self) -> None:
-        def _handler() -> t.Generator:
-            for i in range(0, 100):
-                yield f"label-{i}", {
-                    "data": Binary(bytes(f"data-{i}", "utf-8")),
-                    "label": i,
-                }
-
-        existed_ds_uri = self._init_simple_dataset_with_str_id()
-        with dataset(existed_ds_uri, create_from_handler=_handler) as ds:
-            assert ds._create_by_append
             ds.commit()
-
-        reopen_ds = dataset(ds.uri)
-        assert len(reopen_ds) == 110
-        summary = reopen_ds.summary()
-        assert isinstance(summary, DatasetSummary)
-        assert summary.rows == 110
-        assert summary.increased_rows == 100
-        items = list(reopen_ds)
-        assert len(items) == 110
-        assert isinstance(items[-1].index, str)
-        assert items[-1].index.startswith("label-")
-
-    def test_build_from_handler_with_copy_src(self) -> None:
-        def _handler() -> t.Generator:
-            for i in range(0, 100):
-                yield DataRow(f"label-{i}", {"data": Binary(), "label": i})
-
-        workdir = Path(self.local_storage) / ".data"
-        ensure_dir(workdir)
-        ensure_file(workdir / "t.py", content="")
-
-        ds = dataset("mnist", create_from_handler=_handler)
-        ds.build_with_copy_src(workdir)
-        ds.commit()
-        ds.close()
-
-        reopen_ds = dataset(ds.uri)
-        assert reopen_ds.exists()
-
-        _uri = reopen_ds.uri
-        dataset_dir = (
-            Path(self.local_storage)
-            / _uri.project
-            / "dataset"
-            / reopen_ds.name
-            / reopen_ds.version[:2]
-            / f"{reopen_ds.version}.swds"
-            / "src"
-        )
-        assert dataset_dir.exists()
-        assert (dataset_dir / "t.py").exists()
-
-    def test_forbid_handler(self) -> None:
-        ds = dataset("mnist", create=True)
-        for i in range(0, 3):
-            ds.append(DataRow(i, {"data": Binary(), "label": i}))
-
-        assert ds._trigger_icode_build
-        assert not ds._trigger_handler_build
-
-        with self.assertRaisesRegex(
-            RuntimeError, "dataset append by interactive code has already been called"
-        ):
-            ds.build_handler = MagicMock()
-
-    def test_forbid_icode(self) -> None:
-        ds = dataset("mnist", create=True)
-        ds.build_handler = MagicMock()
-        assert ds._trigger_handler_build
-        assert not ds._trigger_icode_build
-
-        msg = "no support build from handler and from cache code at the same time"
-        with self.assertRaisesRegex(NoSupportError, msg):
-            ds.append(DataRow(1, {"data": Binary(), "label": 1}))
-
-        with self.assertRaisesRegex(NoSupportError, msg):
-            ds.extend([DataRow(1, {"data": Binary(), "label": 1})])
-
-        with self.assertRaisesRegex(NoSupportError, msg):
-            ds[1] = DataRow(1, {"data": Binary(), "label": 1})
-
-        with self.assertRaisesRegex(NoSupportError, msg):
-            del ds[1]
-
-        ds = dataset("mnist", create_from_handler=MagicMock())
-        assert ds._trigger_handler_build
-        assert not ds._trigger_icode_build
-        with self.assertRaisesRegex(NoSupportError, msg):
-            ds.append(DataRow(1, {"data": Binary(), "label": 1}))
-
-        with self.assertRaisesRegex(NoSupportError, msg):
-            ds.extend([DataRow(1, {"data": Binary(), "label": 1})])
-
-        with self.assertRaisesRegex(NoSupportError, msg):
-            ds[1] = DataRow(1, {"data": Binary(), "label": 1})
-
-        with self.assertRaisesRegex(NoSupportError, msg):
-            del ds[1]
 
     def test_close(self) -> None:
         ds = dataset("mnist", create=True)
@@ -689,29 +570,6 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         assert update_table_req.called
 
         ds.close()
-
-    @Mocker()
-    def test_cloud_build_no_support(self, rm: Mocker) -> None:
-        with self.assertRaisesRegex(
-            NoSupportError, "no support to build cloud dataset directly"
-        ):
-            ds = dataset("http://1.1.1.1/project/self/dataset/mnist", create=True)
-            ds.build_handler = MagicMock()
-            ds.commit()
-
-        rm.request(
-            HTTPMethod.HEAD,
-            "http://1.1.1.1/api/v1/project/self/dataset/mnist/version/1234",
-            json={"message": "existed"},
-            status_code=HTTPStatus.OK,
-        )
-
-        with self.assertRaisesRegex(
-            NoSupportError, "Can't build dataset from the existed cloud dataset uri"
-        ):
-            dataset(
-                "http://1.1.1.1/project/self/dataset/mnist/version/1234", create=True
-            )
 
     def test_consumption(self) -> None:
         existed_ds_uri = self._init_simple_dataset_with_str_id()


### PR DESCRIPTION
## Description
`build_from_handler` may bring confusion for the `Python SDK` style. With Python SDK, users can write in-house code to complete the dataset building and management, the external handler code is not friendly for the users.
In further, `swcli dataset build` command focuses on no-code dataset building. 

related: https://github.com/star-whale/starwhale/issues/1940

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
