### PR TITLE
feat(controller): resource pool support tolerations

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -618,7 +618,7 @@ public class RuntimeService {
                 ret.put(templateContainer.getName(), containerOverwriteSpec);
             });
 
-            k8sJobTemplate.renderJob(job, runtimeVersion.getVersionName(), "OnFailure", 2, ret, null);
+            k8sJobTemplate.renderJob(job, runtimeVersion.getVersionName(), "OnFailure", 2, ret, null, List.of());
 
             log.debug("deploying job to k8s :{}", JSONUtil.toJsonStr(job));
             k8sClient.deployJob(job);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/resourcepool/bo/ResourcePool.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/resourcepool/bo/ResourcePool.java
@@ -42,6 +42,7 @@ public class ResourcePool {
     String name;
     Map<String, String> nodeSelector;
     List<Resource> resources;
+    List<Toleration> tolerations;
 
     public static ResourcePool defaults() {
         return ResourcePool

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/resourcepool/bo/Toleration.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/resourcepool/bo/Toleration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.system.resourcepool.bo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Toleration {
+    String key;
+    String operator;
+    String value;
+    String effect;
+    Long tolerationSeconds;
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplate.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.schedule.k8s;
 
+import ai.starwhale.mlops.domain.system.resourcepool.bo.Toleration;
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EmptyDirVolumeSource;
@@ -28,6 +29,7 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 import io.kubernetes.client.openapi.models.V1Probe;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.openapi.models.V1Toleration;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.util.Yaml;
 import java.io.IOException;
@@ -122,14 +124,36 @@ public class K8sJobTemplate {
             String restartPolicy,
             int backoffLimit,
             Map<String, ContainerOverwriteSpec> containerSpecMap,
-            Map<String, String> nodeSelectors
+            Map<String, String> nodeSelectors,
+            List<Toleration> tolerations
     ) {
         job.getMetadata().name(jobName);
         V1JobSpec jobSpec = job.getSpec();
         Objects.requireNonNull(jobSpec, "can not get job spec");
         jobSpec.backoffLimit(backoffLimit);
+
         V1PodSpec podSpec = jobSpec.getTemplate().getSpec();
         Objects.requireNonNull(podSpec, "can not get pod spec");
+
+        if (tolerations != null && !tolerations.isEmpty()) {
+            var originTolerations = podSpec.getTolerations();
+            if (originTolerations == null) {
+                originTolerations = new ArrayList<>();
+            }
+            originTolerations.addAll(
+                    tolerations.stream()
+                        .map(t -> new V1Toleration()
+                            .key(t.getKey())
+                            .operator(t.getOperator())
+                            .value(t.getValue())
+                            .effect(t.getEffect())
+                            .tolerationSeconds(t.getTolerationSeconds())
+                        )
+                        .collect(Collectors.toList())
+            );
+            podSpec.tolerations(originTolerations);
+        }
+
         updateLabels(job, starwhaleJobLabel);
         updateLabels(job, Map.of(JOB_IDENTITY_LABEL, jobName));
         patchPodSpec(restartPolicy, containerSpecMap, nodeSelectors, podSpec);

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplateTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sJobTemplateTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
 import ai.starwhale.mlops.domain.runtime.RuntimeResource;
+import ai.starwhale.mlops.domain.system.resourcepool.bo.Toleration;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
@@ -62,7 +63,8 @@ public class K8sJobTemplateTest {
         Map<String, ContainerOverwriteSpec> containerSpecMap = buildContainerSpecMap();
         Map<String, String> nodeSelectors = Map.of("label.pool.bj01", "true");
         var job = k8sJobTemplate.loadJob(K8sJobTemplate.WORKLOAD_TYPE_EVAL);
-        k8sJobTemplate.renderJob(job, "yxz", "OnFailure", 10, containerSpecMap, nodeSelectors);
+        var toleration = new Toleration("key1", "Equal", "value1", "NoSchedule", 100L);
+        k8sJobTemplate.renderJob(job, "yxz", "OnFailure", 10, containerSpecMap, nodeSelectors, List.of(toleration));
         Assertions.assertEquals(10, Objects.requireNonNull(job.getSpec()).getBackoffLimit());
         V1PodSpec v1PodSpec = job.getSpec().getTemplate().getSpec();
         Assertions.assertEquals("true", v1PodSpec.getNodeSelector().get("label.pool.bj01"));
@@ -86,6 +88,14 @@ public class K8sJobTemplateTest {
                 List.of(new V1EnvVar().name("envx").value("envxvalue"),
                         new V1EnvVar().name("envy").value("envyvalue")),
                 dpC.getEnv());
+
+        Assertions.assertEquals(1, v1PodSpec.getTolerations().size());
+        var tolerationInJob = v1PodSpec.getTolerations().get(0);
+        Assertions.assertEquals("key1", tolerationInJob.getKey());
+        Assertions.assertEquals("Equal", tolerationInJob.getOperator());
+        Assertions.assertEquals("value1", tolerationInJob.getValue());
+        Assertions.assertEquals("NoSchedule", tolerationInJob.getEffect());
+        Assertions.assertEquals(100L, tolerationInJob.getTolerationSeconds());
     }
 
     private Map<String, ContainerOverwriteSpec> buildContainerSpecMap() {
@@ -111,7 +121,7 @@ public class K8sJobTemplateTest {
     public void testPipCache() throws IOException {
         Map<String, ContainerOverwriteSpec> containerSpecMap = buildContainerSpecMap();
         var job = k8sJobTemplate.loadJob(K8sJobTemplate.WORKLOAD_TYPE_EVAL);
-        k8sJobTemplate.renderJob(job, "foo", "OnFailure", 10, containerSpecMap, Map.of());
+        k8sJobTemplate.renderJob(job, "foo", "OnFailure", 10, containerSpecMap, Map.of(), List.of());
         var volume = job.getSpec().getTemplate().getSpec().getVolumes().stream()
                 .filter(v -> v.getName().equals(K8sJobTemplate.PIP_CACHE_VOLUME_NAME)).findFirst().orElse(null);
         Assertions.assertEquals(volume.getHostPath().getPath(), "/path");
@@ -119,7 +129,7 @@ public class K8sJobTemplateTest {
         // empty host path
         var template = new K8sJobTemplate("", "", "", "");
         job = k8sJobTemplate.loadJob(K8sJobTemplate.WORKLOAD_TYPE_EVAL);
-        template.renderJob(job, "foo", "OnFailure", 10, containerSpecMap, Map.of());
+        template.renderJob(job, "foo", "OnFailure", 10, containerSpecMap, Map.of(), List.of());
         volume = job.getSpec().getTemplate().getSpec().getVolumes().stream()
                 .filter(v -> v.getName().equals(K8sJobTemplate.PIP_CACHE_VOLUME_NAME)).findFirst().orElse(null);
         Assertions.assertNull(volume.getHostPath());
@@ -130,7 +140,7 @@ public class K8sJobTemplateTest {
     public void testDevInfoLabel() {
         Map<String, ContainerOverwriteSpec> containerSpecMap = buildContainerSpecMap();
         var job = k8sJobTemplate.loadJob(K8sJobTemplate.WORKLOAD_TYPE_EVAL);
-        k8sJobTemplate.renderJob(job, "foo", "OnFailure", 10, containerSpecMap, Map.of());
+        k8sJobTemplate.renderJob(job, "foo", "OnFailure", 10, containerSpecMap, Map.of(), List.of());
         var labels = job.getSpec().getTemplate().getMetadata().getLabels();
         assertThat(labels, hasEntry(K8sJobTemplate.DEVICE_LABEL_NAME_PREFIX + "cpu", "true"));
 
@@ -146,7 +156,7 @@ public class K8sJobTemplateTest {
         specs.put("baz", cpuSpec);
 
         job = k8sJobTemplate.loadJob(K8sJobTemplate.WORKLOAD_TYPE_EVAL);
-        k8sJobTemplate.renderJob(job, "foo", "OnFailure", 10, specs, Map.of());
+        k8sJobTemplate.renderJob(job, "foo", "OnFailure", 10, specs, Map.of(), List.of());
         labels = job.getSpec().getTemplate().getMetadata().getLabels();
         assertThat(labels, is(Map.of(K8sJobTemplate.DEVICE_LABEL_NAME_PREFIX + "nvidia.com/gpu", "true",
                 K8sJobTemplate.DEVICE_LABEL_NAME_PREFIX + "cpu", "true")));

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
@@ -35,6 +35,7 @@ import ai.starwhale.mlops.domain.model.Model;
 import ai.starwhale.mlops.domain.project.bo.Project;
 import ai.starwhale.mlops.domain.runtime.RuntimeResource;
 import ai.starwhale.mlops.domain.system.resourcepool.bo.ResourcePool;
+import ai.starwhale.mlops.domain.system.resourcepool.bo.Toleration;
 import ai.starwhale.mlops.domain.task.bo.ResultPath;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.bo.TaskRequest;
@@ -175,7 +176,7 @@ public class K8sTaskSchedulerTest {
         @Override
         public V1Job renderJob(V1Job job, String jobName, String restartPolicy, int backoffLimit,
                 Map<String, ContainerOverwriteSpec> containerSpecMap,
-                Map<String, String> nodeSelectors) {
+                Map<String, String> nodeSelectors, List<Toleration> tolerations) {
             ContainerOverwriteSpec worker = containerSpecMap.get("worker");
             Assertions.assertIterableEquals(worker.getCmds(), List.of("evaluation"));
             Assertions.assertEquals("imageRT", worker.getImage());


### PR DESCRIPTION
## Description

Demo resource pool settings:

```yaml
resourcePoolSetting:
- name: "default"
  nodeSelector:
    kubernetes.io/hostname: "starwhale-vk-node"
  resources:
  - name: "nvidia.com/gpu"
    max: 2.0
    min: 1.0
    defaults: 0.0
  - name: "memory"
    max: 10240.0
    min: 1024.0
    defaults: 2048.0
  tolerations:
  - key: "virtual-kubelet.io/provider"
    operator: "Equal"
    value: "starwhale"
    effect: "NoSchedule"
```

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
