### PR TITLE
fix(console): eval pages works with project name in uri

### DIFF
--- a/console/src/api/ApiHeader.tsx
+++ b/console/src/api/ApiHeader.tsx
@@ -17,7 +17,7 @@ export default function ApiHeader() {
     const lastErrMsgRef = useRef<Record<string, number>>({})
     const lastLocationPathRef = useRef(location.pathname)
     const [t] = useTranslation()
-    const projectId = React.useMemo(() => location?.pathname.match(/^\/projects\/(\d*)\/?/)?.[1], [location])
+    const projectId = React.useMemo(() => location?.pathname.match(/^\/projects\/(.+?)\/.*/)?.[1], [location])
     const projectInfo = useFetchProject(projectId)
     const { setProject } = useProject()
     const { role: projectRole } = useFetchProjectRole(projectId as string)

--- a/console/src/components/Editor/index.tsx
+++ b/console/src/components/Editor/index.tsx
@@ -6,15 +6,16 @@ import WidgetRenderTree from '@starwhale/core/widget/WidgetRenderTree'
 import { EventBusSrv } from '@starwhale/core/events'
 import { useJob } from '@/domain/job/hooks/useJob'
 import { tablesOfEvaluation, WidgetStoreState } from '@starwhale/core'
-import { useParams } from 'react-router-dom'
 import BusyPlaceholder from '@starwhale/ui/BusyLoaderWrapper/BusyPlaceholder'
 import { tranformState } from './utils'
+import { useProject } from '@project/hooks/useProject'
 
 registerWidgets()
 
 export function withEditorRegister(EditorApp: React.FC) {
     return function EditorLoader(props: any) {
-        const { projectId } = useParams<{ projectId: string }>()
+        const { project } = useProject()
+        const projectId = project?.id
         const { job } = useJob()
         // eslint-disable-next-line prefer-template
         const prefix = projectId && job?.uuid ? tablesOfEvaluation(projectId, job?.uuid) + '/' : undefined

--- a/console/src/pages/Evaluation/EvaluationListCard.tsx
+++ b/console/src/pages/Evaluation/EvaluationListCard.tsx
@@ -22,12 +22,15 @@ import { toaster } from 'baseui/toast'
 import EvaluationListCompare from './EvaluationListCompare'
 import { BusyPlaceholder, Button, GridResizer } from '@starwhale/ui'
 import { useLocalStorage } from 'react-use'
+import { useProject } from '@project/hooks/useProject'
 
 export default function EvaluationListCard() {
     const { expandedWidth, expanded } = useDrawer()
     const [t] = useTranslation()
     const history = useHistory()
-    const { projectId } = useParams<{ projectId: string }>()
+    const { projectId: projectFromUri } = useParams<{ projectId: string }>()
+    const { project } = useProject()
+    const projectId = project?.id || projectFromUri
     const summaryTableName = React.useMemo(() => {
         return tableNameOfSummary(projectId)
     }, [projectId])

--- a/console/src/pages/Evaluation/EvaluationWidgetResults.tsx
+++ b/console/src/pages/Evaluation/EvaluationWidgetResults.tsx
@@ -15,6 +15,7 @@ import { toaster } from 'baseui/toast'
 import { fetchModelVersionPanelSetting } from '@model/services/modelVersion'
 import { getToken } from '@/api'
 import { tryParseSimplified } from '@/domain/panel/utils'
+import { useProject } from '@project/hooks/useProject'
 
 const PAGE_TABLE_SIZE = 100
 
@@ -197,7 +198,9 @@ interface Layout {
 }
 
 function EvaluationWidgetResults() {
-    const { jobId, projectId } = useParams<{ jobId: string; projectId: string }>()
+    const { jobId, projectId: projectFromUri } = useParams<{ jobId: string; projectId: string }>()
+    const { project } = useProject()
+    const projectId = project?.id ?? projectFromUri
     const { job } = useJob()
     const storeKey = job?.modelName ? ['evaluation-model', job?.modelName].join('-') : ''
     const [currentLayout, setCurrentLayout] = React.useState<Layout | undefined>(undefined)


### PR DESCRIPTION
## Description

`listTables` can not works with project name, fix it

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
