### PR TITLE
feat(dataset): add create mode argument for dataset sdk

### DIFF
--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -105,6 +105,38 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         assert not ds.committed
         ds.close()
 
+    def test_create_mode(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError, "dataset doest not exist, we have already use"
+        ):
+            _ = dataset("mnist", create="forbid")
+
+        ds = dataset("mnist", create="empty")
+        ds.append({"label": 1})
+        ds.commit()
+        ds.close()
+
+        ds = dataset("mnist", create="forbid")
+        assert ds.exists()
+        assert len(ds) == 1
+        ds.close()
+
+        ds = dataset("mnist", create="auto")
+        assert ds.exists()
+        ds.append({"label": 2})
+        ds.commit()
+        ds.close()
+
+        with self.assertRaisesRegex(
+            RuntimeError, "dataset already existed, failed to create"
+        ):
+            _ = dataset("mnist", create="empty")
+
+        with self.assertRaisesRegex(
+            ValueError, "the current create mode is not in the accept options"
+        ):
+            _ = dataset("mnist", create="not-option")
+
     def test_append(self) -> None:
         size = 11
         ds = dataset("mnist")


### PR DESCRIPTION
- create modes:
  - `auto` mode: If the dataset already exists, creation is ignored. If it does not exist, the dataset is created automatically.
  - `empty` mode: If the dataset already exists, an Exception is raised; If it does not exist, an empty dataset is created. This mode ensures the creation of a new, empty dataset.
  - `forbid` mode: If the dataset already exists, nothing is done.If it does not exist, an Exception is raised. This mode ensures the existence of the dataset.
- create mode can help users to ensure the dataset empty or existence.
- related issue:  #1940 

## Description

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
