### PR TITLE
feat(dataset) support mapping style dataset builder

### DIFF
--- a/client/starwhale/api/_impl/dataset/builder/__init__.py
+++ b/client/starwhale/api/_impl/dataset/builder/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .iterable_builder import (
+    RowWriter,
+    BuildExecutor,
+    BaseBuildExecutor,
+    create_generic_cls,
+    IterableDatasetBuilder,
+)
+
+__all__ = [
+    "RowWriter",
+    "BuildExecutor",
+    "BaseBuildExecutor",
+    "create_generic_cls",
+    "IterableDatasetBuilder",
+]

--- a/client/starwhale/api/_impl/dataset/builder/iterable_builder.py
+++ b/client/starwhale/api/_impl/dataset/builder/iterable_builder.py
@@ -402,7 +402,7 @@ class BaseBuildExecutor(metaclass=ABCMeta):
         return idx, row
 
 
-class BuildExecutor(BaseBuildExecutor):
+class IterableDatasetBuilder(BaseBuildExecutor):
     def make_swds(self) -> DatasetSummary:
         increased_rows = 0
         with self.bin_writer as bw:
@@ -428,6 +428,9 @@ class BuildExecutor(BaseBuildExecutor):
             data_byte_size=self.bin_writer.total_bin_size,
         )
         return self._merge_forked_summary(summary)
+
+
+BuildExecutor = IterableDatasetBuilder
 
 
 def create_generic_cls(

--- a/client/starwhale/api/_impl/dataset/builder/mapping_builder.py
+++ b/client/starwhale/api/_impl/dataset/builder/mapping_builder.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import io
+import os
+import time
+import queue
+import struct
+import typing as t
+import tempfile
+import threading
+from types import TracebackType
+from pathlib import Path
+from binascii import crc32
+from collections import defaultdict
+
+from loguru import logger
+
+from starwhale.consts import STANDALONE_INSTANCE
+from starwhale.utils.fs import (
+    empty_dir,
+    ensure_dir,
+    blake2b_file,
+    BLAKE2B_SIGNATURE_ALGO,
+)
+from starwhale.utils.error import NoSupportError
+from starwhale.core.dataset.type import (
+    Link,
+    BaseArtifact,
+    D_ALIGNMENT_SIZE,
+    D_FILE_VOLUME_SIZE,
+)
+from starwhale.core.dataset.store import DatasetStorage
+from starwhale.core.dataset.tabular import TabularDataset, TabularDatasetRow
+from starwhale.api._impl.dataset.loader import DataRow
+
+
+class RotatedBinWriter:
+    """
+    bin format:
+        header_magic    uint32  I
+        crc             uint32  I
+        _reserved       uint64  Q
+        size            uint32  I
+        padding_size    uint32  I
+        header_version  uint32  I
+        data_magic      uint32  I --> above 32 bytes
+        data bytes...
+        padding bytes...        --> default 4K padding
+    """
+
+    _header_magic = struct.unpack(">I", b"SWDS")[0]
+    _data_magic = struct.unpack(">I", b"SDWS")[0]
+    _header_struct = struct.Struct(">IIQIIII")
+    _header_size = _header_struct.size
+    _header_version = 0
+
+    class _BinSection(t.NamedTuple):
+        offset: int
+        size: int
+        raw_data_offset: int
+        raw_data_size: int
+
+    def __init__(
+        self,
+        workdir: Path,
+        rotated_bin_notify_queue: t.Optional[queue.Queue[t.Optional[Path]]] = None,
+        alignment_bytes_size: int = D_ALIGNMENT_SIZE,
+        volume_bytes_size: int = D_FILE_VOLUME_SIZE,
+    ) -> None:
+        self.workdir = workdir
+
+        if alignment_bytes_size <= 0:
+            raise ValueError(
+                f"alignment_bytes_size must be greater than zero: {alignment_bytes_size}"
+            )
+
+        self.alignment_bytes_size = alignment_bytes_size
+
+        if volume_bytes_size < 0:
+            raise ValueError(
+                f"volume_bytes_size must be greater than zero: {volume_bytes_size}"
+            )
+        self.volume_bytes_size = volume_bytes_size
+
+        self._rotated_bin_notify_queue = rotated_bin_notify_queue
+        self._wrote_size = 0
+
+        ensure_dir(self.workdir)
+        _, bin_writer_path = tempfile.mkstemp(
+            prefix="bin-writer-", dir=str(self.workdir.absolute())
+        )
+        self._current_writer_path = Path(bin_writer_path)
+        self._current_writer = self._current_writer_path.open("wb")
+        self._rotated_bin_paths: t.List[Path] = []
+
+    def __enter__(self) -> RotatedBinWriter:
+        return self
+
+    def __exit__(
+        self,
+        type: t.Optional[t.Type[BaseException]],
+        value: t.Optional[BaseException],
+        trace: TracebackType,
+    ) -> None:
+        if value:  # pragma: no cover
+            logger.warning(f"type:{type}, exception:{value}, traceback:{trace}")
+
+        self.close()
+
+    @property
+    def working_path(self) -> Path:
+        return self._current_writer_path
+
+    @property
+    def rotated_paths(self) -> t.List[Path]:
+        return self._rotated_bin_paths
+
+    def close(self) -> None:
+        self._rotate()
+
+        empty = self._current_writer.tell() == 0
+        self._current_writer.close()
+        if empty and self._current_writer_path.exists():
+            # last file is empty
+            os.unlink(self._current_writer_path)
+
+    def _rotate(self) -> None:
+        if self._wrote_size == 0:
+            return
+        self._current_writer.close()
+        self._wrote_size = 0
+
+        self._rotated_bin_paths.append(self._current_writer_path)
+        if self._rotated_bin_notify_queue is not None:
+            self._rotated_bin_notify_queue.put(self._current_writer_path)
+
+        _, bin_writer_path = tempfile.mkstemp(
+            prefix="bin-writer-", dir=str(self.workdir.absolute())
+        )
+        self._current_writer_path = Path(bin_writer_path)
+        self._current_writer = self._current_writer_path.open("wb")
+
+    def write(self, data: bytes) -> t.Tuple[Path, RotatedBinWriter._BinSection]:
+        _cls = RotatedBinWriter
+        size = len(data)
+        crc = crc32(data)  # TODO: crc is right?
+        start = self._current_writer.tell()
+        padding_size = self._get_padding_size(size)
+
+        _header = _cls._header_struct.pack(
+            _cls._header_magic,
+            crc,
+            0,
+            size,
+            padding_size,
+            _cls._header_version,
+            _cls._data_magic,
+        )
+        _padding = b"\0" * padding_size
+        self._current_writer.write(_header + data + _padding)
+        _bin_path = self._current_writer_path
+        _bin_section = _cls._BinSection(
+            offset=start,
+            size=_cls._header_size + size + padding_size,
+            raw_data_offset=start + _cls._header_size,
+            raw_data_size=size,
+        )
+        self._wrote_size += _bin_section.size
+
+        if self._wrote_size > self.volume_bytes_size:
+            self._rotate()
+
+        return _bin_path, _bin_section
+
+    def _get_padding_size(self, size: int) -> int:
+        remain = (size + RotatedBinWriter._header_size) % self.alignment_bytes_size
+        return 0 if remain == 0 else (self.alignment_bytes_size - remain)
+
+
+class MappingDatasetBuilder:
+    _STASH_URI = "_starwhale_stash_uri"
+
+    class _SignedBinMeta(t.NamedTuple):
+        name: str
+        algo: str
+        size: int
+
+    def __init__(
+        self,
+        workdir: t.Union[Path, str],
+        dataset_name: str,
+        project_name: str,
+        instance_name: str = STANDALONE_INSTANCE,
+        bin_alignment_bytes_size: int = D_ALIGNMENT_SIZE,
+        bin_volume_bytes_size: int = D_FILE_VOLUME_SIZE,
+    ) -> None:
+        self.workdir = Path(workdir)
+        self.dataset_name = dataset_name
+        self.project_name = project_name
+        self.instance_name = instance_name
+
+        self._in_standalone = instance_name == STANDALONE_INSTANCE
+
+        self._bin_alignment_bytes_size = bin_alignment_bytes_size
+        self._bin_volume_bytes_size = bin_volume_bytes_size
+        self._tabular_dataset = TabularDataset(
+            name=dataset_name,
+            version="_current",  # use a holder version value, all versions of one dataset use the unified table
+            project=project_name,
+            instance_name=instance_name,
+        )
+        self._rows_put_queue: queue.Queue[
+            t.Optional[t.Union[DataRow, Exception]]
+        ] = queue.Queue()
+        self._rows_put_thread = threading.Thread(
+            target=self._rows_put_worker, daemon=True, name="RowPutThread"
+        )
+        self._rows_put_thread.start()
+        self._rows_put_exception: t.Optional[Exception] = None
+
+        # abs = artifacts bin sync
+        self._abs_queue: queue.Queue[t.Optional[Path]] = queue.Queue()
+        self._abs_exception: t.Optional[Exception] = None
+        self._abs_thread = threading.Thread(
+            target=self._abs_worker, daemon=True, name="ArtifactsBinSyncThread"
+        )
+        self._abs_thread.start()
+
+        self._artifact_bin_tmpdir = self.workdir / "artifact_bin_tmp"
+        self._artifact_bin_writer = RotatedBinWriter(
+            workdir=self._artifact_bin_tmpdir,
+            rotated_bin_notify_queue=self._abs_queue,
+            alignment_bytes_size=bin_alignment_bytes_size,
+            volume_bytes_size=bin_volume_bytes_size,
+        )
+
+        self._stash_uri_rows_map: t.Dict[
+            Path, t.List[t.Tuple[BaseArtifact, TabularDatasetRow]]
+        ] = defaultdict(list)
+        self._signed_bins_meta: t.List[MappingDatasetBuilder._SignedBinMeta] = []
+
+    def __enter__(self) -> MappingDatasetBuilder:
+        return self
+
+    def __exit__(
+        self,
+        type: t.Optional[t.Type[BaseException]],
+        value: t.Optional[BaseException],
+        trace: TracebackType,
+    ) -> None:
+        if value:  # pragma: no cover
+            logger.warning(f"type:{type}, exception:{value}, traceback:{trace}")
+
+        self.close()
+
+    def put(self, row: DataRow) -> None:
+        if not row or not isinstance(row, DataRow):
+            raise ValueError(f"row argument must be DataRow type: {row}")
+
+        self._raise_thread_daemons_exception()
+        self._rows_put_queue.put(row)
+
+    def _raise_thread_daemons_exception(self) -> None:
+        if self._abs_exception:
+            _e = self._abs_exception
+            self._abs_exception = None
+            raise threading.ThreadError(f"ArtifactsBinSyncThread raise exception: {_e}")
+
+        if self._rows_put_exception:
+            _e = self._rows_put_exception
+            self._rows_put_exception = None
+            raise threading.ThreadError(f"RowPutThread raise exception: {_e}")
+
+    def _handle_row_put(self, row: DataRow) -> None:
+        td_row = TabularDatasetRow(id=row.index, features=row.features)
+
+        for artifact in td_row.artifacts:
+            # TODO: refactor BaseArtifact Type, parse link by fp, such as: fp="s3://xx/yy/zz", fp="http://xx/yy/zz"
+            if not artifact.link:
+                if isinstance(artifact.fp, (str, Path)):
+                    content = Path(artifact.fp).read_bytes()
+                elif isinstance(artifact.fp, (bytes, io.IOBase)):
+                    content = artifact.to_bytes()
+                else:
+                    raise TypeError(
+                        f"no support fp type for bin writer:{type(artifact.fp)}, {artifact.fp}"
+                    )
+
+                _path, _meta = self._artifact_bin_writer.write(content)
+                artifact.link = Link(
+                    uri=self._STASH_URI,  # When bin writer is rotated, we can get the signatured uri
+                    offset=_meta.raw_data_offset,
+                    size=_meta.raw_data_size,
+                    bin_offset=_meta.offset,
+                    bin_size=_meta.size,
+                )
+                self._stash_uri_rows_map[_path].append((artifact, td_row))
+
+            # TODO: find a graceful cleanup method
+            # forbid to write cache and fp contents into datastore table
+            artifact.clear_bytes()
+
+        self._tabular_dataset.put(td_row)
+
+    def _handle_bin_sync(self, bin_path: Path) -> None:
+        size = bin_path.stat().st_size
+        if self._in_standalone:
+            uri, _ = DatasetStorage.save_data_file(bin_path, remove_src=True)
+        else:
+            sign_name = blake2b_file(bin_path)
+            # TODO: do upload to cloud with new dataset bin storage api
+            uri = sign_name
+            raise NoSupportError(
+                "no support upload bin files into cloud instance directly"
+            )
+
+        self._signed_bins_meta.append(
+            MappingDatasetBuilder._SignedBinMeta(
+                name=uri,
+                algo=BLAKE2B_SIGNATURE_ALGO,
+                size=size,
+            )
+        )
+
+        for artifact, td_row in self._stash_uri_rows_map.get(bin_path, []):
+            artifact.link.uri = uri  # type: ignore
+            self._tabular_dataset.put(td_row)
+
+        if bin_path in self._stash_uri_rows_map:
+            del self._stash_uri_rows_map[bin_path]
+
+    def _rows_put_worker(self) -> None:
+        try:
+            while True:
+                row = self._rows_put_queue.get(block=True, timeout=None)
+                if row is None:
+                    break
+                elif isinstance(
+                    row, Exception
+                ):  # receive exception from ArtifactsBinSyncThread
+                    raise row
+                else:
+                    self._handle_row_put(row)
+        except Exception as e:
+            self._rows_put_exception = e
+            raise
+        finally:
+            self._artifact_bin_writer.close()
+            self._abs_queue.put(None)
+
+    def _abs_worker(self) -> None:
+        try:
+            while True:
+                bin_path = self._abs_queue.get(block=True, timeout=None)
+                if bin_path is None:
+                    break
+                else:
+                    self._handle_bin_sync(bin_path)
+        except Exception as e:
+            self._abs_exception = e
+            self._rows_put_queue.put(e)
+            raise
+
+    def delete(self, key: t.Union[str, int]) -> None:
+        self._tabular_dataset.delete(key)
+
+    def flush(self, artifacts_flush: bool = False) -> None:
+        while not self._rows_put_queue.empty():
+            time.sleep(0.1)
+
+        if artifacts_flush:
+            self._artifact_bin_writer._rotate()
+            while not self._abs_queue.empty():
+                time.sleep(0.1)
+
+        self._tabular_dataset.flush()
+
+    def _threads_join(self) -> None:
+        self._abs_thread.join()
+        self._rows_put_thread.join()
+
+    def close(self) -> None:
+        self._rows_put_queue.put(None)
+        self._threads_join()
+        self._tabular_dataset.close()
+
+        empty_dir(self._artifact_bin_tmpdir)
+        self._raise_thread_daemons_exception()
+
+    @property
+    def signature_bins_meta(self) -> t.List[MappingDatasetBuilder._SignedBinMeta]:
+        return self._signed_bins_meta

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -4,6 +4,7 @@ import copy
 import json
 import math
 import time
+import queue
 import base64
 import struct
 import typing as t
@@ -11,6 +12,7 @@ import threading
 from http import HTTPStatus
 from types import TracebackType
 from pathlib import Path
+from binascii import crc32
 from unittest.mock import patch, MagicMock
 from concurrent.futures import as_completed, ThreadPoolExecutor
 
@@ -41,7 +43,7 @@ from starwhale.utils.error import (
     FieldTypeOrValueError,
 )
 from starwhale.api._impl.wrapper import Dataset as DatastoreWrapperDataset
-from starwhale.api._impl.wrapper import DatasetTableKind
+from starwhale.api._impl.wrapper import DatasetTableKind, _get_remote_project_id
 from starwhale.core.dataset.copy import DatasetCopy
 from starwhale.core.dataset.type import (
     Link,
@@ -73,7 +75,11 @@ from starwhale.core.dataset.tabular import (
     get_dataset_consumption,
 )
 from starwhale.api._impl.dataset.loader import DataRow
-from starwhale.api._impl.dataset.builder import (
+from starwhale.api._impl.dataset.builder.mapping_builder import (
+    RotatedBinWriter,
+    MappingDatasetBuilder,
+)
+from starwhale.api._impl.dataset.builder.iterable_builder import (
     BinWriter,
     RowWriter,
     _data_magic,
@@ -1769,3 +1775,400 @@ class TestRowWriter(BaseTestCase):
         item = rw._queue.get(block=True)
         assert item.index == 1  # type: ignore
         rw.flush()
+
+
+class TestRotatedBinWriter(TestCase):
+    def setUp(self) -> None:
+        self.setUpPyfakefs()
+
+    def test_bin_format(self) -> None:
+        workdir = Path("/home/test")
+        content = b"123456"
+        alignment_size = 64
+
+        with RotatedBinWriter(workdir, alignment_bytes_size=alignment_size) as w:
+            w.write(content)
+
+        bin_path = list(workdir.iterdir())[0]
+        bin_content = bin_path.read_bytes()
+        assert len(bin_content) == alignment_size
+
+        groups = struct.unpack(">IIQIIII", bin_content[0:32])
+        assert len(groups) == 7
+        assert struct.pack(">I", groups[0]) == b"SWDS"  # header magic
+        assert struct.pack(">I", groups[-1]) == b"SDWS"  # data magic
+        assert groups[1] == crc32(content)  # data crc32
+        assert groups[2] == 0  # reserved
+        assert groups[3] == len(content)  # size
+        assert groups[4] == alignment_size - len(content) - 32  # padding size
+        assert groups[5] == 0  # header version
+
+        c_start, c_end = 32, 32 + len(content)
+        assert bin_content[c_start:c_end] == content
+        assert bin_content[c_end:] == b"\0" * groups[4]
+
+    def test_write_one_bin(self) -> None:
+        workdir = Path("/home/test")
+        content = b"abcdef"
+
+        assert not workdir.exists()
+
+        rbw = RotatedBinWriter(workdir, alignment_bytes_size=1, volume_bytes_size=100)
+        assert not rbw._current_writer.closed
+        bin_path, bin_section = rbw.write(content)
+        assert rbw._wrote_size == bin_section.size
+        assert rbw.working_path == bin_path
+        rbw.close()
+
+        assert bin_section.offset == 0
+        assert bin_section.size == len(content) + RotatedBinWriter._header_size
+        assert bin_section.raw_data_offset == RotatedBinWriter._header_size
+        assert bin_section.raw_data_size == len(content)
+
+        assert rbw.working_path != bin_path
+        assert rbw._wrote_size == 0
+
+        assert workdir.exists()
+        assert bin_path.exists()
+        assert rbw.rotated_paths == [bin_path] == list(workdir.iterdir())
+        assert bin_path.parent == workdir
+        assert rbw._current_writer.closed
+
+    def test_write_multi_bins(self) -> None:
+        workdir = Path("/home/test")
+        rbw = RotatedBinWriter(workdir, alignment_bytes_size=1, volume_bytes_size=1)
+        cnt = 10
+        for _ in range(0, cnt):
+            rbw.write(b"\0")
+        rbw.close()
+        assert len(rbw.rotated_paths) == cnt
+        assert set(rbw.rotated_paths) == set(workdir.iterdir())
+        assert rbw.working_path not in rbw.rotated_paths
+
+    def test_notify(self) -> None:
+        notify_queue = queue.Queue()
+
+        cnt = 10
+        assert notify_queue.qsize() == 0
+        with RotatedBinWriter(
+            Path("/home/test"),
+            alignment_bytes_size=1,
+            volume_bytes_size=1,
+            rotated_bin_notify_queue=notify_queue,
+        ) as w:
+            for i in range(0, cnt):
+                w.write(b"\0")
+                assert notify_queue.qsize() == i + 1
+
+        queue_paths = [notify_queue.get() for _ in range(0, cnt)]
+        assert queue_paths == w.rotated_paths
+
+    def test_close(self) -> None:
+        rbw = RotatedBinWriter(Path("/home/test"))
+        rbw.close()
+
+        rbw = RotatedBinWriter(Path("/home/test"))
+        rbw.write(b"123")
+        rbw.close()
+
+        assert rbw._current_writer.closed
+        with self.assertRaisesRegex(ValueError, "I/O operation on closed file"):
+            rbw.close()
+
+    def test_alignment(self) -> None:
+        class _M(t.NamedTuple):
+            content_size: int
+            alignment_size: int
+            expected_bin_size: int
+
+        cases = [
+            _M(0, 1, 32),
+            _M(0, 31, 62),
+            _M(0, 64, 64),
+            _M(1, 1, 33),
+            _M(3, 1, 35),
+            _M(32, 1, 64),
+            _M(32, 63, 126),
+            _M(32, 64, 64),
+            _M(32, 32, 64),
+            _M(32, 65, 65),
+            _M(16, 16, 48),
+            _M(16, 4096, 4096),
+        ]
+
+        for index, meta in enumerate(cases):
+            workdir = Path(f"/home/test/{index}")
+            with RotatedBinWriter(
+                workdir, alignment_bytes_size=meta.alignment_size
+            ) as w:
+                w.write(b"\0" * meta.content_size)
+
+            self.assertEqual(
+                list(workdir.iterdir())[0].stat().st_size,
+                meta.expected_bin_size,
+                msg=f"content:{meta.content_size}, alignment:{meta.alignment_size}, expected:{meta.expected_bin_size}",
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "alignment_bytes_size must be greater than zero"
+        ):
+            RotatedBinWriter(Path("."), alignment_bytes_size=0)
+
+
+class TestMappingDatasetBuilder(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.workdir = Path(self.local_storage) / "test"
+        self.project_name = "self"
+        self.dataset_name = "mnist"
+        self.holder_dataset_version = "_current"
+
+        self.tdb = TabularDataset(
+            name=self.dataset_name,
+            version=self.holder_dataset_version,
+            project=self.project_name,
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        _get_remote_project_id.cache_clear()
+
+    def test_put(self) -> None:
+        mdb = MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        )
+        mdb.put(DataRow(index=1, features={"label": 1}))
+        mdb.put(DataRow(index=1, features={"label-another": 2}))
+        mdb.close()
+
+        assert len(mdb.signature_bins_meta) == 0
+        assert mdb._abs_queue.qsize() == 0
+        assert mdb._rows_put_queue.qsize() == 0
+
+        rows = list(self.tdb.scan())
+        assert rows[0].id == 1
+        assert rows[0].features == {"label": 1, "label-another": 2}
+
+    def test_put_swds_artifacts(self) -> None:
+        mdb = MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        )
+        mdb.put(DataRow(index=1, features={"bin": Binary(b"123")}))
+        fpath = Path(self.workdir / "test.bin")
+        fpath.write_bytes(b"abc")
+        mdb.put(DataRow(index=2, features={"bin": Binary(fpath)}))
+
+        assert mdb._abs_thread.is_alive()
+        assert mdb._rows_put_thread.is_alive()
+
+        mdb.put(DataRow(index=3, features={"bin": Binary(str(fpath))}))
+        mdb.put(DataRow(index=4, features={"bin": Binary(io.BytesIO(b"000"))}))
+
+        assert mdb._artifact_bin_tmpdir.exists()
+
+        mdb.close()
+
+        assert not mdb._artifact_bin_tmpdir.exists()
+
+        rows = list(self.tdb.scan())
+        assert len(rows) == 4
+        uris = list({r.features["bin"].link.uri for r in rows})
+        assert len(uris) == 1
+        sign_meta_list = mdb.signature_bins_meta
+        assert len(sign_meta_list) == 1
+        assert uris[0] == sign_meta_list[0].name
+
+        stored_bin_path = (
+            Path(self.local_storage)
+            / ".objectstore"
+            / "blake2b"
+            / uris[0][:2]
+            / uris[0]
+        )
+        assert stored_bin_path.exists()
+        assert stored_bin_path.stat().st_size == sign_meta_list[0].size
+        assert sign_meta_list[0].algo == "blake2b"
+
+        assert not mdb._abs_thread.is_alive()
+        assert not mdb._rows_put_thread.is_alive()
+        assert mdb._abs_queue.qsize() == 0
+        assert mdb._rows_put_queue.qsize() == 0
+        assert len(mdb._stash_uri_rows_map) == 0
+
+    def test_put_link_artifacts(self) -> None:
+        uri = "s3://1.1.1.1/dataset/mnist/t10k-ubyte"
+        with MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        ) as mdb:
+            mdb.put(
+                DataRow(
+                    index=1,
+                    features={"image": Image(link=Link(uri, offset=0, size=784))},
+                )
+            )
+
+        assert len(mdb.signature_bins_meta) == 0
+        rows = list(self.tdb.scan())
+        assert len(rows) == 1
+        image = rows[0].features["image"]
+        assert image.link.uri == uri
+        assert image.link.offset == 0
+        assert image.link.size == 784
+
+    def test_put_mixed_artifacts(self) -> None:
+        uri = "s3://1.1.1.1/dataset/mnist/t10k-ubyte"
+        with MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        ) as mdb:
+            mdb.put(
+                DataRow(
+                    index=1,
+                    features={"image": Image(link=Link(uri, offset=0, size=784))},
+                )
+            )
+
+            mdb.put(DataRow(index=2, features={"image": Image(b"\0")}))
+
+        assert len(mdb.signature_bins_meta) == 1
+        rows = list(self.tdb.scan())
+        assert len(rows) == 2
+        assert rows[0].features["image"].link.uri == uri
+        assert rows[1].features["image"].link.uri == mdb.signature_bins_meta[0].name
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_put_raise_exception(self) -> None:
+        mdb = MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        )
+        mdb.put(DataRow(index=5, features={"bin": Binary(1)}))  # type: ignore
+        mdb.flush()
+        exception_msg = (
+            "RowPutThread raise exception: no support fp type for bin writer"
+        )
+        with self.assertRaisesRegex(threading.ThreadError, exception_msg):
+            mdb.put(DataRow(index=5, features={}))
+
+        mdb = MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        )
+        mdb.put(DataRow(index=5, features={"bin": Binary(1)}))  # type: ignore
+        with self.assertRaisesRegex(threading.ThreadError, exception_msg):
+            mdb.close()
+
+    def test_delete(self) -> None:
+        mdb = MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        )
+        for i in range(0, 10):
+            mdb.put(DataRow(index=i, features={"label": i}))
+
+        mdb.flush()
+        for i in range(0, 9):
+            mdb.delete(i)
+
+        mdb.close()
+        rows = list(self.tdb.scan())
+        assert len(rows) == 1
+        assert rows[0].id == 9
+
+    def test_close(self) -> None:
+        mdb = MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        )
+        for i in range(0, 10):
+            mdb.put(DataRow(index=i, features={"label": i}))
+
+        mdb.close()
+        assert mdb._abs_queue.qsize() == mdb._rows_put_queue.qsize() == 0
+        assert not mdb._abs_thread.is_alive()
+        assert not mdb._rows_put_thread.is_alive()
+        assert mdb._artifact_bin_writer._current_writer.closed
+
+        mdb.close()
+
+    def test_flush_artifacts(self) -> None:
+        mdb = MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+            bin_volume_bytes_size=1024 * 1024,
+        )
+        mdb.put(DataRow(index=1, features={"bin": Binary(b"123")}))
+        mdb.flush(artifacts_flush=False)
+
+        mdb.put(DataRow(index=2, features={"bin": Binary(b"123")}))
+        mdb.flush(artifacts_flush=True)
+
+        mdb.put(DataRow(index=3, features={"bin": Binary(b"123")}))
+        mdb.put(DataRow(index=4, features={"bin": Binary(b"123")}))
+        mdb.flush(artifacts_flush=True)
+
+        mdb.close()
+
+        assert len(mdb.signature_bins_meta) == 2
+
+    def test_close_empty(self) -> None:
+        MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+        ).close()
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    @Mocker()
+    def test_put_for_cloud(self, rm: Mocker) -> None:
+        instance_uri = "http://1.1.1.1"
+        rm.request(
+            HTTPMethod.GET,
+            f"{instance_uri}/api/v1/project/self",
+            json={"data": {"id": 1, "name": "project"}},
+        )
+        update_req = rm.request(
+            HTTPMethod.POST, f"{instance_uri}/api/v1/datastore/updateTable"
+        )
+
+        os.environ[SWEnv.instance_token] = "1234"
+
+        mdb = MappingDatasetBuilder(
+            workdir=self.workdir,
+            dataset_name=self.dataset_name,
+            project_name=self.project_name,
+            instance_name=instance_uri,
+        )
+        mdb.put(
+            DataRow(
+                index=1,
+                features={
+                    "bin": Binary(link=Link(uri="s3://1.1.1.1/a/b/c", offset=1, size=1))
+                },
+            )
+        )
+        mdb.flush()
+
+        mdb.put(DataRow(index=1, features={"bin": Binary(b"abc")}))
+        mdb.flush()
+
+        with self.assertRaisesRegex(
+            threading.ThreadError,
+            "no support upload bin files into cloud instance directly",
+        ):
+            mdb.put(DataRow(index=1, features={"label": 1}))
+            mdb.close()
+
+        assert update_req.called


### PR DESCRIPTION
## Description
- changes: 
  - rename BuildExcutor to IterableBuildExecutor
  - add MappingDatasetBuilder
    - provide `put` and `delete` interfaces to create the dataset. But `IterableBuildExecutor` needs an iterable function.
    - sync swds-bin format artifacts for the cloud instance automatically.
- TODO:
  - https://github.com/star-whale/starwhale/pull/1973 will use `MappingDatasetBuilder` to update-create-delete dataset.
  - `swcli dataset build --from-iter` will use `MappingDatasetBuilder` to build dataset.
- related issue:   https://github.com/star-whale/starwhale/issues/1940

## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
