### PR TITLE
fix(e2e): torch 2.0 has no _six module

### DIFF
--- a/example/PennFudanPed/pfp/utils/coco_eval.py
+++ b/example/PennFudanPed/pfp/utils/coco_eval.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 import numpy as np
 import torch
-import torch._six
 import pycocotools.mask as mask_util
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
@@ -249,7 +248,7 @@ def loadRes(self, resFile):
 
     # print('Loading and preparing results...')
     # tic = time.time()
-    if isinstance(resFile, torch._six.string_classes):
+    if isinstance(resFile, (str, bytes)):
         anns = json.load(open(resFile))
     elif type(resFile) == np.ndarray:
         anns = self.loadNumpyAnnotations(resFile)


### PR DESCRIPTION
## Description
After torch being upgrade to 2.0, there no `_six` module there
![image](https://user-images.githubusercontent.com/89630947/225839754-6bd7f316-2e62-40af-a0df-807acea47411.png)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
