### PR TITLE
bug(client): fix too large indexed-size number for localFS make_file

### DIFF
--- a/client/starwhale/core/dataset/store.py
+++ b/client/starwhale/core/dataset/store.py
@@ -504,6 +504,7 @@ class LocalFSStorageBackend(StorageBackend):
             if not data_path.exists():
                 data_path = bucket_path / _key
 
+        _end = min(_end, data_path.stat().st_size)
         with data_path.open("rb") as f:
             f.seek(_start)
             return io.BytesIO(f.read(_end - _start + 1))  # type: ignore


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/590748/228118352-2187f12c-c794-4974-a4fe-8577c438265b.png)


## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
