### PR TITLE
fix(console): resolve the gitignore missing issue after yarn building

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -132,7 +132,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "start": "vite --host 0.0.0.0 --force",
-    "build": "NODE_OPTIONS='--max-old-space-size=5120' vite build",
+    "build": "NODE_OPTIONS='--max-old-space-size=5120' vite build; git checkout build",
     "serve": "vite preview",
     "test": "jest --config jest/jest.config.ts",
     "test:coverage": "jest --coverage --config jest/jest.config.ts",


### PR DESCRIPTION
## Description

`console/build/.gitignore` will be deleted by vite, and the whole build dir will be treated as dirty

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
