### PR TITLE
feat(dataset): new dataset constructive mechanism with versioning datastore table

### DIFF
--- a/client/starwhale/api/_impl/dataset/builder/__init__.py
+++ b/client/starwhale/api/_impl/dataset/builder/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .mapping_builder import MappingDatasetBuilder
 from .iterable_builder import (
     RowWriter,
     BuildExecutor,
@@ -14,4 +15,5 @@ __all__ = [
     "BaseBuildExecutor",
     "create_generic_cls",
     "IterableDatasetBuilder",
+    "MappingDatasetBuilder",
 ]

--- a/client/starwhale/api/_impl/dataset/mapping_builder.py
+++ b/client/starwhale/api/_impl/dataset/mapping_builder.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/client/starwhale/api/_impl/evaluation.py
+++ b/client/starwhale/api/_impl/evaluation.py
@@ -206,8 +206,10 @@ class PipelineHandler(metaclass=ABCMeta):
         # TODO: user custom config batch size, max_retries
         for uri_str in self.dataset_uris:
             _uri = URI(uri_str, expected_type=URIType.DATASET)
-            ds = Dataset.dataset(_uri)
-            ds.make_distributed_consumption(session_id=self.context.version)
+            ds = Dataset.dataset(_uri, readonly=True)
+            ds.make_distributed_consumption(
+                session_id=self.context.version
+            )._use_loading_version_for_loader()
             dataset_info = ds.info
             cnt = 0
             for rows in ds.batch_iter(self.ppl_batch_size):

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -38,7 +38,6 @@ from starwhale.utils.config import SWCliConfigMixed
 from starwhale.api._impl.wrapper import Dataset as DatastoreWrapperDataset
 from starwhale.api._impl.wrapper import DatasetTableKind
 from starwhale.core.dataset.type import Link, JsonDict, BaseArtifact
-from starwhale.core.dataset.store import DatasetStorage
 from starwhale.api._impl.data_store import TableEmptyException
 
 DEFAULT_CONSUMPTION_BATCH_SIZE = 50
@@ -342,14 +341,9 @@ class TabularDataset:
         start: t.Optional[t.Any] = None,
         end: t.Optional[t.Any] = None,
     ) -> _TDType:
-        _version = uri.object.version
-        if uri.instance_type == InstanceType.STANDALONE:
-            _store = DatasetStorage(uri)
-            _version = _store.id
-
         return cls(
             uri.object.name,
-            _version,
+            uri.object.version,
             uri.project,
             start=start,
             end=end,
@@ -474,7 +468,7 @@ class StandaloneTDSC(TabularDatasetSessionConsumption):
 
         self.project = dataset_uri.project
         self.dataset_name = dataset_uri.object.name
-        self.dataset_version = DatasetStorage(dataset_uri).id
+        self.dataset_version = dataset_uri.object.version
 
         self.session_id = session_id
         if batch_size <= 0:

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -905,7 +905,7 @@ class Link(ASDictMixin, SwObject):
         key_compose = (
             Link(self.local_fs_uri) if self.local_fs_uri else self,
             self.offset or 0,
-            self.size + self.offset - 1 if self.size else sys.maxsize,
+            self.size + self.offset - 1 if self.size != -1 else sys.maxsize,
         )
         store = ObjectStore.get_store(self, self.owner)
         with store.backend._make_file(
@@ -953,6 +953,9 @@ class DatasetSummary(ASDictMixin):
         self.increased_rows = increased_rows
         self.unchanged_rows = rows - increased_rows
         self.data_byte_size = data_byte_size
+        # TODO: cleanup expired increased_rows, unchanged_rows, data_byte_size fields
+        self.updated_rows = kw.get("updated_rows", 0)
+        self.deleted_rows = kw.get("deleted_rows", 0)
 
     def __str__(self) -> str:
         return f"Dataset Summary: rows({self.rows})"

--- a/client/tests/sdk/test_evaluation.py
+++ b/client/tests/sdk/test_evaluation.py
@@ -246,6 +246,7 @@ class TestModelPipelineHandler(TestCase):
         )
 
         fname = "data_ubyte_0.swds_bin"
+        sign, _ = DatasetStorage.save_data_file(Path(self.swds_dir) / fname)
         m_scan.side_effect = [
             [{"id": 0, "value": 1}],
             [
@@ -253,7 +254,7 @@ class TestModelPipelineHandler(TestCase):
                     features={
                         "image": GrayscaleImage(
                             link=Link(
-                                fname,
+                                uri=sign,
                                 offset=32,
                                 size=784,
                                 _swds_bin_offset=0,
@@ -270,11 +271,7 @@ class TestModelPipelineHandler(TestCase):
         m_scan_id.return_value = [{"id": 0}]
 
         datastore_dir = DatasetStorage(URI(self.dataset_uri_raw, URIType.DATASET))
-        data_dir = datastore_dir.data_dir
-        ensure_dir(data_dir)
-        shutil.copyfile(os.path.join(self.swds_dir, fname), str(data_dir / fname))
-        ensure_dir(datastore_dir.loc)
-        ensure_file(datastore_dir.manifest_path, "")
+        ensure_file(datastore_dir.manifest_path, "", parents=True)
 
         context = Context(
             workdir=Path(),


### PR DESCRIPTION
## Description
- dependent pr: https://github.com/star-whale/starwhale/pull/1976， please review [86fd0c](https://github.com/star-whale/starwhale/pull/1973/commits/86fd0c561bd2e479fee66f3353903d359715e3eb) commit.
- related issue: https://github.com/star-whale/starwhale/issues/1940
- features:
  - remove fork_dataset
  - provide `commit` interface: flush and generate a version
  - use `MappingDatasetBuilder` to build the dataset
  - use dataset one-one datastore table 

## Modules
- [x] Client
- [x] Python-SDK
- [x] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
