### PR TITLE
feat(runtime): support `swcli runtime build` from multi sources

### DIFF
--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -14,6 +14,7 @@ from starwhale.consts import (
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType, RuntimeLockFileType
 from starwhale.utils.cli import AliasedGroup
+from starwhale.core.runtime.model import _SUPPORT_CUDA, _SUPPORT_CUDNN
 
 from .view import get_term_view, RuntimeTermView
 from .model import RuntimeInfoFilter
@@ -129,91 +130,235 @@ def _quickstart(
     )
 
 
-@runtime_cmd.command(
-    "build",
-    help="[Only Standalone]Create and build a relocated, shareable, packaged runtime bundle. Support python and native libs.",
+@runtime_cmd.command("build")
+@optgroup.group(
+    "\n  ** Acceptable build sources",
+    cls=MutuallyExclusiveOptionGroup,
+    help="The selector of the runtime build source, default is runtime.yaml source",
 )
-@click.argument("workdir", type=click.Path(exists=True, file_okay=False))
-@click.option(
-    "-p",
-    "--project",
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-c",
+    "--conda",
     default="",
-    help="Project URI, default is the current selected project. The runtime package will store in the specified project.",
+    help="from conda environment name",
 )
-@click.option(
-    "-f",
-    "--runtime-yaml",
-    default=DefaultYAMLName.RUNTIME,
-    help="Runtime yaml filename, default use ${workdir}/runtime.yaml file",
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-cp",
+    "--conda-prefix",
+    default="",
+    help="from conda environment prefix path",
 )
-@click.option(
-    "-gab",
-    "--gen-all-bundles",
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-v",
+    "--venv",
+    help="from virtualenv or python-venv environment prefix path",
+)
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-s",
+    "--shell",
     is_flag=True,
-    help="Generate conda or venv files into runtime",
+    help="from current shell, venv or conda environment has been activated",
 )
-@click.option(
-    "-ie", "--include-editable", is_flag=True, help="Include editable packages"
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-y",
+    "--yaml",
+    help="from runtime yaml format file path.Default use runtime.yaml in the work directory(pwd)",
+    default=DefaultYAMLName.RUNTIME,
 )
-@click.option(
-    "-ilw", "--include-local-wheel", is_flag=True, help="Include local wheel packages"
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-d",
+    "--docker",
+    default="",
+    help="from docker image",
 )
-@click.option(
+@optgroup.group(
+    "\n  ** Runtime YAML Source Configuration",
+    help="The configurations only work for `--from-runtime-yaml` source",
+)
+@optgroup.option(  # type: ignore[no-untyped-call]
     "-del",
     "--disable-env-lock",
     is_flag=True,
-    help="Disable virtualenv/conda environment dependencies lock, and the cli supports three methods to lock environment that are shell(auto-detect), prefix_path or env_name",
+    help="Disable virtualenv/conda environment dependencies lock",
 )
-@click.option(
+@optgroup.option(  # type: ignore[no-untyped-call]
     "-nc",
     "--no-cache",
     is_flag=True,
     help="Invalid the cached(installed) packages in the isolate env when env-lock is enabled, \
     only for auto-generated environments",
 )
-@optgroup.group(  # type: ignore
-    "Python environment selectors",
-    cls=MutuallyExclusiveOptionGroup,
-    help="The selector of the python environment, default is the starwhale auto create env prefix path",
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-dad",
+    "--download-all-deps",
+    is_flag=True,
+    help="Download all python dependencies into the runtime bundle file, the file size of swrt maybe very large.",
+    hidden=True,
 )
-@optgroup.option(  # type: ignore
-    "-ep", "--env-prefix-path", default="", help="Conda or virtualenv prefix path"
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-ie",
+    "--include-editable",
+    is_flag=True,
+    help="Include editable packages",
+    hidden=True,
 )
-@optgroup.option(  # type: ignore
-    "-en",
-    "--env-name",
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-ilw",
+    "--include-local-wheel",
+    is_flag=True,
+    help="Include local wheel packages",
+    hidden=True,
+)
+@optgroup.group(
+    "\n  ** Conda/Venv/Shell Sources Configurations",
+    help="The configurations only work for `--from-conda-name`, `--from-conda-prefix-path`, `--from-venv-prefix-path` and `--from-shell` sources",
+)
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "--cuda",
+    type=click.Choice(_SUPPORT_CUDA + [""], case_sensitive=False),
     default="",
-    help="conda name in lock or gen all bundles process",
+    help="cuda version, works for shell, conda name, conda prefix path and venv prefix path sources",
 )
-@optgroup.option(  # type: ignore
-    "-es", "--env-use-shell", is_flag=True, default=False, help="use current shell"
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "--cudnn",
+    default="",
+    type=click.Choice(list(_SUPPORT_CUDNN.keys()) + [""], case_sensitive=False),
+    help="cudnn version, works for shell, conda name, conda prefix path and venv prefix path sources",
+)
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "--arch",
+    type=click.Choice(
+        [SupportArch.AMD64, SupportArch.ARM64, SupportArch.NOARCH],
+        case_sensitive=False,
+    ),
+    default=SupportArch.NOARCH,
+    help="system architecture, works for shell, conda name, conda prefix path and venv prefix path sources",
+)
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-dad",
+    "--download-all-deps",
+    is_flag=True,
+    help="Download all python dependencies into the runtime bundle file, the file size of swrt maybe very large.",
+    hidden=True,
+)
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-ie",
+    "--include-editable",
+    is_flag=True,
+    help="Include editable packages",
+    hidden=True,
+)
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-ilw",
+    "--include-local-wheel",
+    is_flag=True,
+    help="Include local wheel packages",
+    hidden=True,
+)
+@optgroup.group("\n  ** Global Configurations")
+@optgroup.option("-n", "--name", default="", help="runtime name")  # type: ignore[no-untyped-call]
+@optgroup.option(  # type: ignore[no-untyped-call]
+    "-p",
+    "--project",
+    default="",
+    help="Project URI, default is the current selected project. The runtime package will store in the specified project.",
 )
 def _build(
-    workdir: str,
+    name: str,
     project: str,
-    runtime_yaml: str,
-    gen_all_bundles: bool,
+    cuda: str,
+    cudnn: str,
+    arch: str,
+    download_all_deps: bool,
     include_editable: bool,
     include_local_wheel: bool,
     disable_env_lock: bool,
     no_cache: bool,
-    env_prefix_path: str,
-    env_name: str,
-    env_use_shell: bool,
+    conda: str,
+    conda_prefix: str,
+    venv: str,
+    shell: bool,
+    yaml: str,
+    docker: str,
 ) -> None:
-    RuntimeTermView.build(
-        workdir=workdir,
-        project=project,
-        yaml_name=runtime_yaml,
-        gen_all_bundles=gen_all_bundles,
-        include_editable=include_editable,
-        include_local_wheel=include_local_wheel,
-        disable_env_lock=disable_env_lock,
-        no_cache=no_cache,
-        env_prefix_path=env_prefix_path,
-        env_name=env_name,
-        env_use_shell=env_use_shell,
-    )
+    """Create and build a relocated, shareable, packaged runtime bundle(aka `swrt` file). Support python and native libs.
+    Runtime build only works in the Standalone instance.
+
+    Acceptable sources:
+
+        \b
+        - runtime.yaml file: The most flexible and customizable way.By the runtime.yaml file,
+            you can specify the runtime name, python version, conda or venv environment, and the python dependency packages etc.
+        - conda name: Lock the conda environment with conda name and generate the runtime bundle.
+        - conda prefix path: Lock the conda environment with conda prefix path and generate the runtime bundle.
+        - venv prefix path: Lock the virtualenv or python venv environment with venv prefix path and generate the runtime bundle.
+        - shell: Lock the current shell environment and generate the runtime bundle. The current shell must be conda or venv.
+        - docker image: Use the docker image as the runtime directly.
+
+    Examples:
+
+        \b
+        - from runtime.yaml:
+        swcli runtime build  # use the current directory as the workdir and use the default runtime.yaml file
+        swcli runtime build -y example/pytorch/runtime.yaml # use example/pytorch/runtime.yaml as the runtime.yaml file
+        swcli runtime build --yaml runtime.yaml # use runtime.yaml at the current directory as the runtime.yaml file
+
+        \b
+        - from conda name:
+        swcli runtime build -c pytorch # lock pytorch conda environment and use `pytorch` as the runtime name
+        swcli runtime build --conda pytorch --name pytorch-runtime # use `pytorch-runtime` as the runtime name
+        swcli runtime build --conda pytorch --cuda 11.4 # specify the cuda version
+        swcli runtime build --conda pytorch --arch noarch # specify the system architecture
+
+        \b
+        - from conda prefix path:
+        swcli runtime build --conda-prefix /home/starwhale/anaconda3/envs/pytorch # get conda prefix path by `conda info --envs` command
+
+        \b
+        - from venv prefix path:
+        swcli runtime build -v /home/starwhale/.virtualenvs/pytorch
+        swcli runtime build --venv /home/starwhale/.local/share/virtualenvs/pytorch --arch amd64
+
+        \b
+        - from docker image:
+        swcli runtime build --docker pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime  # use the docker image as the runtime directly
+
+        \b
+        - from shell:
+        swcli runtime build -s --cuda 11.4 --cudnn 8 # specify the cuda and cudnn version
+        swcli runtime build --shell --name pytorch-runtime # lock the current shell environment and use `pytorch-runtime` as the runtime name
+    """
+    if docker:
+        RuntimeTermView.build_from_docker_image(
+            image=docker, runtime_name=name, project=project
+        )
+    elif conda or conda_prefix or venv or shell:
+        # TODO: support auto mode for cuda, cudnn and arch
+        RuntimeTermView.build_from_python_env(
+            runtime_name=name,
+            conda_name=conda,
+            conda_prefix=conda_prefix,
+            venv_prefix=venv,
+            project=project,
+            cuda=cuda,
+            cudnn=cudnn,
+            arch=arch,
+            download_all_deps=download_all_deps,
+            include_editable=include_editable,
+            include_local_wheel=include_local_wheel,
+        )
+    else:
+        RuntimeTermView.build_from_runtime_yaml(
+            workdir=Path.cwd(),
+            yaml_path=Path(yaml),
+            project=project,
+            runtime_name=name,
+            download_all_deps=download_all_deps,
+            include_editable=include_editable,
+            include_local_wheel=include_local_wheel,
+            no_cache=no_cache,
+            disable_env_lock=disable_env_lock,
+        )
 
 
 @runtime_cmd.command("remove", aliases=["rm"])
@@ -465,9 +610,9 @@ def _activate(uri: str, force_restore: bool) -> None:
 @click.argument("target_dir", default=".")
 @click.option(
     "-f",
-    "--yaml-name",
+    "--yaml-path",
     default=DefaultYAMLName.RUNTIME,
-    help=f"Runtime YAML file name, default is {DefaultYAMLName.RUNTIME}",
+    help=f"Runtime YAML file path, default is {DefaultYAMLName.RUNTIME} at the current working directory",
 )
 @optgroup.group(  # type: ignore
     "Python environment selectors",
@@ -511,7 +656,7 @@ def _activate(uri: str, force_restore: bool) -> None:
 )
 def _lock(
     target_dir: str,
-    yaml_name: str,
+    yaml_path: str,
     env_name: str,
     env_prefix_path: str,
     env_use_shell: bool,
@@ -524,12 +669,12 @@ def _lock(
     """
     [Only Standalone]Lock Python venv or conda environment
 
-    TARGET_DIR: the runtime.yaml and local file dir, default is "."
+    TARGET_DIR: the lock files will store in the `target_dir` , default is "."
     """
 
     RuntimeTermView.lock(
         target_dir,
-        yaml_name,
+        Path(yaml_path),
         env_name,
         env_prefix_path,
         no_cache,

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -97,6 +97,7 @@ from starwhale.utils.venv import (
     check_valid_conda_prefix,
     get_python_version_by_bin,
     render_python_env_activate,
+    get_user_runtime_python_bin,
 )
 from starwhale.base.bundle import BaseBundle, LocalStorageBundleMixin
 from starwhale.utils.error import (
@@ -107,7 +108,6 @@ from starwhale.utils.error import (
     ConfigFormatError,
     MissingFieldError,
     ExclusiveArgsError,
-    FieldTypeOrValueError,
     UnExpectedConfigFieldError,
 )
 from starwhale.utils.progress import run_with_progress_bar
@@ -669,8 +669,8 @@ class Runtime(BaseBundle, metaclass=ABCMeta):
     @classmethod
     def lock(
         cls,
-        target_dir: t.Union[str, Path],
-        yaml_name: str = DefaultYAMLName.RUNTIME,
+        target_dir: str | Path,
+        yaml_path: str | Path,
         env_name: str = "",
         env_prefix_path: str = "",
         no_cache: bool = False,
@@ -679,10 +679,10 @@ class Runtime(BaseBundle, metaclass=ABCMeta):
         include_local_wheel: bool = False,
         emit_pip_options: bool = False,
         env_use_shell: bool = False,
-    ) -> str:
+    ) -> t.Tuple[str, t.Optional[Path]]:
         return StandaloneRuntime.lock(
             target_dir,
-            yaml_name,
+            yaml_path,
             env_name,
             env_prefix_path,
             no_cache,
@@ -701,6 +701,40 @@ class Runtime(BaseBundle, metaclass=ABCMeta):
         dry_run: bool = False,
         use_starwhale_builder: bool = False,
         reset_qemu_static: bool = False,
+    ) -> None:
+        raise NotImplementedError
+
+    def build_from_docker_image(self, image: str, runtime_name: str) -> None:
+        raise NotImplementedError
+
+    def build_from_python_env(
+        self,
+        runtime_name: str,
+        mode: str = "",
+        conda_name: str = "",
+        conda_prefix: str = "",
+        venv_prefix: str = "",
+        cuda: str = "",
+        cudnn: str = "",
+        arch: str = "",
+        download_all_deps: bool = False,
+        include_editable: bool = False,
+        include_local_wheel: bool = False,
+    ) -> None:
+        raise NotImplementedError
+
+    def build_from_runtime_yaml(
+        self,
+        workdir: str | Path,
+        yaml_path: str | Path,
+        download_all_deps: bool = False,
+        include_editable: bool = False,
+        include_local_wheel: bool = False,
+        no_cache: bool = False,
+        disable_env_lock: bool = False,
+        env_prefix_path: str = "",
+        env_name: str = "",
+        env_use_shell: bool = False,
     ) -> None:
         raise NotImplementedError
 
@@ -804,36 +838,116 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             )
         return _r
 
-    def build(  # type: ignore[override]
-        self,
-        workdir: Path,
-        **kw: t.Any,
-    ) -> None:
-        yaml_name = kw.get("yaml_name", DefaultYAMLName.RUNTIME)
-        disable_env_lock = kw.get("disable_env_lock", False)
-        no_cache = kw.get("no_cache", False)
-        env_name = kw.get("env_name", "")
-        env_prefix_path = kw.get("env_prefix_path", "")
-        env_use_shell = kw.get("env_use_shell", False)
-        include_editable = kw.get("include_editable", False)
-        include_local_wheel = kw.get("include_local_wheel", False)
-        # TODO: tune for no runtime.yaml file
-        swrt_config = self._load_runtime_config(workdir / yaml_name)
+    def build_from_docker_image(self, image: str, runtime_name: str) -> None:
+        # TODO: validate image format
+        workdir = Path(tempfile.mkdtemp(suffix="starwhale-runtime-build-"))
+        try:
+            config: t.Dict[str, t.Any] = dict(
+                name=runtime_name,
+                environment={
+                    "docker": {"image": image},
+                },
+            )
+            yaml_path = workdir / DefaultYAMLName.RUNTIME
+            ensure_file(yaml_path, yaml.dump(config))
+            self.build_from_runtime_yaml(
+                workdir=workdir,
+                yaml_path=yaml_path,
+                disable_env_lock=True,
+            )
+        finally:
+            empty_dir(workdir)
 
-        lock_files = []
+    def build_from_python_env(
+        self,
+        runtime_name: str,
+        mode: str = PythonRunEnv.VENV,
+        conda_name: str = "",
+        conda_prefix: str = "",
+        venv_prefix: str = "",
+        cuda: str = "",
+        cudnn: str = "",
+        arch: str = "",
+        download_all_deps: bool = False,
+        include_editable: bool = False,
+        include_local_wheel: bool = False,
+    ) -> None:
+        if conda_name or conda_prefix:
+            prefix_path = (
+                get_conda_prefix_path(conda_name) if conda_name else conda_prefix
+            )
+            if not check_valid_conda_prefix(prefix_path):
+                raise RuntimeError(f"Invalid conda prefix: {prefix_path}")
+
+            pybin = get_conda_pybin(prefix=prefix_path)
+            env_use_shell = False
+        elif venv_prefix:
+            if not check_valid_venv_prefix(venv_prefix):
+                raise RuntimeError(f"Invalid venv prefix: {venv_prefix}")
+            pybin = os.path.join(venv_prefix, "bin", "python3")
+            env_use_shell = False
+        else:
+            pybin = get_user_runtime_python_bin(mode)
+            env_use_shell = True
+
+        python_version = get_python_version_by_bin(pybin)
+        workdir = Path(tempfile.mkdtemp(suffix="starwhale-runtime-build-"))
+        try:
+            yaml_path = StandaloneRuntime.render_runtime_yaml(
+                workdir,
+                name=runtime_name,
+                mode=mode,
+                python_version=python_version,
+                cuda_version=cuda,
+                cudnn_version=cudnn,
+                arch=arch,
+            )
+
+            self.build_from_runtime_yaml(
+                workdir=workdir,
+                yaml_path=yaml_path,
+                download_all_deps=download_all_deps,
+                include_editable=include_editable,
+                include_local_wheel=include_local_wheel,
+                disable_env_lock=False,
+                env_name=conda_name,
+                env_prefix_path=conda_prefix or venv_prefix,
+                env_use_shell=env_use_shell,
+            )
+        finally:
+            empty_dir(workdir)
+
+    def build_from_runtime_yaml(
+        self,
+        workdir: str | Path,
+        yaml_path: str | Path,
+        download_all_deps: bool = False,
+        include_editable: bool = False,
+        include_local_wheel: bool = False,
+        no_cache: bool = False,
+        disable_env_lock: bool = False,
+        env_prefix_path: str = "",
+        env_name: str = "",
+        env_use_shell: bool = False,
+    ) -> None:
+        workdir = Path(workdir)
+        yaml_path = Path(yaml_path)
+        swrt_config = self._load_runtime_config(yaml_path)
+
+        lock_paths: t.List[Path] = []
         if not disable_env_lock:
             console.print(
-                f":alien: try to lock environment dependencies to {yaml_name}@{workdir} ..."
+                f":alien: try to lock environment dependencies to {workdir} ..."
             )
-            content = self.lock(
+            content, lock_fpath = self.lock(
                 target_dir=workdir,
-                yaml_name=yaml_name,
-                env_name=env_name,
-                env_prefix_path=env_prefix_path,
+                yaml_path=yaml_path,
                 no_cache=no_cache,
                 stdout=False,
                 include_editable=include_editable,
                 include_local_wheel=include_local_wheel,
+                env_name=env_name,
+                env_prefix_path=env_prefix_path,
                 env_use_shell=env_use_shell,
             )
             # try getting starwhale version
@@ -842,12 +956,8 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                     self._detected_sw_version = line.split("==")[1].strip()
                     break
 
-            lock_fname = (
-                RuntimeLockFileType.CONDA
-                if swrt_config.mode == PythonRunEnv.CONDA
-                else RuntimeLockFileType.VENV
-            )
-            lock_files.append(f"{SW_AUTO_DIRNAME}/lock/{lock_fname}")
+            if lock_fpath is not None:
+                lock_paths.append(lock_fpath)
 
         operations = [
             (self._gen_version, 5, "gen version"),
@@ -867,7 +977,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                     env_prefix_path=env_prefix_path,
                     env_name=env_name,
                     env_use_shell=env_use_shell,
-                    lock_files=lock_files,
+                    lock_paths=lock_paths,
                 ),
             ),
             (
@@ -875,7 +985,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                 50,
                 "dump python dependencies",
                 dict(
-                    gen_all_bundles=kw.get("gen_all_bundles", False),
+                    download_all_deps=download_all_deps,
                     deps=swrt_config.dependencies,
                     mode=swrt_config.mode,
                     include_editable=include_editable,
@@ -895,9 +1005,8 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                 "dump src files:wheel, native files",
                 dict(
                     config=swrt_config,
-                    workdir=workdir,
-                    yaml_name=yaml_name,
-                    lock_files=lock_files,
+                    yaml_path=yaml_path,
+                    lock_paths=lock_paths,
                 ),
             ),
             (
@@ -917,25 +1026,12 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
     def _copy_src(
         self,
         config: RuntimeConfig,
-        workdir: Path,
-        yaml_name: str = DefaultYAMLName.RUNTIME,
-        lock_files: t.Optional[t.List[str]] = None,
+        yaml_path: Path,
+        lock_paths: t.Optional[t.List[Path]] = None,
     ) -> None:
-        lock_files = lock_files or []
-
-        conda_file_dups = set(config.dependencies._conda_files) & set(lock_files)
-        if conda_file_dups:
-            raise FieldTypeOrValueError(
-                f"conda files have used the auto-locked dependency files: {conda_file_dups}"
-            )
-
-        pip_file_dups = set(config.dependencies._pip_files) & set(lock_files)
-        if pip_file_dups:
-            raise FieldTypeOrValueError(
-                f"pip files have used the auto-locked dependency files:{pip_file_dups}"
-            )
-
-        workdir_fs = open_fs(str(workdir.resolve()))
+        workdir = yaml_path.parent.resolve()
+        yaml_name = yaml_path.name
+        workdir_fs = open_fs(str(workdir))
         snapshot_fs = open_fs(str(self.store.snapshot_workdir.resolve()))
         copy_file(workdir_fs, yaml_name, snapshot_fs, yaml_name)
 
@@ -984,11 +1080,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         logger.info("[step:copy-deps]start to copy pip/conda requirement files")
         ensure_dir(self.store.snapshot_workdir / RuntimeArtifactType.DEPEND)
 
-        for _fname in (
-            config.dependencies._conda_files
-            + config.dependencies._pip_files
-            + lock_files
-        ):
+        for _fname in config.dependencies._conda_files + config.dependencies._pip_files:
             _fpath = workdir / _fname
             if not _fpath.exists():
                 logger.warning(f"not found dependencies: {_fpath}")
@@ -1002,6 +1094,26 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                 _fname,
                 snapshot_fs,
                 _dest,
+            )
+
+        lock_paths = lock_paths or []
+        for _fpath in lock_paths:
+            _fname = _fpath.name
+            _dest_name = f"{RuntimeArtifactType.DEPEND}/{SW_AUTO_DIRNAME}/lock/{_fname.lstrip('/')}"
+            _dest_path = self.store.snapshot_workdir / _dest_name
+            if _dest_path.exists():
+                raise RuntimeError(
+                    f"{_dest_name} has already been added into the runtime.yaml, failed to copy the auto-lock file"
+                )
+
+            ensure_dir(_dest_path.parent)
+            self._manifest["artifacts"][RuntimeArtifactType.DEPEND].append(_dest_name)
+
+            copy_file(
+                open_fs(str(_fpath.parent)),
+                _fname,
+                snapshot_fs,
+                _dest_name,
             )
 
     def _dump_base_image(self, config: RuntimeConfig) -> None:
@@ -1035,12 +1147,12 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         env_prefix_path: str = "",
         env_name: str = "",
         env_use_shell: bool = False,
-        lock_files: t.Optional[t.List[str]] = None,
+        lock_paths: t.Optional[t.List[Path]] = None,
     ) -> None:
         console.print(":bee: dump environment info...")
         sh_py_env = guess_current_py_env()
         sh_py_ver = get_user_python_version(sh_py_env)
-        lock_files = lock_files or []
+        lock_paths = lock_paths or []
 
         self._manifest["environment"] = self._manifest.get("environment") or {}
 
@@ -1058,9 +1170,9 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                     "env_prefix_path": env_prefix_path,
                     "env_name": env_name,
                     "env_use_shell": env_use_shell,
-                    "files": lock_files,
+                    "files": [f"{SW_AUTO_DIRNAME}/lock/{p.name}" for p in lock_paths],
                 },
-                "auto_lock_dependencies": bool(lock_files),
+                "auto_lock_dependencies": bool(lock_paths),
                 "python": swrt_config.environment.python,
                 "arch": swrt_config.environment.arch,
                 "mode": swrt_config.mode,
@@ -1070,13 +1182,13 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
     def _dump_dependencies(
         self,
         mode: str = PythonRunEnv.AUTO,
-        gen_all_bundles: bool = False,
+        download_all_deps: bool = False,
         deps: t.Optional[Dependencies] = None,
         include_editable: bool = False,
         env_prefix_path: str = "",
         env_name: str = "",
     ) -> None:
-        console.print("dump dependencies info...")
+        console.print(":bagel: dump dependencies info...")
         deps = deps or Dependencies()
 
         self._manifest["dependencies"] = {
@@ -1091,7 +1203,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
 
         logger.info("[step:dep]finish dump dep")
 
-        if gen_all_bundles:
+        if download_all_deps:
             packaged = package_python_env(
                 export_dir=self.store.export_dir,
                 mode=mode,
@@ -1349,8 +1461,8 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
     @classmethod
     def lock(
         cls,
-        target_dir: t.Union[str, Path],
-        yaml_name: str = DefaultYAMLName.RUNTIME,
+        target_dir: str | Path,
+        yaml_path: str | Path,
         env_name: str = "",
         env_prefix_path: str = "",
         no_cache: bool = False,
@@ -1359,26 +1471,29 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         include_local_wheel: bool = False,
         emit_pip_options: bool = False,
         env_use_shell: bool = False,
-    ) -> str:
+    ) -> t.Tuple[str, t.Optional[Path]]:
+        """Install dependencies and save or print lock file
+
+        Arguments:
+            workdir: runtime work directory which contains the configured runtime.yaml
+            yaml_name: runtime config file name
+            env_name: conda environment name (used by conda env)
+            env_prefix_path: python env prefix path (used by both venv and conda)
+            no_cache: invalid all pkgs installed
+            stdout: just print the lock info into stdout without saving lock file
+            include_editable: include the editable pkg (only for venv)
+            include_local_wheel: include local wheel pkg (only for venv)
+            emit_pip_options: use user's pip configuration when freeze pkgs (only for venv)
+            env_use_shell: automatically detect env in current shell session
+
+        Returns:
+            the lock file content(str) and the lock file path(Path)
         """
-        Install dependencies and save or print lock file
-        :param target_dir: runtime work directory which contains the configured runtime.yaml
-        :param yaml_name: runtime config file name
-        :param env_name: conda environment name (used by conda env)
-        :param env_prefix_path: python env prefix path (used by both venv and conda)
-        :param no_cache: invalid all pkgs installed
-        :param stdout: just print the lock info into stdout without saving lock file
-        :param include_editable: include the editable pkg (only for venv)
-        :param include_local_wheel: include local wheel pkg (only for venv)
-        :param emit_pip_options: use user's pip configuration when freeze pkgs (only for venv)
-        :param env_use_shell: automatically detect env in current shell session
-        :return: the lock file content
-        """
-        target_dir = Path(target_dir)
-        runtime_fpath = target_dir / yaml_name
-        if not runtime_fpath.exists():
-            raise NotFoundError(runtime_fpath)
-        runtime_yaml = load_yaml(runtime_fpath)
+        yaml_path = Path(yaml_path)
+        if not yaml_path.exists():
+            raise NotFoundError(yaml_path)
+        runtime_yaml = load_yaml(yaml_path)
+
         mode = runtime_yaml.get("mode", PythonRunEnv.VENV)
         expected_pyver = str(runtime_yaml.get("environment", {}).get("python", ""))
         _, temp_lock_path = tempfile.mkstemp(prefix="starwhale-lock-")
@@ -1401,14 +1516,14 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         elif env_prefix_path:
             prefix_path = env_prefix_path
         else:
-            _sw_auto_path = target_dir / SW_AUTO_DIRNAME / mode
+            _sw_auto_path = Path(target_dir) / SW_AUTO_DIRNAME / mode
             cls._ensure_isolated_python_env(
                 _sw_auto_path, expected_pyver, mode, no_cache
             )
             prefix_path = str(_sw_auto_path)
 
         cls._install_dependencies_with_runtime_yaml(
-            workdir=target_dir,
+            src_dir=yaml_path.parent,
             runtime_yaml=runtime_yaml,
             env_dir=prefix_path,
             skip_deps=[DependencyType.NATIVE_FILE],
@@ -1452,6 +1567,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             console.rule("dependencies lock")
             console.print(content)
             os.unlink(temp_lock_path)
+            return content, None
         else:
             dest_fname = (
                 RuntimeLockFileType.CONDA
@@ -1463,8 +1579,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             dest_fpath = lock_dir / dest_fname
             shutil.move(temp_lock_path, dest_fpath)
             console.print(f":mouse: dump lock file: {dest_fpath}")
-
-        return content
+            return content, dest_fpath
 
     @staticmethod
     def render_runtime_yaml(
@@ -1475,27 +1590,14 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         pkgs: t.Optional[t.List[str]] = None,
         force: bool = False,
         auto_inject_sw: bool = True,
-        cuda_version: t.Optional[str] = None,
-    ) -> None:
+        cuda_version: str = "",
+        cudnn_version: str = "",
+        arch: str = "",
+    ) -> Path:
         workdir = Path(workdir)
         _rm = workdir / DefaultYAMLName.RUNTIME
-
-        if python_version == "":
-            python_version = get_python_version()
-
         if _rm.exists() and not force:
             raise ExistedError(f"{_rm} was already existed")
-
-        if mode == PythonRunEnv.CONDA:
-            lock_fname = RuntimeLockFileType.CONDA
-            lock_content = f"name: {name}"
-        else:
-            lock_fname = RuntimeLockFileType.VENV
-            lock_content = ""
-
-        lock_fpath = workdir / lock_fname
-        if not lock_fpath.exists():
-            ensure_file(lock_fpath, content=lock_content)
 
         pkgs = pkgs or []
         if auto_inject_sw and not any(
@@ -1505,28 +1607,25 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             if STARWHALE_VERSION and STARWHALE_VERSION != SW_DEV_DUMMY_VERSION:
                 sw_pkg = f"{sw_pkg}=={STARWHALE_VERSION}"
             pkgs.append(sw_pkg)
-
         pkgs = [p.strip() for p in pkgs if p.strip()]
 
-        ensure_dir(workdir)
         config: t.Dict[str, t.Any] = dict(
             name=name,
             mode=mode,
             environment={
-                "python": python_version,
-                "arch": SupportArch.NOARCH,
+                "python": python_version or get_python_version(),
+                "arch": arch or SupportArch.NOARCH,
                 "os": SupportOS.UBUNTU,
+                "cuda": cuda_version,
+                "cudnn": cudnn_version,
             },
             dependencies=[
-                lock_fname,
                 {"pip": pkgs},
             ],
             api_version=RUNTIME_API_VERSION,
         )
-        if cuda_version is not None:
-            config["environment"]["cuda"] = cuda_version
-
-        ensure_file(_rm, yaml.safe_dump(config, default_flow_style=False))
+        ensure_file(_rm, yaml.safe_dump(config, default_flow_style=False), parents=True)
+        return _rm
 
     def dockerize(
         self,
@@ -1712,7 +1811,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
 
     @staticmethod
     def _install_dependencies_with_runtime_yaml(
-        workdir: Path,
+        src_dir: Path,
         runtime_yaml: t.Any,
         env_dir: t.Union[Path, str],
         skip_deps: t.Optional[t.List[DependencyType]] = None,
@@ -1734,7 +1833,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             _func = (
                 dep.conda_install if PythonRunEnv.CONDA == mode else dep.venv_install
             )
-            _func(workdir, env_dir, configs)
+            _func(src_dir, env_dir, configs)
 
     @staticmethod
     def _install_dependencies_within_restore(
@@ -1872,6 +1971,3 @@ class CloudRuntime(CloudBundleModelMixin, Runtime):
         return crm._fetch_bundle_all_list(
             project_uri, URIType.RUNTIME, page, size, filter_dict
         )
-
-    def build(self, *args: t.Any, **kwargs: t.Any) -> None:
-        raise NoSupportError("no support build runtime in the cloud instance")

--- a/scripts/client_test/cmds/artifacts_cmd.py
+++ b/scripts/client_test/cmds/artifacts_cmd.py
@@ -330,22 +330,15 @@ class Runtime(BaseArtifact):
         workdir: str,
         project: str = "",
         runtime_yaml: str = "runtime.yaml",
-        gen_all_bundles: bool = False,
+        download_all_deps: bool = False,
         include_editable: bool = False,
-        enable_lock: bool = False,
-        env_prefix_path: str = "",
-        env_name: str = "",
     ) -> t.Any:
-        return RuntimeTermView.build(
-            workdir,
-            project,
-            runtime_yaml,
-            gen_all_bundles,
-            include_editable,
-            enable_lock,
-            env_prefix_path,
-            env_name,
-            False,
+        return RuntimeTermView.build_from_runtime_yaml(
+            workdir=workdir,
+            yaml_path=Path(workdir) / runtime_yaml,
+            project=project,
+            download_all_deps=download_all_deps,
+            include_editable=include_editable,
         )
 
     def build(
@@ -353,7 +346,7 @@ class Runtime(BaseArtifact):
         workdir: str,
         project: str = "",
         runtime_yaml: str = "",
-        gen_all_bundles: bool = False,
+        download_all_deps: bool = False,
         include_editable: bool = False,
         enable_lock: bool = False,
         env_prefix_path: str = "",
@@ -369,7 +362,7 @@ class Runtime(BaseArtifact):
             _args.extend(["--env-prefix-path", env_prefix_path])
         if env_name:
             _args.extend(["--env-name", env_name])
-        if gen_all_bundles:
+        if download_all_deps:
             _args.append("--gen-all-bundles")
         if include_editable:
             _args.append("--include-editable")


### PR DESCRIPTION
## Description
- build from multi-sources
  - build from conda name or conda_prefix without runtime.yaml
    ```bash
    swcli runtime build -c pytorch # lock pytorch conda environment and use `pytorch` as the runtime name                                                                                                                                                                   
    swcli runtime build --conda pytorch --name pytorch-runtime # use `pytorch-runtime` as the runtime name                                                                                                                                                                  
    swcli runtime build --conda pytorch --cuda 11.4 # specify the cuda version                                                                                                                                                                                              
    swcli runtime build --conda pytorch --arch noarch # specify the system architecture 
    swcli runtime build --conda-prefix /home/starwhale/anaconda3/envs/pytorch # get conda prefix path by `conda info --envs` command
    ```
    [![asciicast](https://asciinema.org/a/576854.svg)](https://asciinema.org/a/576854)
  - build from venv prefix without runtime.yaml
    ```bash
    swcli runtime build -v /home/starwhale/.virtualenvs/pytorch
    swcli runtime build --venv /home/starwhale/.local/share/virtualenvs/pytorch --arch amd64    
    ```
    [![asciicast](https://asciinema.org/a/576857.svg)](https://asciinema.org/a/576857)
  - build from shell without runtime.yaml
    ```bash
    swcli runtime build -s --cuda 11.4 --cudnn 8 # specify the cuda and cudnn version
    swcli runtime build --shell --name pytorch-runtime # lock the current shell environment and use `pytorch-runtime` as the runtime name
    ```
    [![asciicast](https://asciinema.org/a/576859.svg)](https://asciinema.org/a/576859)
  - build from runtime.yaml
    ```bash
    swcli runtime build  # use the current directory as the workdir and use the default runtime.yaml file                                                                                                                                                                   
    swcli runtime build -y example/pytorch/runtime.yaml # use example/pytorch/runtime.yaml as the runtime.yaml file                                                                                                                                                         
    swcli runtime build --yaml runtime.yaml # use runtime.yaml at the current directory as the runtime.yaml file  
    ```
    [![asciicast](https://asciinema.org/a/576861.svg)](https://asciinema.org/a/576861)
  - build from docker-image
    ```bash
    swcli runtime build --docker pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime  # use the docker image as the runtime directly
    ```
    [![asciicast](https://asciinema.org/a/576860.svg)](https://asciinema.org/a/576860)

- add more user-friendly help output in the `swcli runtime build --help` command
  - hide `--download-all-deps`, `--include-editable` and `--include-local-wheel` options for users

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
