### PR TITLE
feat(client): model building support eval layout yaml config

### DIFF
--- a/client/starwhale/consts/__init__.py
+++ b/client/starwhale/consts/__init__.py
@@ -17,9 +17,16 @@ ENV_SW_LOCAL_STORAGE = "SW_LOCAL_STORAGE"
 
 DEFAULT_STARWHALE_API_VERSION = "1.0"
 DEFAULT_MANIFEST_NAME = "_manifest.yaml"
+
+# evaluation related constants
 DEFAULT_EVALUATION_JOB_NAME = "default"
-DEFAULT_EVALUATION_JOBS_FNAME = "eval_jobs.yaml"
-DEFAULT_EVALUATION_SVC_META_FNAME = "svc.json"
+DEFAULT_EVALUATION_JOBS_FILE_NAME = "eval_jobs.yaml"
+EVALUATION_SVC_META_FILE_NAME = "svc.json"
+# auto generated evaluation panel layout file name from yaml or local console
+EVALUATION_PANEL_LAYOUT_JSON_FILE_NAME = "eval_panel_layout.json"
+# user defined evaluation panel layout file name
+EVALUATION_PANEL_LAYOUT_YAML_FILE_NAME = "eval_panel_layout.yaml"
+
 DEFAULT_LOCAL_SW_CONTROLLER_ADDR = "localhost:7827"
 LOCAL_CONFIG_VERSION = "2.0"
 DEFAULT_FILE_SIZE_THRESHOLD_TO_TAR_IN_MODEL = 10 * 1024  # 10KB

--- a/client/starwhale/web/panel.py
+++ b/client/starwhale/web/panel.py
@@ -1,10 +1,16 @@
+import json
 import os.path
 from pathlib import Path
 
 from fastapi import APIRouter
 from starlette.requests import Request
 
-from starwhale.consts import SW_AUTO_DIRNAME
+from starwhale.utils import load_yaml
+from starwhale.consts import (
+    SW_AUTO_DIRNAME,
+    EVALUATION_PANEL_LAYOUT_JSON_FILE_NAME,
+    EVALUATION_PANEL_LAYOUT_YAML_FILE_NAME,
+)
 from starwhale.utils.fs import ensure_file
 from starwhale.web.response import success, SuccessResp
 
@@ -12,21 +18,46 @@ router = APIRouter()
 prefix = "panel"
 
 
-def _setting_path() -> str:
-    return os.path.join(os.getcwd(), SW_AUTO_DIRNAME, "panel.json")
+def _setting_file() -> Path:
+    base = Path(os.path.join(os.getcwd(), SW_AUTO_DIRNAME))
+    yaml_fmt = base / EVALUATION_PANEL_LAYOUT_YAML_FILE_NAME
+    json_fmt = base / EVALUATION_PANEL_LAYOUT_JSON_FILE_NAME
+    # only one of them should exist
+    # we can not decide which one to use when both exist
+    if yaml_fmt.exists() and json_fmt.exists():
+        raise RuntimeError("Both yaml and json file exist, please remove one of them")
+
+    # prefer using yaml config for local development (manual edit)
+    if yaml_fmt.exists():
+        return yaml_fmt
+    return json_fmt
+
+
+def _is_yaml_fmt(file: Path) -> bool:
+    return file.name == EVALUATION_PANEL_LAYOUT_YAML_FILE_NAME
 
 
 @router.post("/setting/{project}/{key}")
 async def setting(project: str, key: str, request: Request) -> SuccessResp:
     content = await request.body()
-    ensure_file(_setting_path(), content.decode("utf-8"), parents=True)
+    f = _setting_file()
+    if _is_yaml_fmt(f):
+        raise RuntimeError(
+            "Can not save the console layout in yaml format when the manual edit yaml is exist"
+        )
+    ensure_file(f, content.decode("utf-8"), parents=True)
     return success({})
 
 
 @router.get("/setting/{project}/{key}")
 def get_setting(project: str, key: str) -> SuccessResp:
-    file = Path(_setting_path())
-    if not file.exists() or not file.is_file():
+    f = _setting_file()
+    if not f.exists() or not f.is_file():
         return success("")
-    with file.open("r") as f:
-        return success(f.read())
+
+    if _is_yaml_fmt(f):
+        # render yaml to json for console
+        content = load_yaml(f)
+        return success(json.dumps(content))
+    with f.open("r") as fd:
+        return success(fd.read())

--- a/console/src/domain/model/services/modelVersion.ts
+++ b/console/src/domain/model/services/modelVersion.ts
@@ -104,5 +104,5 @@ export async function fetchModelVersionPanelSetting(
     modelVersionId: string | undefined,
     token: string
 ) {
-    return fetchModelVersionFile(projectId, modelId, modelVersionId, token, 'panel.json')
+    return fetchModelVersionFile(projectId, modelId, modelVersionId, token, 'eval_panel_layout.json')
 }


### PR DESCRIPTION
## Description

- Add support for the yaml format layout config file
- `sw mp build` will generate the JSON format config from the yaml format if exists
- `sw eval info xx --web` support render from the yaml config file
  - refuse to save the panel layout settings from the console when using yaml config

related to #1980

The yaml format config demo:

```yaml
layouts:
  - title: model builtin layout
    panels:
      - title: tables for datastore
        charts:
        - type: table
          table: confusion_matrix/binarylabel
        - type: table
          table: results
      - title: charts
        height: 500
        charts:
        - type: roc_auc
          table: roc_auc/1
          x: tpr
          y: fpr
          title: roc auc for label 1
        - type: confusion_matrix
          table: confusion_matrix/binarylabel
          title: confusion matrix

```

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
