### PR TITLE
fix(datastore): sort attributes by names when creating parquet types

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/parquet/SwWriteSupport.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/parquet/SwWriteSupport.java
@@ -34,6 +34,7 @@ import ai.starwhale.mlops.datastore.type.StringValue;
 import ai.starwhale.mlops.exception.SwProcessException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -326,6 +327,7 @@ public class SwWriteSupport extends WriteSupport<Map<String, BaseValue>> {
             case OBJECT:
                 valueType = Types.optionalGroup()
                         .addFields(schema.getAttributesSchema().values().stream()
+                                .sorted(Comparator.comparing(ColumnSchema::getName))
                                 .map(SwWriteSupport::createParquetType)
                                 .toArray(Type[]::new))
                         .addField(Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL)

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/parquet/ParquetReadWriteTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/parquet/ParquetReadWriteTest.java
@@ -80,7 +80,8 @@ public class ParquetReadWriteTest {
                         .type("OBJECT")
                         .pythonType("placeholder")
                         .attributes(List.of(ColumnSchemaDesc.builder().name("a").type("INT32").build(),
-                                ColumnSchemaDesc.builder().name("b").type("INT32").build()))
+                                ColumnSchemaDesc.builder().name("b").type("INT32").build(),
+                                ColumnSchemaDesc.builder().name("aa").type("STRING").build()))
                         .build(),
                 ColumnSchemaDesc.builder().name("l")
                         .type("LIST")
@@ -141,7 +142,7 @@ public class ParquetReadWriteTest {
                         put("i", null);
                         put("j", BaseValue.valueOf(List.of(10)));
                         put("jj", BaseValue.valueOf(Map.of("a", 0, "b", 1)));
-                        put("k", ObjectValue.valueOf("t", Map.of("b", 11, "a", 12)));
+                        put("k", ObjectValue.valueOf("t", Map.of("b", 11, "a", 12, "aa", "13")));
                         put("l", BaseValue.valueOf(List.of(List.of(
                                 ObjectValue.valueOf("v",
                                         Map.of("a", ObjectValue.valueOf("t", Map.of("b", 3, "a", 4)),


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
