### PR TITLE
feat(dataset): support dataset blob attributes

### DIFF
--- a/client/starwhale/api/_impl/dataset/builder/mapping_builder.py
+++ b/client/starwhale/api/_impl/dataset/builder/mapping_builder.py
@@ -38,7 +38,7 @@ from starwhale.api._impl.dataset.loader import DataRow
 
 class RotatedBinWriter:
     """
-    bin format:
+    format:
         header_magic    uint32  I
         crc             uint32  I
         _reserved       uint64  Q
@@ -197,8 +197,8 @@ class MappingDatasetBuilder:
         dataset_name: str,
         project_name: str,
         instance_name: str = STANDALONE_INSTANCE,
-        bin_alignment_bytes_size: int = D_ALIGNMENT_SIZE,
-        bin_volume_bytes_size: int = D_FILE_VOLUME_SIZE,
+        blob_alignment_bytes_size: int = D_ALIGNMENT_SIZE,
+        blob_volume_bytes_size: int = D_FILE_VOLUME_SIZE,
     ) -> None:
         self.workdir = Path(workdir)
         self.dataset_name = dataset_name
@@ -207,8 +207,8 @@ class MappingDatasetBuilder:
 
         self._in_standalone = instance_name == STANDALONE_INSTANCE
 
-        self._bin_alignment_bytes_size = bin_alignment_bytes_size
-        self._bin_volume_bytes_size = bin_volume_bytes_size
+        self._blob_alignment_bytes_size = blob_alignment_bytes_size
+        self._blob_volume_bytes_size = blob_volume_bytes_size
         self._tabular_dataset = TabularDataset(
             name=dataset_name,
             version=self._HOLDER_VERSION,  # use a holder version value, all versions of one dataset use the unified table
@@ -236,8 +236,8 @@ class MappingDatasetBuilder:
         self._artifact_bin_writer = RotatedBinWriter(
             workdir=self._artifact_bin_tmpdir,
             rotated_bin_notify_queue=self._abs_queue,
-            alignment_bytes_size=bin_alignment_bytes_size,
-            volume_bytes_size=bin_volume_bytes_size,
+            alignment_bytes_size=self._blob_alignment_bytes_size,
+            volume_bytes_size=self._blob_volume_bytes_size,
         )
 
         self._stash_uri_rows_map: t.Dict[

--- a/client/starwhale/core/dataset/cli.py
+++ b/client/starwhale/core/dataset/cli.py
@@ -10,7 +10,7 @@ from starwhale.base.type import URIType
 from starwhale.utils.cli import AliasedGroup
 from starwhale.utils.load import import_object
 from starwhale.utils.error import NotFoundError
-from starwhale.core.dataset.type import MIMEType, DatasetAttr, DatasetConfig
+from starwhale.core.dataset.type import DatasetAttr, DatasetConfig
 
 from .view import get_term_view, DatasetTermView
 
@@ -49,7 +49,6 @@ def dataset_cmd(ctx: click.Context) -> None:
     "--volume-size",
     help="swds-bin format dataset: volume size",
 )
-@click.option("-dmt", "--data-mime-type", help="Dataset global default data mime type")
 @click.option(
     "-f",
     "--dataset-yaml",
@@ -68,7 +67,6 @@ def _build(
     dataset_yaml: str,
     alignment_size: str,
     volume_size: str,
-    data_mime_type: str,
     runtime: str,
 ) -> None:
     # TODO: add dry-run
@@ -92,7 +90,6 @@ def _build(
     config.attr = DatasetAttr(
         volume_size=volume_size or config.attr.volume_size,
         alignment_size=alignment_size or config.attr.alignment_size,
-        data_mime_type=MIMEType(data_mime_type or config.attr.data_mime_type),
     )
 
     config.do_validate()

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -282,11 +282,16 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
     def build(self, *args: t.Any, **kwargs: t.Any) -> None:
         from starwhale.api._impl.dataset.model import Dataset as SDKDataset
 
+        dataset_config: DatasetConfig = kwargs["config"]
         with SDKDataset.dataset(self.uri) as sds:
+            sds = sds.with_builder_blob_config(
+                volume_size=dataset_config.attr.volume_size,
+                alignment_size=dataset_config.attr.alignment_size,
+            )
             console.print(
                 f":new: pending commit version: {sds.pending_commit_version[:SHORT_VERSION_CNT]}"
             )
-            self._build_from_iterable_handler(sds, kwargs["config"])
+            self._build_from_iterable_handler(sds, dataset_config)
             version = sds.commit()
             self._version = self.uri.object.version = version
 

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -972,12 +972,10 @@ class DatasetAttr(ASDictMixin):
         self,
         volume_size: t.Union[int, str] = D_FILE_VOLUME_SIZE,
         alignment_size: t.Union[int, str] = D_ALIGNMENT_SIZE,
-        data_mime_type: MIMEType = MIMEType.UNDEFINED,
         **kw: t.Any,
     ) -> None:
         self.volume_size = convert_to_bytes(volume_size)
         self.alignment_size = convert_to_bytes(alignment_size)
-        self.data_mime_type = data_mime_type
         self.kw = kw
 
     def asdict(self, ignore_keys: t.Optional[t.List[str]] = None) -> t.Dict:

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -163,8 +163,6 @@ class StandaloneDatasetTestCase(TestCase):
                 "dataset:buildFunction",
                 "--project",
                 "self",
-                "-dmt",
-                "video/mp4",
             ],
             obj=mock_obj,
         )
@@ -174,7 +172,6 @@ class StandaloneDatasetTestCase(TestCase):
         call_args = mock_obj.build.call_args[0]
         assert call_args[1].name == "mnist"
         assert call_args[1].handler == handler_func
-        assert call_args[1].attr.data_mime_type == MIMEType.MP4
         assert call_args[1].attr.volume_size == D_FILE_VOLUME_SIZE
 
     def test_build_workflow(

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -1507,7 +1507,7 @@ class TestMappingDatasetBuilder(BaseTestCase):
             workdir=self.workdir,
             dataset_name=self.dataset_name,
             project_name=self.project_name,
-            bin_volume_bytes_size=1024 * 1024,
+            blob_volume_bytes_size=1024 * 1024,
         )
         mdb.put(DataRow(index=1, features={"bin": Binary(b"123")}))
         mdb.flush(artifacts_flush=False)

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/dataset/concepts.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/dataset/concepts.md
@@ -83,7 +83,6 @@ title: 核心概念
 |attr|数据集构建参数|否|Dict||
 |attr.volume_size|swds-bin格式的数据集每个data文件的大小。当写数字时，单位bytes；也可以是数字+单位格式，如64M, 1GB等|否|Int或Str|64MB|
 |attr.alignment_size|swds-bin格式的数据集每个数据块的数据alignment大小，如果设置alignment_size为4k，数据块大小为7.9K，则会补齐0.1K的空数据，让数据块为alignment_size的整数倍，提升page size等读取效率|否|Integer或String|4k|
-|attr.data_mime_type|如果不在代码中为每条数据指定MIMEType，则会使用该字段，便于Dataset Viewer呈现|否|String|undefined|
 |append|当append设置为True时，表示此次数据集构建会继承 `append_from`版本的数据集内容，实现追加数据集的目的。|否|Boolean|False|
 |append_from|与 `append` 参数组合使用，指定继承数据集的版本，注意此处并不是Dataset URI，而是同一个数据集下的其他版本号或tag，默认为latest，即最近一次构建的版本。|否|String|latest|
 |project_uri|Project URI|`swcli project select`命令设定的project|String||
@@ -113,7 +112,6 @@ desc: MNIST data and label test dataset
 attr:
   alignment_size: 1k
   volume_size: 4M
-  data_mime_type: "x/grayscale"
 ```
 
 #### handler为generator function的例子

--- a/example/mnist/dataset.yaml
+++ b/example/mnist/dataset.yaml
@@ -8,4 +8,3 @@ desc: MNIST data and label test dataset
 attr:
   alignment_size: 1k
   volume_size: 4M
-  data_mime_type: "x/grayscale"


### PR DESCRIPTION
## Description
- related: #1940 
- changes:
    - remove useless data_mime_type for dataset data
    - support with_builder_blob_config function for dataset sdk
    - support volume_size and alignment_size options for `swcli dataset build` command.
- depends on: 
  - https://github.com/star-whale/starwhale/pull/2019 

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
