### PR TITLE
fix(console): online eval page can not show

### DIFF
--- a/console/src/pages/Project/OnlineEval.tsx
+++ b/console/src/pages/Project/OnlineEval.tsx
@@ -152,7 +152,7 @@ export default function OnlineEval() {
             fetch(
                 `${api}?${qs.stringify({
                     Authorization: getToken(),
-                    partName: '.starwhale/svc.json',
+                    partName: 'svc.json',
                     signature: '',
                 })}`
             )


### PR DESCRIPTION
## Description

- Related to https://github.com/star-whale/starwhale/pull/1936/files#diff-0bb49f51eec0b9cb35d56beb255d80db70c48b935f05b04ddeed8d218db5b29dR155
- Need to refine the pull logic later in the server side #1969

cc @lijing-susan 

![image](https://user-images.githubusercontent.com/3217223/225252059-7215f4a1-1135-4574-b9b2-2b7da7034165.png)

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
