### PR TITLE
feat(client): eval info --web support remote instance

### DIFF
--- a/client/starwhale/web/server.py
+++ b/client/starwhale/web/server.py
@@ -1,16 +1,20 @@
 import typing as t
 import os.path
+from urllib.parse import urlparse
 
+import httpx
 import pkg_resources
 from fastapi import FastAPI, APIRouter
 from fastapi.responses import ORJSONResponse
 from typing_extensions import Protocol
 from starlette.requests import Request
-from starlette.responses import FileResponse
+from starlette.responses import Response, FileResponse, StreamingResponse
+from starlette.background import BackgroundTask
 from starlette.exceptions import HTTPException
 from starlette.staticfiles import StaticFiles
 
 from starwhale.web import user, panel, system, project, data_store
+from starwhale.base.uricomponents.instance import Instance
 
 STATIC_DIR_DEV = pkg_resources.resource_filename("starwhale", "web/ui")
 
@@ -27,32 +31,68 @@ class Server(FastAPI):
     def add_component(self, component: Component) -> None:
         self.include_router(component.router, prefix=f"/{component.prefix.lstrip('/')}")
 
-    @staticmethod
-    def with_components(components: t.List[Component]) -> FastAPI:
+    @classmethod
+    def mount_static(cls, app: FastAPI) -> FastAPI:
+        def index() -> FileResponse:
+            return FileResponse(os.path.join(STATIC_DIR_DEV, "index.html"))
+
+        app.add_route("/", index, methods=["GET"])
+        app.mount("/", StaticFiles(directory=STATIC_DIR_DEV), name="assets")
+
+        def not_found_exception_handler(
+            request: Request, exc: HTTPException
+        ) -> FileResponse:
+            return FileResponse(os.path.join(STATIC_DIR_DEV, "index.html"))
+
+        app.add_exception_handler(404, not_found_exception_handler)
+
+        return app
+
+    @classmethod
+    def with_components(cls, components: t.List[Component]) -> FastAPI:
         api = Server()
         for component in components:
             api.add_component(component)
 
         app = FastAPI()
         app.mount("/api/v1", api)
+        return cls.mount_static(app)
 
-        @app.get("/")
-        def index() -> FileResponse:
-            return FileResponse(os.path.join(STATIC_DIR_DEV, "index.html"))
+    @classmethod
+    def default(cls) -> FastAPI:
+        return cls.with_components([panel, project, data_store, user, system])
 
-        app.mount("/", StaticFiles(directory=STATIC_DIR_DEV), name="assets")
+    @classmethod
+    def proxy(cls, instance: Instance) -> FastAPI:
+        app = FastAPI()
+        client = httpx.AsyncClient(base_url=instance.url)
+        host = urlparse(instance.url).netloc
 
-        @app.exception_handler(404)
-        def not_found_exception_handler(
-            request: Request, exc: HTTPException
-        ) -> FileResponse:
-            return FileResponse(os.path.join(STATIC_DIR_DEV, "index.html"))
+        async def proxy(request: Request) -> Response:
+            url = httpx.URL(path=request.url.path, params=request.query_params)
+            headers = request.headers.mutablecopy()
+            headers.update({"Authorization": instance.token, "Host": host})
+            content = await request.body()
+            req = client.build_request(
+                request.method, url, content=content, headers=headers
+            )
+            resp = await client.send(req, stream=True)
+            return StreamingResponse(
+                resp.aiter_bytes(),
+                status_code=resp.status_code,
+                headers=resp.headers,
+                background=BackgroundTask(resp.aclose),
+            )
 
-        return app
+        # serve panel related api in local mode for customizing panel
+        app.include_router(panel.router, prefix="/api/v1/panel")
+        app.add_route(
+            "/api/v1/{path:path}",
+            proxy,
+            methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
+        )
 
-    @staticmethod
-    def default() -> FastAPI:
-        return Server.with_components([panel, project, data_store, user, system])
+        return cls.mount_static(app)
 
 
 # for testing


### PR DESCRIPTION
## Description

`sw eval info --web` support remote instance

- serve local assets like the index.html and js 
- serve panel-related API for customizing layout
- proxy all the other APIs with the auth and host header

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
