### PR TITLE
chore(dataset): hidden get_data_loader and get_dataset_consumption low-level api

### DIFF
--- a/client/starwhale/__init__.py
+++ b/client/starwhale/__init__.py
@@ -23,14 +23,12 @@ from starwhale.api.dataset import (
     NumpyBinary,
     BoundingBox3D,
     GrayscaleImage,
-    get_data_loader,
     LocalFSLinkAuth,
     DefaultS3LinkAuth,
     COCOObjectAnnotation,
 )
 from starwhale.api.evaluation import PipelineHandler
 from starwhale.core.job.context import Context
-from starwhale.core.dataset.tabular import get_dataset_consumption
 
 dataset = Dataset.dataset
 
@@ -47,7 +45,6 @@ __all__ = [
     "step",
     "pass_context",
     "Context",
-    "get_data_loader",
     "Link",
     "LinkAuth",
     "DefaultS3LinkAuth",
@@ -69,6 +66,5 @@ __all__ = [
     "BoundingBox3D",
     "GrayscaleImage",
     "COCOObjectAnnotation",
-    "get_dataset_consumption",
     "track",
 ]

--- a/client/starwhale/api/_impl/dataset/__init__.py
+++ b/client/starwhale/api/_impl/dataset/__init__.py
@@ -23,10 +23,8 @@ from starwhale.core.dataset.type import (
 )
 
 from .model import Dataset
-from .loader import get_data_loader
 
 __all__ = [
-    "get_data_loader",
     "Link",
     "LinkAuth",
     "DefaultS3LinkAuth",

--- a/client/starwhale/api/dataset.py
+++ b/client/starwhale/api/dataset.py
@@ -18,7 +18,6 @@ from ._impl.dataset import (
     NumpyBinary,
     BoundingBox3D,
     GrayscaleImage,
-    get_data_loader,
     LocalFSLinkAuth,
     DefaultS3LinkAuth,
     COCOObjectAnnotation,
@@ -28,7 +27,6 @@ from ._impl.dataset import (
 
 
 __all__ = [
-    "get_data_loader",
     "Link",
     "LinkAuth",
     "DefaultS3LinkAuth",

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -51,32 +51,18 @@ class Dataset(BaseBundle, metaclass=ABCMeta):
     def head(
         self, rows: int = 5, show_raw_data: bool = False
     ) -> t.List[t.Dict[str, t.Any]]:
-        from starwhale.api._impl.dataset import get_data_loader
+        from starwhale.api._impl.dataset.model import Dataset as SDKDataset
 
         ret = []
-        loader = get_data_loader(self.uri)
-        for idx, row in enumerate(loader._iter_meta()):
-            info: t.Dict[str, t.Any] = {}
-            if idx >= rows:
-                break
-            if show_raw_data:
-                data_row = loader._unpack_row(row)
-                info.update(
-                    {
-                        "index": data_row.index,
-                        "features": data_row.features,
-                        "id": idx,
-                    }
-                )
-            else:
-                info.update(
-                    {
-                        "index": row.id,
-                        "features": row.features,
-                        "id": idx,
-                    }
-                )
-            ret.append(info)
+        sds = SDKDataset.dataset(self.uri, readonly=True)
+        for idx, row in enumerate(sds.head(n=rows, skip_fetch_data=not show_raw_data)):
+            ret.append(
+                {
+                    "index": row.index,
+                    "features": row.features,
+                    "id": idx,
+                }
+            )
 
         return ret
 

--- a/client/tests/sdk/test_evaluation.py
+++ b/client/tests/sdk/test_evaluation.py
@@ -9,7 +9,6 @@ from unittest.mock import patch, MagicMock
 
 from pyfakefs.fake_filesystem_unittest import TestCase
 
-from starwhale import get_data_loader
 from starwhale.utils import gen_uniq_version
 from starwhale.consts import DEFAULT_PROJECT
 from starwhale.base.uri import URI
@@ -22,7 +21,7 @@ from starwhale.core.dataset.type import Link, DatasetSummary, GrayscaleImage
 from starwhale.core.dataset.store import ObjectStore, DatasetStorage
 from starwhale.api._impl.evaluation import PipelineHandler, EvaluationLogStore
 from starwhale.core.dataset.tabular import TabularDatasetRow, TabularDatasetInfo
-from starwhale.api._impl.dataset.loader import DataRow, DataLoader
+from starwhale.api._impl.dataset.loader import DataRow, DataLoader, get_data_loader
 
 from .. import ROOT_DIR, BaseTestCase
 

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -8,7 +8,6 @@ from requests_mock import Mocker
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from tests import ROOT_DIR
-from starwhale import get_data_loader
 from starwhale.utils import config
 from starwhale.consts import HTTPMethod, SWDSBackendType
 from starwhale.base.uri import URI
@@ -30,7 +29,7 @@ from starwhale.core.dataset.tabular import (
     TabularDatasetRow,
     get_dataset_consumption,
 )
-from starwhale.api._impl.dataset.loader import DataRow, DataLoader
+from starwhale.api._impl.dataset.loader import DataRow, DataLoader, get_data_loader
 
 
 class TestDataLoader(TestCase):

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/dataset/api/sdk.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/dataset/api/sdk.md
@@ -131,35 +131,3 @@ class LinkRawDatasetBuildExecutor(UserRawBuildExecutor):
 ## starwhale.BuildExecutor
 
 `SWDSBinBuildExecutor` 类的别称，同为swds-bin格式的数据集构建类。
-
-## starwhale.get_data_loader
-
-获取Starwhale Dataset的Data Loader，是一个可迭代的对象，能够获取数据集中具体样本的索引、data和annotations。Github上的[代码链接](https://github.com/star-whale/starwhale/blob/dc6e6fdeae2f7c5bd0e72ccd8fb50768b1ce0826/client/starwhale/api/_impl/dataset/loader.py)。该函数返回的loader有两种:一种是表示swds-bin格式的 `SWDSBinDataLoader`, 另一种是表示remote-link或user-raw格式的 `UserRawDataLoader`。两种loader类型目前都能处理在LocalFS和S3协议的对象存储上数据。
-
-```python
-def get_data_loader(
-    dataset_uri: URI,
-    start: int = 0,
-    end: int = sys.maxsize,
-    logger: t.Union[loguru.Logger, None] = None,
-) -> DataLoader:
-```
-
-|参数|说明|
-|---|---|
-|`dataset_uri`| `starwhale.URI` 对象 |
-|`start`| 数据集index的起始位，默认从0开始 |
-|`end`| 数据集index的结束位。start和end表示是左闭右开的区间，即 `start <= i < end` |
-|`logger`|可传入自定义的logger对象|
-
-使用示例如下：
-
-```python
-from starwhale import get_data_loader, URI
-
-uri = URI("mnist/version/latest", expected_type="dataset")
-data_loader = get_data_loader(dataset_uri=uri)
-
-for idx, data, annotations in data_loader:
-    ...
-```

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/sdk/overview.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/sdk/overview.md
@@ -17,7 +17,6 @@ Starwhale 提供一系列的Python SDK，帮助用户更容易的制作数据集
 
 - `multi_classification`: 修饰器，适用于多分类问题，用来简化cmp结果的进一步计算和结果存储，能更好的呈现评测结果。
 - `step`: 修饰器，可以指定DAG的依赖关系和Task数量、资源等配置，实现用户自定义评测过程。
-- `get_data_loader`: 获取Starwhale Dataset的Data Loader，是一个可迭代的对象，能够获取数据集中具体样本的索引、data和annotations。
 
 ## 数据类型
 

--- a/example/datasets/cifar100/example.py
+++ b/example/datasets/cifar100/example.py
@@ -2,18 +2,18 @@ import io
 
 from PIL import Image as PILImage
 
-from starwhale import URI, URIType, get_data_loader
+from starwhale import dataset
 
 
 def main():
-    uri = URI("cifar100-test/version/latest", expected_type=URIType.DATASET)
-    for idx, data in get_data_loader(uri, 0, 10):
-        with PILImage.open(io.BytesIO(data["image"].to_bytes())) as img:
+    ds = dataset("cifar100-test/version/latest")
+    for row in ds.head(n=10):
+        with PILImage.open(io.BytesIO(row.features.image.to_bytes())) as img:
             img.show()
         print(
             f"other data: "
-            f"fine({data['coarse_label_name']}[{data['coarse_label']}]), "
-            f"coarse({data['fine_label_name']}[{data['fine_label']}])"
+            f"fine({row.features['coarse_label_name']}[{row.features['coarse_label']}]), "
+            f"coarse({row.features['fine_label_name']}[{row.features['fine_label']}])"
         )
 
 

--- a/example/datasets/emnist/example.py
+++ b/example/datasets/emnist/example.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-from starwhale import URI, URIType, get_data_loader
+from starwhale import dataset
 
 
 def show_image(image) -> None:
@@ -10,14 +10,14 @@ def show_image(image) -> None:
 
 
 def main():
-    uri = URI("emnist-digits-test/version/latest", expected_type=URIType.DATASET)
-    for idx, data in get_data_loader(uri, 0, 10):
+    ds = dataset("emnist-digits-test/version/latest")
+    for row in ds[0:10]:
         show_image(
-            np.frombuffer(data["image"].to_bytes(), dtype=np.uint8).reshape(
-                data["image"].shape
+            np.frombuffer(row.features.image.to_bytes(), dtype=np.uint8).reshape(
+                row.features.image.shape
             )
         )
-        print(f"label({data['label']})")
+        print(f"label({row.features.label})")
 
 
 if __name__ == "__main__":

--- a/example/datasets/fgvc-aircraft/example.py
+++ b/example/datasets/fgvc-aircraft/example.py
@@ -2,14 +2,14 @@ import io
 
 from PIL import Image as PILImage
 
-from starwhale import URI, URIType, get_data_loader
+from starwhale import dataset
 
 
 def main():
-    uri = URI("fgvc-aircraft-family-test/version/latest", expected_type=URIType.DATASET)
-    for idx, data in get_data_loader(uri, 0, 10):
-        PILImage.open(io.BytesIO(data["image"].to_bytes())).show()
-        print(f"label({data['family']})")
+    ds = dataset("fgvc-aircraft-family-test/version/latest")
+    for row in ds[0:10]:
+        PILImage.open(io.BytesIO(row.features.image.to_bytes())).show()
+        print(f"label({row.features.family})")
 
 
 if __name__ == "__main__":

--- a/example/datasets/test_annotations/dataset.py
+++ b/example/datasets/test_annotations/dataset.py
@@ -7,11 +7,11 @@ from starwhale import (
     Link,
     Text,
     Image,
+    dataset,
     URIType,
     MIMEType,
     ClassLabel,
     BoundingBox,
-    get_data_loader,
     COCOObjectAnnotation,
 )
 from starwhale.api._impl.data_store import Link as PlainLink
@@ -71,16 +71,17 @@ def iter_swds_bin_item():
 def _load_dataset(uri):
     print("-" * 20)
     print(uri)
-    for idx, data in get_data_loader(uri, "idx-0", "idx-2"):
+    ds = dataset(uri, readonly=True)
+    for idx, features in ds["idx-0":"idx-2"]:
         print(
-            f"---->[{idx}] {data['text'].content} data-length:{len(data['text'].to_bytes())}"
+            f"---->[{idx}] {features.text.content} data-length:{len(features.text.to_bytes())}"
         )
         ats = "\n".join(
-            [f"\t{k}-{v}-{type(v)}-{_get_type(v)}" for k, v in data.items()]
+            [f"\t{k}-{v}-{type(v)}-{_get_type(v)}" for k, v in features.items()]
         )
-        print(f"data: {len(data)}\n {ats}")
-        if "artifact_s3_link" in data:
-            link = data["artifact_s3_link"]
+        print(f"data: {len(features)}\n {ats}")
+        if "artifact_s3_link" in features:
+            link = features["artifact_s3_link"]
             content = link.to_bytes(uri)
             image = PILImage.open(io.BytesIO(content))
             print(


### PR DESCRIPTION
- changes:
  - use `dataset` SDK to replace `get_data_loader` and `get_dataset_consumption` low-level api for users
  - update dataset examples
- related: 
  - #1940  

## Description

## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
