### PR TITLE
fix(e2e): remove possible ^M char in auth header

### DIFF
--- a/scripts/client_test/update_controller_setting.sh
+++ b/scripts/client_test/update_controller_setting.sh
@@ -17,6 +17,8 @@ for line in $resps; do
   fi
 done
 
+export auth_header=$(echo ${auth_header%$'\r'})
+
 curl -X 'POST' \
   "$CONTROLLER_URL/api/v1/system/setting" \
   -H 'accept: application/json' \


### PR DESCRIPTION
## Description
` ^M` in request header is legal before https://github.com/star-whale/starwhale/pull/1909
Now it should be trimed or `400` will be raised by server

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
