### PR TITLE
chore(controller): datastore query and scan api support revision

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
@@ -54,6 +54,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -154,11 +155,13 @@ public class DataStoreController implements DataStoreApi {
                                     throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE,
                                             "table name should not be null or empty: " + x);
                                 }
+                                var ts = StringUtils.hasText(x.getRevision()) ? Long.parseLong(x.getRevision()) : 0;
                                 return DataStoreScanRequest.TableInfo.builder()
                                         .tableName(x.getTableName())
                                         .columnPrefix(x.getColumnPrefix())
                                         .columns(DataStoreController.convertColumns(x.getColumns()))
                                         .keepNone(x.isKeepNone())
+                                        .timestamp(ts)
                                         .build();
                             })
                             .collect(Collectors.toList()))
@@ -223,6 +226,7 @@ public class DataStoreController implements DataStoreApi {
                 .rawResult(request.isRawResult())
                 .encodeWithType(request.isEncodeWithType())
                 .ignoreNonExistingTable(request.isIgnoreNonExistingTable())
+                .timestamp(StringUtils.hasText(request.getRevision()) ? Long.parseLong(request.getRevision()) : 0)
                 .build());
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/QueryTableRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/QueryTableRequest.java
@@ -34,4 +34,5 @@ public class QueryTableRequest {
     private boolean rawResult;
     private boolean encodeWithType;
     private boolean ignoreNonExistingTable = true;
+    private String revision;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/TableDesc.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/TableDesc.java
@@ -26,4 +26,5 @@ public class TableDesc {
     private String columnPrefix;
     private List<ColumnDesc> columns;
     private boolean keepNone;
+    private String revision;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
@@ -157,9 +157,9 @@ public class DataStore {
         //noinspection ConstantConditions
         table.lock();
         try {
-            var revision = table.update(schema, records);
+            var ts = table.update(schema, records);
             this.dirtyTables.put(table, "");
-            return revision;
+            return Long.toString(ts);
         } finally {
             table.unlock();
         }
@@ -191,7 +191,7 @@ public class DataStore {
             var schema = table.getSchema();
             var columns = this.getColumnAliases(schema, req.getColumns());
             var results = new ArrayList<RecordResult>();
-            var timestamp = req.getTimestamp() * 1000;
+            var timestamp = req.getTimestamp();
             if (timestamp == 0) {
                 timestamp = System.currentTimeMillis();
             }
@@ -291,9 +291,9 @@ public class DataStore {
                 var ret = new TableMeta();
                 ret.tableName = info.getTableName();
                 if (info.getTimestamp() > 0) {
-                    ret.timestamp = info.getTimestamp() * 1000;
+                    ret.timestamp = info.getTimestamp();
                 } else if (req.getTimestamp() > 0) {
-                    ret.timestamp = req.getTimestamp() * 1000;
+                    ret.timestamp = req.getTimestamp();
                 } else {
                     ret.timestamp = currentTimestamp;
                 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreQueryRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreQueryRequest.java
@@ -30,6 +30,7 @@ import lombok.NoArgsConstructor;
 public class DataStoreQueryRequest {
 
     private String tableName;
+    // timestamp in milliseconds, used to filter out the data that is older than the timestamp for this table
     private long timestamp;
     private Map<String, String> columns;
     private List<OrderByDesc> orderBy;

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreScanRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreScanRequest.java
@@ -36,6 +36,7 @@ public class DataStoreScanRequest {
     public static class TableInfo {
 
         private String tableName;
+        // timestamp in milliseconds, used to filter out the data that is older than the timestamp for this table
         private long timestamp;
         private String columnPrefix;
         private Map<String, String> columns;
@@ -43,6 +44,7 @@ public class DataStoreScanRequest {
     }
 
     private List<TableInfo> tables;
+    // timestamp in milliseconds, used to filter out the data that is older than the timestamp for all tables
     private long timestamp;
     private String start;
     private String startType;

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
@@ -27,8 +27,8 @@ public interface MemoryTable {
 
     void updateFromWal(Wal.WalEntry entry);
 
-    // update records, returns the revision
-    String update(TableSchemaDesc schema, List<Map<String, Object>> records);
+    // update records, returns the timestamp in milliseconds
+    long update(TableSchemaDesc schema, List<Map<String, Object>> records);
 
     Iterator<RecordResult> query(long timestamp,
             Map<String, String> columns,


### PR DESCRIPTION
## Description

- Use timestamp ms as revision for scan and query
- Ignore the entry with the key only which does not match the revision when scan

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
