### PR TITLE
fix(client): remove the prefix slash when listing tables in the client

### DIFF
--- a/client/starwhale/web/data_store.py
+++ b/client/starwhale/web/data_store.py
@@ -35,7 +35,9 @@ def list_tables(request: ListTablesRequest) -> SuccessResp:
     root = str(SWCliConfigMixed().datastore_dir)
     path = os.path.join(root, request.prefix)
     files = glob.glob(f"{path}**", recursive=True)
-    files = [os.path.split(f)[0][len(root) :] for f in files if os.path.isfile(f)]
+    files = [
+        os.path.split(f)[0][len(root) :].lstrip("/") for f in files if os.path.isfile(f)
+    ]
     return success({"tables": files})
 
 

--- a/client/tests/web/test_server.py
+++ b/client/tests/web/test_server.py
@@ -60,7 +60,7 @@ def test_datastore_list_tables(root: MagicMock, tmpdir: Path):
 
     resp = client.post("/api/v1/datastore/listTables", content='{"prefix": ""}')
     assert resp.status_code == 200
-    assert set(resp.json()["data"]["tables"]) == {"/a", "/b/c"}
+    assert set(resp.json()["data"]["tables"]) == {"a", "b/c"}
 
 
 @patch("starwhale.api._impl.data_store.LocalDataStore.scan_tables")


### PR DESCRIPTION
## Description

### Remove the prefix slash when listing tables in the client

Console uses regex `/(^project\/.*?\/.*?\/.*?\/.*?\/)/` to replace the evaluation related info, and the table name with `/` prefix can not match it.

https://github.com/star-whale/starwhale/blob/e1dd759a7803a5879457dc2e272c47de54b1e664/console/packages/starwhale-core/src/widget/utils/replacer.ts#L14-L21

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
