### PR TITLE
feat(runtime): enable runtime activate command restore automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ Starwhale is an MLOps platform. It provides **Instance**, **Project**, **Runtime
     swcli runtime build example/runtime/pytorch
     swcli runtime list
     swcli runtime info pytorch/version/latest
-    swcli runtime restore pytorch/version/latest
     ```
 
 - 🍞 **STEP4**: Building a model

--- a/client/starwhale/core/runtime/process.py
+++ b/client/starwhale/core/runtime/process.py
@@ -24,7 +24,6 @@ from .model import StandaloneRuntime
 
 
 class Process:
-
     EnvInActivatedProcess = "SW_RUNTIME_ACTIVATED_PROCESS"
 
     def __init__(

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -52,8 +52,8 @@ class RuntimeTermView(BaseTermView):
 
     @classmethod
     @BaseTermView._only_standalone
-    def activate(cls, path: str = "", uri: str = "") -> None:
-        Runtime.activate(path, uri)
+    def activate(cls, uri: URI, force_restore: bool = False) -> None:
+        Runtime.activate(uri, force_restore)
 
     @BaseTermView._only_standalone
     def dockerize(

--- a/docs/docs/examples/ucf101.md
+++ b/docs/docs/examples/ucf101.md
@@ -45,8 +45,7 @@ swcli dataset info ucf101/version/latest
 - Debug the Model at the step of preBuild
 
 ```bash
-swcli runtime activate --uri ucf101/version/latest
-swcli model eval . --dataset ucf101/version/latest
+swcli model eval . --dataset ucf101/version/latest --runtime ucf101/version/latest
 swcli model info ${version}
 ```
 

--- a/docs/docs/getting-started/runtime.md
+++ b/docs/docs/getting-started/runtime.md
@@ -46,13 +46,11 @@ dump dependencies info...
 ### Use Starwhale Runtime in the shell
 
 ```console
-# Create a python environment base on the runtime
-swcli runtime restore pytorch
 # Activate the runtime
-swcli runtime activate --uri pytorch
+swcli runtime activate pytorch/version/latest
 ```
 
-`swcli runtime restore` will download all python dependencies of the runtime, which may take a long time.
+`swcli runtime activate` will download all python dependencies of the runtime, which may take a long time.
 
 All dependencies are ready in your python environment when the runtime is activated. It is similar to `source venv/bin/activate` of virtualenv or the `conda activate` command of conda. If you close the shell or switch to another shell, you need to reactivate the runtime.
 

--- a/docs/docs/instances/standalone/getting_started.md
+++ b/docs/docs/instances/standalone/getting_started.md
@@ -67,12 +67,6 @@ Runtime example code are in the `example/runtime/pytorch` directory.
   swcli runtime info pytorch/version/latest
   ```
 
-- Restore Starwhale Runtime(optional):
-
-  ```bash
-  swcli runtime restore pytorch/version/latest
-  ```
-
 ## Building Model
 
 Model example code are in the `example/mnist` directory.

--- a/docs/docs/reference/swcli/runtime.md
+++ b/docs/docs/reference/swcli/runtime.md
@@ -30,21 +30,18 @@ The `runtime` command includes the following subcommands:
 ## swcli runtime activate {#activate}
 
 ```bash
-swcli [GLOBAL OPTIONS] runtime activate [OPTIONS]
+swcli [GLOBAL OPTIONS] runtime activate [OPTIONS] URI
 ```
 
 Like `source venv/bin/activate` or `conda activate xxx`, `runtime activate` setups a new python environment according to the settings of the specified runtime. When the current shell is closed or switched to another shell, you need to reactivate the runtime.
 
-**`runtime activate` only works for the [standalone instance](../../instances/standalone/index.md).**
+**`runtime activate` only works for the [standalone instance](../../instances/standalone/index.md).** When the 'activate' command is used to activate an environment, it will check if the environment corresponding to the Runtime URI has been locally built. If not, it will automatically create a 'venv' or 'conda' environment, and download the Python dependencies for the corresponding Runtime.
 
 If you want to quit the activated runtime environment, please run `venv deactivate` for the venv environment or `conda deactivate` in the conda environment.
 
 | Option | Required | Type | Defaults | Description |
 | --- | --- | --- | --- | --- |
-| `--uri` or `-u` | ❌ | String | | the Runtime URI |
-| `--path` | `-p` | ❌ | String | | Path to venv or conda directory |
-
-`--uri` and `--path` can not be used together.
+|`--force-restore`|`-f`|❌|Bool|False|Force to restore runtime into the related snapshot workdir even the runtime has been restored|
 
 ## swcli runtime build {#build}
 

--- a/docs/docs/runtime/api/cli.md
+++ b/docs/docs/runtime/api/cli.md
@@ -140,31 +140,6 @@ swcli runtime extract [OPTIONS] RUNTIME
     👏 extracted @ /home/liutianwei/.cache/starwhale/self/workdir/runtime/mnist/g4/g4zwkyjumm2dinrtmftdgyjznb4xcni 🎉
     ```
 
-## Restore runtime python environment
-
-```bash
-swcli runtime restore [OPTIONS] TARGET
-```
-
-- This command will prepare dirs, restore python environment with virtualenv or conda, and show activate command. It will help you create a runtime environment, then run an evaluation job or build a dataset.
-- `TARGET` argument is `RUNTIME URI` or runtime working dir path.
-- Restore python environment will run `pip install` command to download python packages, which may take some time.
-- In the Starwhale agent docker environment, only the working dir path is supported.
-
-- Example:
-
-    ```bash
-    ❯ swcli runtime restore mnist/version/g4zwkyjumm2d
-    🏌 try to restore python runtime environment/home/liutianwei/.cache/starwhale/self/workdir/runtime/mnist/g4/g4zwkyjumm2dinrtmftdgyjznb4xcni ...
-    🍞 restore python:3.7.13 venv@/home/liutianwei/.cache/starwhale/self/workdir/runtime/mnist/g4/g4zwkyjumm2dinrtmftdgyjznb4xcni, use local env data: False
-    👏 create venv@/home/liutianwei/.cache/starwhale/self/workdir/runtime/mnist/g4/g4zwkyjumm2dinrtmftdgyjznb4xcni/dep/python/venv, python:3.7.13 (default, Mar 29 2022, 02:18:16)
-    [GCC 7.5.0]
-     👏 activate.sw and activate.host is generated at /home/liutianwei/.cache/starwhale/self/workdir/runtime/mnist/g4/g4zwkyjumm2dinrtmftdgyjznb4xcni
-     🧭 run cmd:
-             Docker Container:  $(sh /home/liutianwei/.cache/starwhale/self/workdir/runtime/mnist/g4/g4zwkyjumm2dinrtmftdgyjznb4xcni/activate.sw)
-             Host:  $(sh /home/liutianwei/.cache/starwhale/self/workdir/runtime/mnist/g4/g4zwkyjumm2dinrtmftdgyjznb4xcni/activate.host)
-    ```
-
 ## List runtimes
 
 ```bash

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/ag_news.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/ag_news.md
@@ -37,11 +37,10 @@ cd starwhale/example/runtime/pytorch
 swcli runtime build .
 ```
 
-- Restore Runtime：本地复原Runtime环境，并在当前shell中激活相应的Python环境
+- Activate Runtime：在当前shell中激活相应的Python环境
 
 ```shell
-swcli runtime restore pytorch/version/latest
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 ```
 
 ### 数据准备与模型训练
@@ -92,15 +91,13 @@ finish gen resource @ /home/liutianwei/.cache/starwhale/self/dataset/ag_news_tes
 ### 步骤2：Standalone Instance中评测模型
 
 ```bash
-#如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
 # 根据model.yaml运行评测任务
-swcli model eval . --dataset  ag_news_test/version/latest
+swcli model eval . --dataset  ag_news_test/version/latest --runtime pytorch/version/latest
 # 展示评测结果
 swcli model info ${version}
 ```
 
-上面的`build`命令在`starwhale/example/text_cls_AG_NEWS`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate --uri pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
+上面的`build`命令在`starwhale/example/text_cls_AG_NEWS`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
 
 ![eval.png](../img/examples/ag_news-eval.png)
 
@@ -110,7 +107,7 @@ swcli model info ${version}
 
 ```shell
 #如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 #根据model.yaml构建Starwhale Model
 swcli model build .
 # 查看最新构建的模型信息

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/cifar10.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/cifar10.md
@@ -37,11 +37,10 @@ cd starwhale/example/runtime/pytorch
 swcli runtime build .
 ```
 
-- Restore Runtime：本地复原Runtime环境，并在当前shell中激活相应的Python环境
+- Activate Runtime：在当前shell中激活相应的Python环境
 
 ```shell
-swcli runtime restore pytorch/version/latest
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 ```
 
 ### 数据准备与模型训练
@@ -66,7 +65,7 @@ make train
 
 ```bash
 #如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 # 根据dataset.yaml构建swds-bin格式in格式in格式in格式in格式的数据集
 swcli dataset build .
 # 查看最新构建的数据集详情
@@ -108,15 +107,13 @@ def _iter_item(paths: t.List[Path]) -> t.Generator[t.Tuple[t.Any, t.Dict], None,
 ### 步骤2：Standalone Instance中评测模型
 
 ```bash
-#如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
 # 根据model.yaml运行评测任务
-swcli model eval . --dataset  cifar10-test/version/latest
+swcli model eval . --dataset  cifar10-test/version/latest --runtime pytorch/version/latest
 # 展示评测结果
 swcli model info ${version}
 ```
 
-上面的`build`命令在`starwhale/example/cifar10`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate --uri pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
+上面的`build`命令在`starwhale/example/cifar10`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
 
 ### 步骤3：构建Starwhale Model
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/mnist.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/mnist.md
@@ -38,11 +38,10 @@ cd starwhale/example/runtime/pytorch
 swcli runtime build .
 ```
 
-- Restore Runtime：本地复原Runtime环境，并在当前shell中激活相应的Python环境
+- Activate Runtime：在当前shell中激活相应的Python环境
 
 ```shell
-swcli runtime restore pytorch/version/latest
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 ```
 
 ### 数据准备与模型训练
@@ -77,15 +76,13 @@ swcli dataset info mnist/version/latest
 ### 步骤2：Standalone Instance中评测模型
 
 ```bash
-#如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
 # 根据model.yaml运行评测任务
-swcli model eval . --dataset mnist/version/latest
+swcli model eval . --dataset mnist/version/latest --runtime pytorch/version/latest
 # 展示评测结果
 swcli model info ${version}
 ```
 
-上面的`build`命令在`starwhale/example/mnist`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate --uri pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
+上面的`build`命令在`starwhale/example/mnist`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
 
 ![mnist-eval.png](../img/examples/mnist-eval.png)
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/nmt.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/nmt.md
@@ -39,11 +39,10 @@ cd starwhale/example/runtime/pytorch
 swcli runtime build .
 ```
 
-- Restore Runtime：本地复原Runtime环境，并在当前shell中激活相应的Python环境
+- Activate Runtime：在当前shell中激活相应的Python环境
 
 ```shell
-swcli runtime restore pytorch/version/latest
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 ```
 
 ### 数据准备与模型训练
@@ -81,15 +80,13 @@ swcli dataset info nmt-test/version/latest
 ### 步骤2：Standalone Instance中评测模型
 
 ```bash
-#如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
 # 根据model.yaml运行评测任务
-swcli model eval . --dataset nmt-test/version/latest
+swcli model eval . --dataset nmt-test/version/latest --runtime pytorch/version/latest
 # 展示评测结果
 swcli model info ${version}
 ```
 
-上面的`build`命令在`starwhale/example/nmt`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate --uri pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
+上面的`build`命令在`starwhale/example/nmt`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate  pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
 
 nmt例子并不是多分类问题，无法使用 `starwhale.multi_classification` 修饰器，Starwhale SDK中也没有提供合适的修饰器自动处理cmp结果。本例中，我们使用 `self.evaluation_store.log_metrics` 函数，将report的结果存储到Starwhale Datastore中，这样在Standalone Instance 和 Cloud Instance中都能看到相关结果。用户可以使用 `evaluation` SDK上报各种评测结果数据。
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/pfp.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/pfp.md
@@ -37,11 +37,10 @@ cd starwhale/example/runtime/pytorch
 swcli runtime build .
 ```
 
-- Restore Runtime：本地复原Runtime环境，并在当前shell中激活相应的Python环境
+- Activate Runtime：在当前shell中激活相应的Python环境
 
 ```shell
-swcli runtime restore pytorch/version/latest
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 ```
 
 ### 数据准备与模型训练
@@ -67,7 +66,7 @@ make train
 
 ```bash
 # 如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 # 根据dataset.yaml构建swds-bin格式in格式的数据集
 swcli dataset build .
 # 查看最新构建的数据集详情

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/speech.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/speech.md
@@ -37,11 +37,10 @@ cd starwhale/example/runtime/pytorch
 swcli runtime build .
 ```
 
-- Restore Runtime：本地复原Runtime环境，并在当前shell中激活相应的Python环境
+- Activate Runtime：在当前shell中激活相应的Python环境
 
 ```shell
-swcli runtime restore pytorch/version/latest
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 ```
 
 ### 数据准备与模型训练
@@ -83,15 +82,13 @@ swcli dataset info speech_commands_validation/version/latest
 ### 步骤2：Standalone Instance中评测模型
 
 ```bash
-#如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
 # 根据model.yaml运行评测任务
 swcli model eval . --dataset  speech_commands_validation/version/latest --runtime pytorch/version/latest
 # 展示评测结果
 swcli model info ${version}
 ```
 
-上面的`build`命令在`starwhale/example/speech_command`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate --uri pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
+上面的`build`命令在`starwhale/example/speech_command`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate pytorch/version/latest`命令激活当前shell环境，或在一个已经激活Pytorch Runtime环境shell中执行评测。
 
 ![eval.png](../img/examples/sc_eval.png)
 
@@ -101,7 +98,7 @@ swcli model info ${version}
 
 ```bash
 #如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri pytorch/version/latest
+swcli runtime activate pytorch/version/latest
 #根据model.yaml构建Starwhale Model
 swcli model build .
 # 查看最新构建的模型信息

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/ucf101.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples/ucf101.md
@@ -72,15 +72,13 @@ swcli dataset info ucf101/version/latest
 ### 步骤2：Standalone Instance中评测模型
 
 ```bash
-#如果已经激活该runtime环境，则忽略本行命令
-swcli runtime activate --uri ucf101/version/latest
 # 根据model.yaml运行评测任务
-swcli model eval . --dataset ucf101/version/latest
+swcli model eval . --dataset ucf101/version/latest --runtime ucf101/version/latest
 # 展示评测结果
 swcli model info ${version}
 ```
 
-上面的`build`命令在`starwhale/example/ucf101`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate --uri ucf101/version/latest`命令激活当前shell环境，或在一个已经激活该Runtime环境shell中执行评测。
+上面的`build`命令在`starwhale/example/ucf101`中执行，也可以在其他目录中执行，但要合理设置 `swcli model eval`命令的`WORKDIR`参数。如果不想每次执行`eval`命令都指定`--runtime`参数，则可以先执行`swcli runtime activate ucf101/version/latest`命令激活当前shell环境，或在一个已经激活该Runtime环境shell中执行评测。
 
 cmp中核心代码：
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/runtime.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/runtime.md
@@ -49,13 +49,11 @@ dump dependencies info...
 ### 在shell中使用Starwhale Runtime
 
 ```console
-# 基于Starwhale Runtime创建对应的python环境
-swcli runtime restore pytorch
 # 激活runtime
-swcli runtime activate --uri pytorch
+swcli runtime activate pytorch/version/latest
 ```
 
-`swcli runtime restore`会下载runtime的所有python依赖。这个过程可能需要很长时间。
+`swcli runtime activate`会下载runtime的所有python依赖，并在当前shell环境中激活该环境。这个过程可能需要很长时间。
 
 当runtime被激活时，所有依赖项都已在您的python环境中准备就绪，类似于virtualenv的`source venv/bin/activate`或者conda的`conda activate`命令。如果您关闭了shell或切换到另一个shell，则下次使用之前需要重新激活这个runtime。
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/instances/standalone/getting_started.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/instances/standalone/getting_started.md
@@ -66,12 +66,6 @@ Runtime的示例程序在 `example/runtime/pytorch` 目录中。
   swcli runtime info pytorch/version/latest
   ```
 
-- 预先restore Starwhale Runtime(可选):
-
-  ```bash
-  swcli runtime restore pytorch/version/latest
-  ```
-
 ## 构建Starwhale Model模型包
 
 Model的示例程序在 `example/mnist` 目录中。

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/runtime.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/runtime.md
@@ -30,21 +30,18 @@ swcli [全局选项] model [选项] <SUBCOMMAND> [参数]...
 ## swcli runtime activate {#activate}
 
 ```bash
-swcli [全局选项] runtime activate [选项]
+swcli [全局选项] runtime activate [选项] URI
 ```
 
-`runtime activate`根据指定的运行时创建一个全新的Python环境，类似`source venv/bin/activate`或`conda activate xxx`的效果。关闭当前shell或切换到其他shell后，需要重新激活Runtime。
+`runtime activate`根据指定的运行时创建一个全新的Python环境，类似`source venv/bin/activate`或`conda activate xxx`的效果。关闭当前shell或切换到其他shell后，需要重新激活Runtime。`URI` 参数为Runtime URI。
 
-**`runtime activate`仅适用于[Standalone实例](../../instances/standalone/index.md).**
+**`runtime activate`仅适用于[Standalone实例](../../instances/standalone/index.md).** Activate命令激活环境时，会检测Runtime URI对应的环境是否在本地构建过，如果没有，则自动构建venv或conda环境，并下载Runtime对应的Python依赖包。
 
 对于已经激活的Runtime，如果想要退出该环境，需要在venv环境中执行 `deactivate` 命令或conda环境中执行`conda deactivate` 命令。
 
 | 选项 | 必填项 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
-| `--uri` or `-u` | ❌ | String | | 运行时URI |
-| `--path` | `-p` | ❌ | String | | venv或conda目录路径 |
-
-`--uri`和`--path`不能同时使用。
+|`--force-restore`|`-f`|❌|Bool|False|对Runtime强制重新restore|
 
 ## swcli runtime build {#build}
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/runtime/api/cli.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/runtime/api/cli.md
@@ -28,17 +28,16 @@ runtime包含如下子命令：
 |quickstart|qs|✅|❌|
 |recover||✅|✅|
 |remove|rm|✅|✅|
-|restore||✅|❌|
 |tag||✅|❌|
 
 ## 激活Runtime
 
 ```bash
-swcli runtime activate [OPTIONS]
+swcli runtime activate [OPTIONS] URI
 ```
 
-`runtime activate` 命令支持bash/zsh/fish下直接激活Starwhale Runtime，起到类似virtualenv中 `source venv/bin/activate` 或 `conda activate xxx` 的作用。当关闭当前shell或切换到其他shell时，需要重新激活Runtime。`--uri` 和 `--path` 参数只能选择一个进行设置。
-**`runtime activate`命令目前只能在standalone instance下执行**。如果对某个Runtime URI进行激活，需要确保该Runtime已经被重建，一般通过执行 `swcli runtime restore` 命令实现。
+`runtime activate` 命令支持bash/zsh/fish下直接激活Starwhale Runtime，起到类似virtualenv中 `source venv/bin/activate` 或 `conda activate xxx` 的作用。当关闭当前shell或切换到其他shell时，需要重新激活Runtime。`URI` 参数为Runtime URI。
+**`runtime activate`命令目前只能在standalone instance下执行**。Activate命令激活环境时，会检测Runtime URI对应的环境是否在本地构建过，如果没有，则自动构建venv或conda环境，并下载Runtime对应的Python依赖包。
 
 对于已经激活的Runtime，如果想要退出该环境，需要在venv mode中执行 `deactivate` 命令或conda mode中执行`conda deactivate` 命令。
 
@@ -46,8 +45,7 @@ swcli runtime activate [OPTIONS]
 
 |参数|参数别名|必要性|类型|默认值|说明|
 |------|--------|-------|-----------|-----|-----------|
-|`--uri`|`-u`|❌|String||Standalone Instance下Runtime URI|
-|`--path`|`-p`|❌|String||venv或conda目录路径|
+|`--force-restore`|`-f`|❌|Bool|False|对Runtime强制重新restore|
 
 ## 构建Runtime
 
@@ -301,16 +299,6 @@ swcli runtime recover [OPTIONS] RUNTIME
 |参数|参数别名|必要性|类型|默认值|说明|
 |------|--------|-------|-----------|-----|-----------|
 |`--force`|`-f`|❌|Boolean|False|强制恢复，处理类似恢复版本冲突的情况。|
-
-## 重建Runtime
-
-```bash
-swcli runtime restore [OPTIONS] TARGET
-```
-
-`runtime restore` 命令可以根据 `TARGET` 参数信息创建venv或conda的Python隔离环境，并下载和安装Runtime所描述的Python依赖。**该命令目前只能在standalone instance下执行**。restore操作用时取决于所在机器的网络情况，可以通过合理设置pip.conf或代理提升安装速度。
-
-`TARGET` 参数有两种形式，一种是表示某个 runtime uri的snapshot_workdir， 另一种是某个Standalone Instance下的Runtime URI。
 
 ## 标记Runtime
 

--- a/example/notebooks/quickstart-standalone.ipynb
+++ b/example/notebooks/quickstart-standalone.ipynb
@@ -129,25 +129,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Restore Starwhale Runtime(optional)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "swcli runtime restore pytorch/version/latest"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## 4. Building Model\n",
     "\n",
     "Model example code are in the `example/mnist` directory.\n",


### PR DESCRIPTION
## Description
- changes:
  - hide `swcli runtime restore` command for users in the help output.
  - make `swcli runtime activate` command enable to restore runtime automatically. 
- demo:
  - ![image](https://user-images.githubusercontent.com/590748/230361395-335f671c-1110-4bde-9220-615cdbc6690f.png)

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
