### PR TITLE
chore(client): data store support deep copy when scan and insert

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -778,7 +778,7 @@ class InnerRecord:
             self.ordered = True
 
     def get_record(
-        self, revision: Optional[str] = None, deep_copy: bool = False
+        self, revision: Optional[str] = None, deep_copy: Optional[bool] = None
     ) -> Dict[str, Any]:
         self._reorder()
         ret: Dict[str, Any] = dict()
@@ -913,9 +913,13 @@ class MemoryTable:
         keep_none: bool = False,
         end_inclusive: bool = False,
         revision: Optional[str] = None,
-        deep_copy: bool = False,
+        deep_copy: Optional[bool] = None,
     ) -> Iterator[Dict[str, Any]]:
         _end_check: Callable = lambda x, y: x <= y if end_inclusive else x < y
+        if deep_copy is None:
+            env = os.getenv("SW_DATASTORE_SCAN_DEEP_COPY")
+            # make deep copy to True as default if env is not set
+            deep_copy = True if env is None else env.strip().upper() == "TRUE"
 
         with self.lock:
             records = []


### PR DESCRIPTION
## Description

Data store support deep copy when scan and insert
- insert : always deep copy
- scan: deep copy by default, can be set to false by setting the `SW_DATASTORE_SCAN_DEEP_COPY` env to any string but "true" (case insensitive)

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
