### PR TITLE
feat(client): support swcli model info command for output filter

### DIFF
--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -409,7 +409,7 @@ def _info(
     runtime: str,
     output_filter: str,
 ) -> None:
-    """Show runtime details
+    """Show runtime details.
 
     RUNTIME: argument use the `Runtime URI` format. Version is optional for the Runtime URI.
     If the version is not specified, the latest version will be used.

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -760,10 +760,9 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             "project": self.uri.project,
             "snapshot_workdir": str(self.store.snapshot_workdir),
             "bundle_path": str(self.store.bundle_path),
+            "version": self.uri.object.version,
+            "tags": StandaloneTag(self.uri).list(),
         }
-
-        ret["basic"]["version"] = self.uri.object.version
-        ret["basic"]["tags"] = StandaloneTag(self.uri).list()
 
         if self.store.snapshot_workdir.exists():
             ret["manifest"] = self.store.manifest

--- a/docs/docs/reference/swcli/model.md
+++ b/docs/docs/reference/swcli/model.md
@@ -93,7 +93,7 @@ swcli [GLOBAL OPTIONS] model info [OPTIONS] <MODEL>
 
 | Option | Required | Type | Defaults | Description |
 | --- | --- | --- | --- | --- |
-| `--fullname` | ❌ | Boolean | False | Show the full version name. Only the first 12 characters are shown if this option is false. |
+| `--output-filter` or `-of` | ❌ | Choice of [basic|model_yaml|manifest|files|handlers|all] | basic | Filter the output content. Only standalone instance supports this option. |
 
 ## swcli model list {#list}
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/model.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/model.md
@@ -91,7 +91,7 @@ swcli model info [选项] <MODEL>
 
 | 选项 | 必填项 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
-| `--fullname` | ❌ | Boolean | False | 显示完整的版本名称。如果没有使用该选项，则仅显示前 12 个字符。 |
+| `--output-filter` 或 `-of` | ❌ | Choice of [basic|model_yaml|manifest|files|handlers|all] | basic | 设置输出的过滤规则，比如只显示Model的model.yaml。目前该参数仅对Standalone Instance的Model生效。 |
 
 ## swcli model list {#list}
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/runtime.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/reference/swcli/runtime.md
@@ -101,7 +101,7 @@ swcli [全局选项] runtime info [选项] RUNTIME
 
 | 选项 | 必填项 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
-| `--output-filter` or `-of` | ❌ | Choice of [basic|runtime_yaml|manifest|lock|all] | basic | 设置输出的过滤规则，比如只显示Runtime的runtime.yaml。目前该参数仅对Standalone Instance的Runtime生效。 |
+| `--output-filter` 或 `-of` | ❌ | Choice of [basic|runtime_yaml|manifest|lock|all] | basic | 设置输出的过滤规则，比如只显示Runtime的runtime.yaml。目前该参数仅对Standalone Instance的Runtime生效。 |
 
 ## swcli runtime list {#list}
 


### PR DESCRIPTION
## Description
- changes:
  - support `--output-filter` option for `swcli model info` command
- command help:
  ```console
  ❯ swcli model info --help
  Usage: swcli model info [OPTIONS] MODEL
  
    Show model details.
  
    MODEL: argument use the `Model URI` format. Version is optional for the
    Model URI. If the version is not specified, the latest version will be used.
  
    Example:
  
            swcli model info mnist # show basic info from the latest version of model
            swcli model info mnist/version/v0 # show basic info from the v0 version of model
            swcli model info mnist/version/latest --output-filter=all # show all info
            swcli model info mnist -of basic # show basic info
            swcli model info mnist -of manifest # show manifest.yaml
            swcli model info mnist -of model_yaml  # show model.yaml
            swcli model info mnist -of handlers # show model runnable handlers info
            swcli model info mnist -of files # show model package files tree
            swcli -o json model info mnist -of all # show all info in json format
  
  Options:
    -of, --output-filter [basic|model_yaml|manifest|handlers|files|all]
                                    Filter the output content. Only standalone
                                    instance supports this option.  [default:
                                    basic]
    --help                          Show this message and exit.
  ```   
- [![asciicast](https://asciinema.org/a/578810.svg)](https://asciinema.org/a/578810)

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
