### PR TITLE
fix(console): set ploty auto layout  when large mount of data

### DIFF
--- a/console/packages/starwhale-ui/src/Plotly/utils.ts
+++ b/console/packages/starwhale-ui/src/Plotly/utils.ts
@@ -129,8 +129,6 @@ export function getHeatmapConfig(title = '', labels: string[], heatmap: number[]
         layout = {
             ...Layout.auto,
             title,
-            width: nums * 30,
-            height: nums * 30,
         }
     }
 


### PR DESCRIPTION
## Description

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
