### PR TITLE
chore(client): always retry when updating remote data store

### DIFF
--- a/client/starwhale/utils/retry.py
+++ b/client/starwhale/utils/retry.py
@@ -38,13 +38,16 @@ def http_retry(*args: t.Any, **kw: t.Any) -> t.Any:
     else:
 
         def wrap(f: t.Callable) -> t.Any:
-            _attempts = kw.get("attempts", 3)
+            _attempts = kw.pop("attempts", 3)
             _cls = AsyncRetrying if iscoroutinefunction(f) else Retrying
             return _cls(
                 *args,
                 reraise=True,
-                stop=stop_after_attempt(_attempts),
-                retry=retry_if_http_exception(_RETRY_HTTP_STATUS_CODES),
+                stop=kw.pop("stop", stop_after_attempt(_attempts)),
+                retry=kw.pop(
+                    "retry", retry_if_http_exception(_RETRY_HTTP_STATUS_CODES)
+                ),
+                **kw,
             ).wraps(f)
 
         return wrap


### PR DESCRIPTION
## Description

Always retry when updating the remote data store even if the exception is raised (such as `socket.timeout`)

![image](https://user-images.githubusercontent.com/3217223/232978582-7f74b3ad-8f4e-459a-96af-f710d625de33.png)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
