### PR TITLE
feat(runtime): support output filter for runtime info

### DIFF
--- a/client/starwhale/base/cloud.py
+++ b/client/starwhale/base/cloud.py
@@ -180,7 +180,7 @@ class CloudRequestMixed:
         }
 
         if uri.object.version:
-            # TODO: add manifest info by controller api
+            # TODO: add manifest, lock(runtime), model/dataset/runtime yaml info by controller api
             _manifest["version"] = uri.object.version
             _info = self._fetch_bundle_version_info(uri, typ)
             _manifest[CREATED_AT_KEY] = self.fmt_timestamp(_info["createdTime"])

--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -252,38 +252,28 @@ def _recover(runtime: str, force: bool) -> None:
 @runtime_cmd.command("info")
 @click.argument("runtime")
 @click.option(
-    "--fullname",
-    is_flag=True,
-    help="Show version fullname of the runtime without specified version",
-)
-@click.option(
     "-of",
     "--output-filter",
     type=click.Choice([f.value for f in RuntimeInfoFilter], case_sensitive=False),
     default=RuntimeInfoFilter.basic.value,
     show_default=True,
-    help="Filter the output content of the specified runtime version. Only standalone instance supports this option.",
+    help="Filter the output content. Only standalone instance supports this option.",
 )
 @click.pass_obj
 def _info(
     view: t.Type[RuntimeTermView],
     runtime: str,
-    fullname: bool,
     output_filter: str,
 ) -> None:
     """Show runtime details
 
-    RUNTIME: argument use the `Runtime URI` format. version is optional for the runtime uri.
+    RUNTIME: argument use the `Runtime URI` format. Version is optional for the Runtime URI.
+    If the version is not specified, the latest version will be used.
 
     Example:
 
         \b
-        - show all versions of runtime
-          swcli runtime info pytorch
-          swcli runtime info pytorch --fullname  # full version name
-
-        \b
-        - show the specified version of runtime
+          swcli runtime info pytorch # show basic info from the latest version of runtime
           swcli runtime info pytorch/version/v0  # show basic info
           swcli runtime info pytorch/version/v0 --output-filter basic  # show basic info
           swcli runtime info pytorch/version/v1 -of runtime_yaml  # show runtime.yaml content
@@ -291,7 +281,11 @@ def _info(
           swcli runtime info pytorch/version/v1 -of manifest # show _manifest.yaml content
           swcli runtime info pytorch/version/v1 -of all # show all info of the runtime
     """
-    view(runtime).info(fullname, RuntimeInfoFilter(output_filter))
+    uri = URI(runtime, expected_type=URIType.RUNTIME)
+    if not uri.object.version:
+        uri.object.version = "latest"
+
+    view(uri).info(RuntimeInfoFilter(output_filter))
 
 
 @runtime_cmd.command("history", help="Show runtime history")

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -728,10 +728,6 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             "bundle_path": str(self.store.bundle_path),
         }
 
-        if not self.uri.object.version:
-            ret["history"] = self.history()
-            return ret
-
         ret["basic"]["version"] = self.uri.object.version
         ret["basic"]["tags"] = StandaloneTag(self.uri).list()
 

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -547,15 +547,6 @@ class StandaloneRuntimeTestCase(TestCase):
         for p in _manifest["artifacts"]["dependencies"]:
             assert os.path.exists(os.path.join(runtime_workdir, p))
 
-        uri = URI(name, expected_type=URIType.RUNTIME)
-        sr = StandaloneRuntime(uri)
-        ensure_dir(sr.store.bundle_dir / f"xx{sr.store.bundle_type}")
-        info = sr.info()
-        assert info["basic"]["project"] == "self"
-        assert "version" not in info
-        assert len(info["history"]) == 1
-        assert info["history"][0]["version"] == build_version
-
         uri = URI(f"{name}/version/{build_version[:6]}", expected_type=URIType.RUNTIME)
         sr = StandaloneRuntime(uri)
         info = sr.info()
@@ -585,10 +576,6 @@ class StandaloneRuntimeTestCase(TestCase):
         tag_content = yaml.safe_load(tag_manifest_path.read_text())
         assert "t1" not in tag_content["tags"]
         assert "t2" in tag_content["tags"]
-
-        runtime_term_view(name).history(fullname=True)
-        runtime_term_view(name).info(fullname=True)
-        runtime_json_view(name).info(fullname=True)
 
         uri = f"{name}/version/{build_version}"
         for f in RuntimeInfoFilter:

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -49,6 +49,7 @@ from starwhale.core.runtime.model import (
     _TEMPLATE_DIR,
     RuntimeConfig,
     WheelDependency,
+    RuntimeInfoFilter,
     StandaloneRuntime,
 )
 from starwhale.core.runtime.store import RuntimeStorage
@@ -550,7 +551,7 @@ class StandaloneRuntimeTestCase(TestCase):
         sr = StandaloneRuntime(uri)
         ensure_dir(sr.store.bundle_dir / f"xx{sr.store.bundle_type}")
         info = sr.info()
-        assert info["project"] == "self"
+        assert info["basic"]["project"] == "self"
         assert "version" not in info
         assert len(info["history"]) == 1
         assert info["history"][0]["version"] == build_version
@@ -559,14 +560,18 @@ class StandaloneRuntimeTestCase(TestCase):
         sr = StandaloneRuntime(uri)
         info = sr.info()
         assert "history" not in info
-        assert info["version"] == build_version
+        assert info["basic"]["version"] == build_version
+        assert "manifest" in info
+        assert "runtime_yaml" in info
+        assert "requirements-sw-lock.txt" in info["lock"]
 
         rts = StandaloneRuntime.list(URI(""))
         assert len(rts[0]) == 1
         assert len(rts[0][name]) == 1
         assert rts[0][name][0]["version"] == build_version
 
-        runtime_term_view = get_term_view({"output": "json"})
+        runtime_json_view = get_term_view({"output": "json"})
+        runtime_term_view = get_term_view({"output": "terminal"})
 
         build_uri = f"{name}/version/{build_version}"
         tag_manifest_path = (
@@ -583,7 +588,12 @@ class StandaloneRuntimeTestCase(TestCase):
 
         runtime_term_view(name).history(fullname=True)
         runtime_term_view(name).info(fullname=True)
-        runtime_term_view(f"{name}/version/{build_version}").info(fullname=True)
+        runtime_json_view(name).info(fullname=True)
+
+        uri = f"{name}/version/{build_version}"
+        for f in RuntimeInfoFilter:
+            runtime_term_view(uri).info(output_filter=f)
+            runtime_json_view(uri).info(output_filter=f)
 
         runtime_term_view.list()
         RuntimeTermViewRich.list()

--- a/docs/docs/reference/swcli/runtime.md
+++ b/docs/docs/reference/swcli/runtime.md
@@ -120,6 +120,7 @@ swcli [GLOBAL OPTIONS] runtime info [OPTIONS] RUNTIME
 | Option | Required | Type | Defaults | Description |
 | --- | --- | --- | --- | --- |
 | `--fullname` | ❌ | Boolean | False | Show the full version name. Only the first 12 characters are shown if this option is false. |
+| `--output-filter` or `-of` | ❌ | Choice of [basic|runtime_yaml|manifest|lock|all] | basic | Filter the output content of the specified runtime version. Only standalone instance supports this option. |
 
 ## swcli runtime list {#list}
 

--- a/docs/docs/reference/swcli/runtime.md
+++ b/docs/docs/reference/swcli/runtime.md
@@ -119,8 +119,7 @@ swcli [GLOBAL OPTIONS] runtime info [OPTIONS] RUNTIME
 
 | Option | Required | Type | Defaults | Description |
 | --- | --- | --- | --- | --- |
-| `--fullname` | ❌ | Boolean | False | Show the full version name. Only the first 12 characters are shown if this option is false. |
-| `--output-filter` or `-of` | ❌ | Choice of [basic|runtime_yaml|manifest|lock|all] | basic | Filter the output content of the specified runtime version. Only standalone instance supports this option. |
+| `--output-filter` or `-of` | ❌ | Choice of [basic|runtime_yaml|manifest|lock|all] | basic | Filter the output content. Only standalone instance supports this option. |
 
 ## swcli runtime list {#list}
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/runtime.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/runtime.md
@@ -120,6 +120,7 @@ The `runtime info`命令输出指定Starwhale运行时版本的详细信息。
 | 选项 | 必填项 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `--fullname` | ❌ | Boolean | False | 显示完整的版本名称。如果没有使用该选项，则仅显示前 12 个字符。 |
+| `--output-filter` or `-of` | ❌ | Choice of [basic|runtime_yaml|manifest|lock|all] | basic | 对于具体版本的Runtime，可以设置输出的过滤规则，比如只显示Runtime的runtime.yaml。目前该参数仅对Standalone Instance的Runtime生效。 |
 
 ## swcli runtime list {#list}
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/runtime.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/runtime.md
@@ -119,8 +119,7 @@ The `runtime info`命令输出指定Starwhale运行时版本的详细信息。
 
 | 选项 | 必填项 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
-| `--fullname` | ❌ | Boolean | False | 显示完整的版本名称。如果没有使用该选项，则仅显示前 12 个字符。 |
-| `--output-filter` or `-of` | ❌ | Choice of [basic|runtime_yaml|manifest|lock|all] | basic | 对于具体版本的Runtime，可以设置输出的过滤规则，比如只显示Runtime的runtime.yaml。目前该参数仅对Standalone Instance的Runtime生效。 |
+| `--output-filter` or `-of` | ❌ | Choice of [basic|runtime_yaml|manifest|lock|all] | basic | 设置输出的过滤规则，比如只显示Runtime的runtime.yaml。目前该参数仅对Standalone Instance的Runtime生效。 |
 
 ## swcli runtime list {#list}
 


### PR DESCRIPTION
## Description
[![asciicast](https://asciinema.org/a/576532.svg)](https://asciinema.org/a/576532)

```shell
❯ swcli runtime info --help
Usage: swcli runtime info [OPTIONS] RUNTIME

  Show runtime details

  RUNTIME: argument use the `Runtime URI` format. Version is optional for the
  Runtime URI. If the version is not specified, the latest version will be
  used.

  Example:

            swcli runtime info pytorch # show basic info from the latest version of runtime
            swcli runtime info pytorch/version/v0  # show basic info
            swcli runtime info pytorch/version/v0 --output-filter basic  # show basic info
            swcli runtime info pytorch/version/v1 -of runtime_yaml  # show runtime.yaml content
            swcli runtime info pytorch/version/v1 -of lock # show auto lock file content
            swcli runtime info pytorch/version/v1 -of manifest # show _manifest.yaml content
            swcli runtime info pytorch/version/v1 -of all # show all info of the runtime

Options:
  -of, --output-filter [basic|runtime_yaml|manifest|lock|all]
                                  Filter the output content. Only standalone
                                  instance supports this option.  [default:
                                  basic]
  --help                          Show this message and exit.
```

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
