### PR TITLE
fix(controller): the token may be treated as invalid if the pod is pending in eval

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/configuration/security/TaskTokenValidator.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/configuration/security/TaskTokenValidator.java
@@ -33,6 +33,7 @@ public class TaskTokenValidator implements JwtClaimValidator {
 
     private static final String CLAIM_TASK_ID = "taskId";
     private static final Set<TaskStatus> TOKEN_VALID_STATUSES = Set.of(
+            TaskStatus.PREPARING,
             TaskStatus.RUNNING,
             TaskStatus.READY
     );


### PR DESCRIPTION
## Description

The token may be treated as invalid in this condition:

- Task ready
- Pod start
- Pod failed
- New pod created (pending)
- Task status changed from running to preparing
- The `TaskTokenValidator` treat the token as invalid

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
