### PR TITLE
fix(datastore): fix rename issue after table file compress

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -864,7 +864,8 @@ class ZipCompressor(Compressor):
         return ".zip"
 
     def compress(self, source: Path) -> Path:
-        output = tempfile.mktemp()
+        # use the same dir as the source file
+        output = source.with_suffix(self.extension())
         with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
             zipf.write(source, source.name)
         return Path(output)


### PR DESCRIPTION
## Description

Fix issue

``` python
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/home/foo/work/repo/starwhale/client/starwhale/api/_impl/data_store.py", line 999, in dump
    return self._dump(root, if_dirty)
  File "/home/foo/work/repo/starwhale/client/starwhale/api/_impl/data_store.py", line 1031, in _dump
    os.rename(compressed, new_dst)
OSError: [Errno 18] Invalid cross-device link: '/tmp/tmpcdimdctd' -> '/home/foo/.starwhale/.datastore/project/self/dataset/mnist/_current/meta.sw-datastore.zip'
```

```bash
df -T
Filesystem     Type     1K-blocks      Used Available Use% Mounted on
dev            devtmpfs  15807652         0  15807652   0% /dev
run            tmpfs     15827352      1948  15825404   1% /run
/dev/nvme0n1p5 ext4     283661824 206080776  63098772  77% /
tmpfs          tmpfs     15827352     97004  15730348   1% /dev/shm
tmpfs          tmpfs     15827352     19332  15808020   1% /tmp
/dev/nvme0n1p1 vfat       1040428    160690    879738  16% /boot
tmpfs          tmpfs      3165468       112   3165356   1% /run/user/1000
```

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
