### PR TITLE
chore(client): make the internal options hidden in the `--help` output

### DIFF
--- a/client/starwhale/core/dataset/cli.py
+++ b/client/starwhale/core/dataset/cli.py
@@ -285,7 +285,7 @@ def _tag(
     view(dataset).tag(tags, remove, quiet)
 
 
-@dataset_cmd.command("head", help="Print the first 10 rows of the dataset")
+@dataset_cmd.command("head", help="Print the first 5 rows of the dataset")
 @click.argument("dataset")
 @click.option("-n", "--rows", default=5, help="Print the first NUM rows of the dataset")
 @click.option(

--- a/client/starwhale/core/eval/cli.py
+++ b/client/starwhale/core/eval/cli.py
@@ -17,7 +17,7 @@ from .view import (
 @click.group(
     "eval",
     cls=AliasedGroup,
-    help="Evaluation management, create/list/info/compare evaluation job",
+    help="Evaluation management, run/list/info/compare evaluation job",
 )
 @click.pass_context
 def eval_job_cmd(ctx: click.Context) -> None:
@@ -50,6 +50,7 @@ def _list(
     )
 
 
+# make the internal options hidden in the `--help` output.
 @eval_job_cmd.command("run", help="Run job")
 @click.option(
     "-p",
@@ -63,9 +64,9 @@ def _list(
     envvar=SWEnv.eval_version,
     default=None,
     help=f"Evaluation job version, env is {SWEnv.eval_version}",
+    hidden=True,
 )
 @click.option("--model", required=True, help="model uri or model.yaml dir path")
-# TODO:support multi dataset
 @click.option(
     "datasets",
     "--dataset",
@@ -81,26 +82,35 @@ def _list(
     "--step-spec",
     default="",
     type=str,
-    help="[Cloud_ONLY] A file contains the specification for steps of the job",
+    help="[Cloud_ONLY]a file contains the specification for steps of the job",
+    hidden=True,
 )
 @click.option(
     "--resource-pool",
     default="default",
     type=str,
-    help="[Cloud_ONLY] The node group you would like to run your job on",
+    help="[Cloud_ONLY]the job runs in the specified resource pool",
 )
 @click.option(
     "--use-docker",
     is_flag=True,
     help="[ONLY Standalone]use docker to run evaluation job",
 )
-@click.option("--gencmd", is_flag=True, help="[ONLY Standalone]gen docker run command")
-@click.option("--step", default="", help="Evaluation run step")
-@click.option("--task-index", default=-1, help="Index of tasks in the current step")
+@click.option(
+    "--gencmd",
+    is_flag=True,
+    help="[ONLY Standalone]gen docker run command",
+    hidden=True,
+)
+@click.option("--step", default="", help="Evaluation run step", hidden=True)
+@click.option(
+    "--task-index", default=-1, help="Index of tasks in the current step", hidden=True
+)
 @click.option(
     "--override-task-num",
     default=0,
     help="Total num of tasks in the current step",
+    hidden=True,
 )
 def _run(
     project: str,

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -220,13 +220,20 @@ def _recover(model: str, force: bool) -> None:
     envvar=SWEnv.eval_version,
     default=None,
     help=f"Evaluation job version, env is {SWEnv.eval_version}",
+    hidden=True,
 )
-@click.option("--step", default="", help="Evaluation run step")
-@click.option("--task-index", default=None, help="Index of tasks in the current step")
+@click.option("--step", default="", help="Evaluation run step", hidden=True)
+@click.option(
+    "--task-index",
+    default=None,
+    help="Index of tasks in the current step",
+    hidden=True,
+)
 @click.option(
     "--override-task-num",
     default=0,
     help="Total num of tasks in the current step",
+    hidden=True,
 )
 @click.option("--runtime", default="", help="runtime uri")
 @click.option(

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/evaluation/api/cli.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/evaluation/api/cli.md
@@ -40,9 +40,6 @@ swcli eval run [OPTIONS]
 
 |参数|参数别名|必要性|类型|默认值|说明|
 |---|-------|-----|---|------|---|
-|`--version`||❌|String|生成一个随机ID|模型评测的版本号，可以使用该参数进行分Step调试。该参数也可以通过 `SW_EVALUATION_VERSION` 环境变量来设置。|
-|`--step`||❌|String||评测任务的Step名称，实现只执行该Step的目的。如果不指定，则所有Step都会运行，对于继承 `starwhale.PipelineHandler` 的评测任务，就是ppl和cmp两个Step。|
-|`--task-index`||❌|Integer|| `--task-index` 参数用来表明 `--step` 中Step的第n个Task会执行，如果不指定 `--task-index`，则该Step中所有Tasks都会执行。Task索引从0开始，会通过 `starwhale.Context` 传入用户程序中，很多场景下Task的索引值用来指导评测数据集如何分割，实现评测的时候同一个Step的不同Task处理不同部分的评测数据集，实现并行提速。另外需要注意的是，`--task-index` 只有在同时设置 `--step` 参数时才生效。|
 |`--model`||✅||String||Model URI或model.yaml所在的目录。如果在Cloud Instance上运行，支持Model URI形式。|
 |`--dataset`||✅||String||Dataset URI，该参数也可以通过 `SW_DATASET_URI` 环境变量来设置。|
 |`--runtime`||❌|String||`--runtime`参数为Standalone Instance中的Runtime URI。若设置，则表示运行模型评测的时候会使用该Runtime提供的运行时环境；若不设置，则使用当前shell环境作为运行时。设置`--runtime`参数是安全的，只在运行时才会使用Runtime，不会污染当前shell环境。|


### PR DESCRIPTION
## Description
- hidden some options in the `--help` output, but they can work, and reduce learning costs for the users.

![image](https://user-images.githubusercontent.com/590748/228414884-eca8b573-2483-4408-8ab7-d2f712670ed5.png)


## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [x] add necessary doc
