### PR TITLE
refactor(client): use uri components instead of URI

### DIFF
--- a/client/starwhale/api/_impl/dataset/loader.py
+++ b/client/starwhale/api/_impl/dataset/loader.py
@@ -8,8 +8,6 @@ from functools import total_ordering
 
 from starwhale.utils import console
 from starwhale.consts import HTTPMethod
-from starwhale.base.uri import URI
-from starwhale.base.type import URIType, InstanceType
 from starwhale.base.cloud import CloudRequestMixed
 from starwhale.utils.error import ParameterError
 from starwhale.utils.dict_util import transform_dict
@@ -19,6 +17,7 @@ from starwhale.core.dataset.tabular import (
     DEFAULT_CONSUMPTION_BATCH_SIZE,
     TabularDatasetSessionConsumption,
 )
+from starwhale.base.uricomponents.resource import Resource, ResourceType
 
 _DEFAULT_LOADER_CACHE_SIZE = 20
 
@@ -140,7 +139,7 @@ _TRowQItem = t.Optional[t.Union[DataRow, Exception]]
 class DataLoader:
     def __init__(
         self,
-        dataset_uri: URI,
+        dataset_uri: Resource,
         start: t.Optional[t.Any] = None,
         end: t.Optional[t.Any] = None,
         session_consumption: t.Optional[TabularDatasetSessionConsumption] = None,
@@ -183,9 +182,9 @@ class DataLoader:
             else DEFAULT_CONSUMPTION_BATCH_SIZE
         )
         r = CloudRequestMixed.do_http_request(
-            f"/project/{self.dataset_uri.project}/{self.dataset_uri.object.typ}/{self.dataset_uri.object.name}/uri/sign-links",
+            f"/project/{self.dataset_uri.project.name}/{self.dataset_uri.typ.value}/{self.dataset_uri.name}/uri/sign-links",
             method=HTTPMethod.POST,
-            instance_uri=self.dataset_uri,
+            instance=self.dataset_uri.instance,
             params={
                 "expTimeMillis": int(
                     os.environ.get("SW_MODEL_PROCESS_UNIT_TIME_MILLIS", "60000")
@@ -211,7 +210,7 @@ class DataLoader:
                 if rt is None:
                     break
 
-                if self.dataset_uri.instance_type == InstanceType.CLOUD:
+                if self.dataset_uri.instance.is_cloud:
                     for rows in self.tabular_dataset.scan_batch(
                         rt[0], rt[1], self.session_consumption.batch_size
                     ):
@@ -341,7 +340,7 @@ class DataLoader:
 
 
 def get_data_loader(
-    dataset_uri: t.Union[str, URI],
+    dataset_uri: t.Union[str, Resource],
     start: t.Optional[t.Any] = None,
     end: t.Optional[t.Any] = None,
     session_consumption: t.Optional[TabularDatasetSessionConsumption] = None,
@@ -359,7 +358,7 @@ def get_data_loader(
             )
 
     if isinstance(dataset_uri, str):
-        dataset_uri = URI(dataset_uri, expected_type=URIType.DATASET)
+        dataset_uri = Resource(dataset_uri, ResourceType.dataset)
 
     return DataLoader(
         dataset_uri,

--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import typing as t
 from http import HTTPStatus
@@ -23,20 +25,15 @@ from starwhale.consts import (
     HTTPMethod,
     CREATED_AT_KEY,
     VERSION_PREFIX_CNT,
-    STANDALONE_INSTANCE,
     DEFAULT_MANIFEST_NAME,
 )
 from starwhale.base.tag import StandaloneTag
-from starwhale.base.uri import URI
 from starwhale.utils.fs import ensure_dir, ensure_file
-from starwhale.base.type import URIType, InstanceType, get_bundle_type_by_uri
+from starwhale.base.type import URIType, get_bundle_type_by_uri
 from starwhale.base.cloud import CloudRequestMixed
 from starwhale.utils.error import NotFoundError, NoSupportError, FieldTypeOrValueError
 from starwhale.utils.config import SWCliConfigMixed
 from starwhale.base.blob.store import LocalFileStore
-from starwhale.core.model.store import ModelStorage
-from starwhale.core.dataset.store import DatasetStorage
-from starwhale.core.runtime.store import RuntimeStorage
 from starwhale.base.uricomponents.project import Project
 from starwhale.base.uricomponents.resource import Resource, ResourceType
 
@@ -59,130 +56,137 @@ class _UploadPhase:
 class BundleCopy(CloudRequestMixed):
     def __init__(
         self,
-        src_uri: str,
-        dest_uri: str,
+        src_uri: str | Resource,
+        dest_uri: str | Resource | Project,
         typ: str,
         force: bool = False,
         **kw: t.Any,
     ) -> None:
-        self.src_resource = Resource(src_uri, typ=ResourceType[typ])
-        self.src_uri = self.src_resource.to_uri()
-        if self.src_uri.instance_type == InstanceType.CLOUD:
+        self.src_resource: Resource = (
+            Resource(src_uri, typ=ResourceType[typ])
+            if isinstance(src_uri, str)
+            else src_uri
+        )
+        if not self.src_resource.version:
+            self.src_resource.version = "latest"
+
+        if not self.src_resource.instance.is_local:
             p = kw.get("dest_local_project_uri")
             project = p and Project(p) or None
-            dest_uri = self.src_uri.object.name if dest_uri.strip() == "." else dest_uri
+            dest_uri = (
+                f"{self.src_resource.name}/version/{self.src_resource.version}"
+                if (dest_uri == "." or dest_uri == "")
+                else dest_uri
+            )
         else:
             project = None
 
-        try:
+        dest = dest_uri
+        if isinstance(dest_uri, str):
+            try:
+                dest = Resource(
+                    dest_uri, typ=ResourceType[typ], project=project, _skip_refine=True
+                )
+            except Exception as e:
+                if str(e).startswith("invalid uri"):
+                    dest = Project(dest_uri)
+                else:
+                    raise
+        if isinstance(dest, Project):
             self.dest_uri = Resource(
-                dest_uri, typ=ResourceType[typ], project=project
-            ).to_uri()
-        except Exception as e:
-            if str(e).startswith("invalid uri"):
-                self.dest_uri = Project(dest_uri).to_uri()
-            else:
-                raise
+                f"{self.src_resource.name}/version/{self.src_resource.version}",
+                name=self.src_resource.name,
+                typ=ResourceType[typ],
+                project=dest,
+                _skip_refine=True,
+            )
+        elif isinstance(dest, Resource):
+            self.dest_uri = dest
+        else:
+            raise Exception("invalid dest_uri")  # this can not happen
+
+        if not self.dest_uri.version:
+            self.dest_uri.version = self.src_resource.version
+        if self.dest_uri.version == "latest":
+            self.dest_uri.version = ""
 
         self.typ = typ
         self.force = force
-        self.bundle_name = self.src_uri.object.name
-        self.bundle_version = self._guess_bundle_version()
         self.field_flag = _query_param_map[self.typ]
-        self.field_value = f"{self.bundle_name}:{self.bundle_version}"
-
+        self.field_value = f"{self.src_resource.name}:{self.src_resource.version}"
         self.kw = kw
 
         self._sw_config = SWCliConfigMixed()
         self._do_validate()
         self._object_store = LocalFileStore()
 
-    def _guess_bundle_version(self) -> str:
-        if self.src_uri.instance_type == InstanceType.CLOUD:
-            return self.src_uri.object.version
-        else:
-            if self.typ == URIType.DATASET:
-                _v = DatasetStorage(self.src_uri).id
-            elif self.typ == URIType.MODEL:
-                _v = ModelStorage(self.src_uri).id
-            elif self.typ == URIType.RUNTIME:
-                _v = RuntimeStorage(self.src_uri).id
-            else:
-                raise NoSupportError(self.typ)
-
-            return _v or self.src_uri.object.version
-
     def _do_validate(self) -> None:
         if self.typ not in (URIType.DATASET, URIType.MODEL, URIType.RUNTIME):
             raise NoSupportError(f"{self.typ} copy does not work")
 
-        if self.bundle_version == "":
-            raise Exception(f"must specify version src:({self.bundle_version})")
-
-    def _check_cloud_obj_existed(self, instance_uri: URI) -> bool:
+    def _check_cloud_obj_existed(self, rc: Resource) -> bool:
         # TODO: add more params for project
         # TODO: tune controller api, use unified params name
         ok, _ = self.do_http_request_simple_ret(
             path=self._get_remote_bundle_api_url(for_head=True),
             method=HTTPMethod.HEAD,
-            instance_uri=instance_uri,
+            instance=rc.instance,
             ignore_status_codes=[HTTPStatus.NOT_FOUND],
         )
         return ok
 
-    def _get_versioned_resource_path(self, uri: URI) -> Path:
-        if uri.instance_type != InstanceType.STANDALONE:
+    def _get_versioned_resource_path(self, uri: Resource) -> Path:
+        if not uri.instance.is_local:
             raise NoSupportError(f"{uri} to get target dir path")
 
-        resource_name = uri.object.name or self.bundle_name
         return (
             self._sw_config.rootdir
-            / uri.project
+            / uri.project.name
             / self.typ
-            / resource_name
-            / self.bundle_version[:VERSION_PREFIX_CNT]
-            / f"{self.bundle_version}{get_bundle_type_by_uri(self.typ)}"
+            / uri.name
+            / self.src_resource.version[:VERSION_PREFIX_CNT]
+            / f"{uri.version}{get_bundle_type_by_uri(self.typ)}"
         )
 
-    def _check_version_existed(self, uri: URI) -> bool:
-        if uri.instance_type == InstanceType.CLOUD:
+    def _check_version_existed(self, uri: Resource) -> bool:
+        if uri.instance.is_cloud:
             return self._check_cloud_obj_existed(uri)
         else:
             return self._get_versioned_resource_path(uri).exists()
 
     def _get_remote_bundle_console_url(self, with_version: bool = True) -> str:
-        if self.src_uri.instance_type == InstanceType.CLOUD:
-            remote = self.src_uri
-            resource_name = self.src_uri.object.name
+        if self.src_resource.instance.is_cloud:
+            remote = self.src_resource
+            resource_name = self.src_resource.name
         else:
             remote = self.dest_uri
-            resource_name = self.dest_uri.object.name or self.src_uri.object.name
+            resource_name = self.dest_uri.name or self.src_resource.name
 
         url = f"{remote.instance}/projects/{remote.project}/{self.typ}s/{resource_name}"
         if with_version:
-            url = f"{url}/versions/{self.src_uri.object.version}/overview"
+            url = f"{url}/versions/{self.src_resource.version}/overview"
         return url
 
     def _get_remote_bundle_api_url(self, for_head: bool = False) -> str:
-        version = self.src_uri.object.version
+        version = self.src_resource.version
         if not version:
             raise FieldTypeOrValueError(
-                f"cannot fetch version from src uri:{self.src_uri}"
+                f"cannot fetch version from src uri:{self.src_resource}"
             )
 
-        if self.src_uri.instance_type == InstanceType.CLOUD:
-            project = self.src_uri.project
-            resource_name = self.src_uri.object.name
+        if self.src_resource.instance.is_cloud:
+            project = self.src_resource.project
+            resource_name = self.src_resource.name
         else:
             project = self.dest_uri.project
-            resource_name = self.dest_uri.object.name or self.src_uri.object.name
+            resource_name = self.dest_uri.name or self.src_resource.name
 
         if not resource_name:
             raise FieldTypeOrValueError(
-                f"cannot fetch {self.typ} resource name from src_uri({self.src_uri}) or dest_uri({self.dest_uri})"
+                f"cannot fetch {self.typ} resource name from src_uri({self.src_resource}) or dest_uri({self.dest_uri})"
             )
 
-        base = [f"/project/{project}/{self.typ}/{resource_name}/version/{version}"]
+        base = [f"/project/{project.name}/{self.typ}/{resource_name}/version/{version}"]
         if not for_head:
             # uri for head request contains no 'file'
             base.append("file")
@@ -190,7 +194,7 @@ class BundleCopy(CloudRequestMixed):
         return "/".join(base)
 
     def _do_upload_bundle_tar(self, progress: Progress) -> None:
-        file_path = self._get_versioned_resource_path(self.src_uri)
+        file_path = self._get_versioned_resource_path(self.src_resource)
         task_id = progress.add_task(
             f":bowling: upload {file_path.name}",
             total=file_path.stat().st_size,
@@ -199,10 +203,10 @@ class BundleCopy(CloudRequestMixed):
         self.do_multipart_upload_file(
             url_path=self._get_remote_bundle_api_url(),
             file_path=file_path,
-            instance_uri=self.dest_uri,
+            instance=self.dest_uri.instance,
             fields={
                 self.field_flag: self.field_value,
-                "project": self.dest_uri.project,
+                "project": self.dest_uri.project.name,
                 "force": "1" if self.force else "0",
             },
             use_raise=True,
@@ -218,10 +222,10 @@ class BundleCopy(CloudRequestMixed):
         self.do_download_file(
             url_path=self._get_remote_bundle_api_url(),
             dest_path=file_path,
-            instance_uri=self.src_uri,
+            instance=self.src_resource.instance,
             params={
                 self.field_flag: self.field_value,
-                "project": self.src_uri.project,
+                "project": self.src_resource.project.name,
             },
             progress=progress,
             task_id=task_id,
@@ -230,13 +234,15 @@ class BundleCopy(CloudRequestMixed):
     def do(self) -> None:
         remote_url = self._get_remote_bundle_console_url()
         if not self.force and self._check_version_existed(self.dest_uri):
-            console.print(f":tea: {remote_url} was already existed, skip copy")
+            console.print(f":tea: {self.dest_uri} was already existed, skip copy")
             return
 
-        if not self._check_version_existed(self.src_uri):
-            raise NotFoundError(str(self.src_uri))
+        if not self._check_version_existed(self.src_resource):
+            raise NotFoundError(str(self.src_resource))
 
-        console.print(f":construction: start to copy {self.src_uri} -> {self.dest_uri}")
+        console.print(
+            f":construction: start to copy {self.src_resource} -> {self.dest_uri}"
+        )
 
         with Progress(
             SpinnerColumn(),
@@ -249,7 +255,7 @@ class BundleCopy(CloudRequestMixed):
             console=console.rich_console,
             refresh_per_second=0.2,
         ) as progress:
-            if self.src_uri.instance_type == InstanceType.STANDALONE:
+            if self.src_resource.instance.is_local:
                 if self.typ == URIType.MODEL:
                     self._do_upload_bundle_dir(progress)
                 elif self.typ == URIType.RUNTIME:
@@ -268,16 +274,9 @@ class BundleCopy(CloudRequestMixed):
                         f"no support to copy {self.typ} from server to standalone"
                     )
 
-                _dest_uri = URI.capsulate_uri(
-                    instance=STANDALONE_INSTANCE,
-                    project=self.dest_uri.project,
-                    obj_type=self.typ,
-                    obj_name=self.dest_uri.object.name or self.bundle_name,
-                    obj_ver=self.bundle_version,
-                )
-                StandaloneTag(_dest_uri).add_fast_tag()
+                StandaloneTag(self.dest_uri).add_fast_tag()
                 self._update_manifest(
-                    self._get_versioned_resource_path(_dest_uri),
+                    self._get_versioned_resource_path(self.dest_uri),
                     {CREATED_AT_KEY: now_str()},
                 )
         console.print(f":tea: console url of the remote bundle: {remote_url}")
@@ -303,7 +302,7 @@ class BundleCopy(CloudRequestMixed):
                 # TODO: use /project/{self.typ}/pull api
                 url_path=self._get_remote_bundle_api_url(),
                 dest_path=fd.path,
-                instance_uri=self.src_uri,
+                instance=self.src_resource.instance,
                 params={
                     "desc": fd.file_desc.name,
                     "partName": fd.name,
@@ -355,7 +354,7 @@ class BundleCopy(CloudRequestMixed):
         r = self.do_multipart_upload_file(
             url_path=url_path,
             file_path=manifest_path,
-            instance_uri=self.dest_uri,
+            instance=self.dest_uri.instance,
             params={
                 self.field_flag: self.field_value,
                 "phase": _UploadPhase.MANIFEST,
@@ -389,7 +388,7 @@ class BundleCopy(CloudRequestMixed):
             self.do_multipart_upload_file(
                 url_path=url_path,
                 file_path=fd.path,
-                instance_uri=self.dest_uri,
+                instance=self.dest_uri.instance,
                 params={
                     self.field_flag: self.field_value,
                     "phase": _UploadPhase.BLOB,
@@ -432,7 +431,7 @@ class BundleCopy(CloudRequestMixed):
         self.do_http_request(
             path=url_path,
             method=HTTPMethod.POST,
-            instance_uri=self.dest_uri,
+            instance=self.dest_uri.instance,
             data={
                 self.field_flag: self.field_value,
                 "project": self.dest_uri.project,
@@ -448,7 +447,7 @@ class BundleCopy(CloudRequestMixed):
         progress: t.Optional[Progress] = None,
         workdir: t.Optional[Path] = None,
     ) -> None:
-        workdir = workdir or self._get_versioned_resource_path(self.src_uri)
+        workdir = workdir or self._get_versioned_resource_path(self.src_resource)
         url_path = self._get_remote_bundle_api_url()
 
         res_data = self._do_ubd_bundle_prepare(

--- a/client/starwhale/base/cloud.py
+++ b/client/starwhale/base/cloud.py
@@ -20,11 +20,13 @@ from starwhale.consts import (
     DEFAULT_PAGE_IDX,
     DEFAULT_PAGE_SIZE,
 )
-from starwhale.base.uri import URI
 from starwhale.utils.fs import ensure_dir
 from starwhale.utils.http import ignore_error, wrap_sw_error_resp
 from starwhale.utils.error import NoSupportError
 from starwhale.utils.retry import http_retry
+from starwhale.base.uricomponents.project import Project
+from starwhale.base.uricomponents.instance import Instance
+from starwhale.base.uricomponents.resource import Resource
 
 _TMP_FILE_BUFSIZE = 8192
 _DEFAULT_TIMEOUT_SECS = 90
@@ -42,14 +44,14 @@ class CloudRequestMixed:
         self,
         url_path: str,
         dest_path: Path,
-        instance_uri: URI,
+        instance: Instance,
         progress: t.Optional[Progress] = None,
         task_id: TaskID = TaskID(0),
         **kw: t.Any,
     ) -> None:
         r = self.do_http_request(
             path=url_path,
-            instance_uri=instance_uri,
+            instance=instance,
             method=HTTPMethod.GET,
             use_raise=True,
             **kw,
@@ -68,7 +70,7 @@ class CloudRequestMixed:
     def do_multipart_upload_file(
         self,
         url_path: str,
-        instance_uri: URI,
+        instance: Instance,
         file_path: t.Union[str, Path],
         fields: t.Optional[t.Dict[str, t.Any]] = None,
         headers: t.Optional[t.Dict[str, t.Any]] = None,
@@ -98,7 +100,7 @@ class CloudRequestMixed:
             _monitor = MultipartEncoderMonitor(_encoder, callback=_progress_bar)
             return self.do_http_request(  # type: ignore
                 url_path,
-                instance_uri=instance_uri,
+                instance=instance,
                 method=HTTPMethod.POST,
                 timeout=1200,
                 data=_monitor,
@@ -109,11 +111,11 @@ class CloudRequestMixed:
     def do_http_request_simple_ret(
         self,
         path: str,
-        instance_uri: URI,
+        instance: Instance,
         method: str = HTTPMethod.GET,
         **kw: t.Any,
     ) -> t.Tuple[bool, str]:
-        r = self.do_http_request(path, instance_uri, method, **kw)
+        r = self.do_http_request(path, instance, method, **kw)
         status = r.status_code == HTTPStatus.OK
 
         try:
@@ -127,16 +129,16 @@ class CloudRequestMixed:
     @http_retry
     def do_http_request(
         path: str,
-        instance_uri: URI,
+        instance: Instance,
         method: str = HTTPMethod.GET,
         timeout: int = _DEFAULT_TIMEOUT_SECS,
         headers: t.Optional[t.Dict[str, t.Any]] = None,
         disable_default_content_type: bool = False,
         **kw: t.Any,
     ) -> requests.Response:
-        _url = f"{instance_uri.instance}/api/{SW_API_VERSION}/{path.lstrip('/')}"
+        _url = f"{instance.url}/api/{SW_API_VERSION}/{path.lstrip('/')}"
         _headers = {
-            "Authorization": instance_uri.sw_token,
+            "Authorization": instance.token,
         }
         if not disable_default_content_type:
             _headers["Content-Type"] = "application/json"
@@ -172,47 +174,47 @@ class CloudRequestMixed:
             remain=_d["total"] - _d["size"],
         )
 
-    def _fetch_bundle_info(self, uri: URI, typ: str) -> t.Dict[str, t.Any]:
+    def _fetch_bundle_info(self, uri: Resource, typ: str) -> t.Dict[str, t.Any]:
         _manifest: t.Dict[str, t.Any] = {
-            "uri": uri.full_uri,
+            "uri": uri.to_uri().full_uri,
             "project": uri.project,
-            "name": uri.object.name,
+            "name": uri.name,
         }
 
-        if uri.object.version:
+        if uri.version:
             # TODO: add manifest, lock(runtime), model/dataset/runtime yaml info by controller api
-            _manifest["version"] = uri.object.version
+            _manifest["version"] = uri.version
             _info = self._fetch_bundle_version_info(uri, typ)
             _manifest[CREATED_AT_KEY] = self.fmt_timestamp(_info["createdTime"])
             _manifest["size"] = _info["files"][0]["size"]
         else:
             _manifest["history"] = self._fetch_bundle_history(
-                name=uri.object.name,
-                project_uri=uri,
+                name=uri.name,
+                project_uri=uri.project,
                 typ=typ,
             )[0]
         return _manifest
 
-    def _fetch_bundle_version_info(self, uri: URI, typ: str) -> t.Dict[str, t.Any]:
+    def _fetch_bundle_version_info(self, uri: Resource, typ: str) -> t.Dict[str, t.Any]:
         r = self.do_http_request(
-            f"/project/{uri.project}/{typ}/{uri.object.name}",
+            f"/project/{uri.project}/{typ}/{uri.name}",
             method=HTTPMethod.GET,
-            instance_uri=uri,
-            params={"versionName": uri.object.version},
+            instance=uri,
+            params={"versionName": uri.version},
         ).json()
         return r["data"]  # type: ignore
 
     def _fetch_bundle_history(
         self,
         name: str,
-        project_uri: URI,
+        project_uri: Project,
         typ: str,
         page: int = DEFAULT_PAGE_IDX,
         size: int = DEFAULT_PAGE_SIZE,
     ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
         r = self.do_http_request(
-            f"/project/{project_uri.project}/{typ}/{name}/version",
-            instance_uri=project_uri,
+            f"/project/{project_uri.name}/{typ}/{name}/version",
+            instance=project_uri.instance,
             method=HTTPMethod.GET,
             params={"pageNum": page, "pageSize": size},
         ).json()
@@ -235,7 +237,7 @@ class CloudRequestMixed:
 
     def _fetch_bundle_all_list(
         self,
-        project_uri: URI,
+        project_uri: Project,
         uri_typ: str,
         page: int = DEFAULT_PAGE_IDX,
         size: int = DEFAULT_PAGE_SIZE,
@@ -245,9 +247,9 @@ class CloudRequestMixed:
         _params = {"pageNum": page, "pageSize": size}
         _params.update(filter_dict)
         r = self.do_http_request(
-            f"/project/{project_uri.project}/{uri_typ}",
+            f"/project/{project_uri.name}/{uri_typ}",
             params=_params,
-            instance_uri=project_uri,
+            instance=project_uri.instance,
         ).json()
         objects = {}
 
@@ -295,18 +297,18 @@ class CloudRequestMixed:
 
 class CloudBundleModelMixin(CloudRequestMixed):
     def info(self) -> t.Dict[str, t.Any]:
-        uri: URI = self.uri  # type: ignore
-        return self._fetch_bundle_info(uri, uri.object.typ)
+        uri: Resource = self.uri  # type: ignore
+        return self._fetch_bundle_info(uri, uri.typ.value)
 
     @ignore_error(({}, {}))
     def history(
         self, page: int = DEFAULT_PAGE_IDX, size: int = DEFAULT_PAGE_SIZE
     ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
-        uri: URI = self.uri  # type: ignore
+        uri: Resource = self.uri  # type: ignore
         return self._fetch_bundle_history(
-            name=uri.object.name,
-            project_uri=uri,
-            typ=uri.object.typ,
+            name=uri.name,
+            project_uri=uri.project,
+            typ=uri.typ.value,
             page=page,
             size=size,
         )
@@ -314,21 +316,21 @@ class CloudBundleModelMixin(CloudRequestMixed):
     def remove(self, force: bool = False) -> t.Tuple[bool, str]:
         # TODO: remove specific version
         # TODO: add force flag
-        uri: URI = self.uri  # type: ignore
+        uri: Resource = self.uri  # type: ignore
         return self.do_http_request_simple_ret(
-            f"/project/{uri.project}/{uri.object.typ}/{uri.object.name}",
+            f"/project/{uri.project}/{uri.typ}/{uri.name}",
             method=HTTPMethod.DELETE,
-            instance_uri=uri,
+            instance=uri.instance,
         )
 
     def recover(self, force: bool = False) -> t.Tuple[bool, str]:
         # TODO: recover specific version
         # TODO: add force flag
-        uri: URI = self.uri  # type: ignore
+        uri: Resource = self.uri  # type: ignore
         return self.do_http_request_simple_ret(
-            f"/project/{uri.project}/{uri.object.typ}/{uri.object.name}/recover",
+            f"/project/{uri.project}/{uri.typ}/{uri.name}/recover",
             method=HTTPMethod.PUT,
-            instance_uri=uri,
+            instance=uri.instance,
         )
 
     def list_tags(self) -> t.List[str]:

--- a/client/starwhale/base/type.py
+++ b/client/starwhale/base/type.py
@@ -57,11 +57,12 @@ class RuntimeLockFileType:
 
 
 def get_bundle_type_by_uri(uri_type: str) -> str:
-    if uri_type == URIType.DATASET:
+    # TODO use constant
+    if uri_type == "dataset":
         return BundleType.DATASET
-    elif uri_type == URIType.MODEL:
+    elif uri_type == "model":
         return BundleType.MODEL
-    elif uri_type == URIType.RUNTIME:
+    elif uri_type == "runtime":
         return BundleType.RUNTIME
     else:
         raise NoSupportError(uri_type)

--- a/client/starwhale/base/uricomponents/project.py
+++ b/client/starwhale/base/uricomponents/project.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Optional
 from dataclasses import dataclass
 
 from starwhale.base.uri import URI
@@ -6,7 +6,7 @@ from starwhale.base.uricomponents.instance import Instance
 from starwhale.base.uricomponents.exceptions import UriTooShortException
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class Project:
     name: str
     instance: Instance
@@ -17,7 +17,6 @@ class Project:
         name: str = "",
         uri: Optional[str] = None,
         instance: Optional[Instance] = None,
-        **kwargs: Any,
     ) -> None:
         if name and uri:
             raise Exception("name and uri can not both set")
@@ -25,7 +24,7 @@ class Project:
         if "/" in name:
             uri = name
             name = ""
-        self.instance = instance or Instance(uri=uri or "", **kwargs)
+        self.instance = instance or Instance(uri=uri or "")
 
         if not name:
             # use project name in path, the path must at least contain project/{name}
@@ -76,3 +75,7 @@ class Project:
 
     def to_uri(self) -> URI:
         return URI.capsulate_uri(instance=str(self.instance), project=self.name)
+
+    @property
+    def full_uri(self) -> str:
+        return "/".join([self.instance.url, "project", self.name])

--- a/client/starwhale/base/uricomponents/resource.py
+++ b/client/starwhale/base/uricomponents/resource.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import requests
 
+from starwhale.utils import load_yaml
 from starwhale.consts import SW_API_VERSION
 from starwhale.base.uri import URI
 from starwhale.utils.config import load_swcli_config
@@ -17,13 +18,23 @@ from starwhale.base.uricomponents.exceptions import (
     UriTooShortException,
 )
 
-url_regex = re.compile(
+rc_url_regex = re.compile(
     r"(?P<scheme>https*)://"
     r"(?P<host>.*)/projects/"
     r"(?P<project>.+)/"
-    r"(?P<rc_type>models|datasets|runtimes|evaluations)"
+    r"(?P<rc_type>models|datasets|runtimes)"
     r"(/(?P<rc_id>.+)/versions)?"  # optional
     r"(/(?P<rc_version>.+)/.*)?",  # optional
+    re.UNICODE,
+)
+
+# TODO split job and resources
+job_url_regex = re.compile(
+    r"(?P<scheme>https*)://"
+    r"(?P<host>.*)/projects/"
+    r"(?P<project>.+)/"
+    r"(?P<rc_type>evaluations|jobs)"
+    r"(/(?P<rc_id>.+))?",
     re.UNICODE,
 )
 
@@ -33,9 +44,10 @@ class ResourceType(Enum):
     model = "model"
     dataset = "dataset"
     evaluation = "evaluation"
+    job = "job"
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class Resource:
     """
     Resource holds the DataSet, Model, Runtime, Eval etc.
@@ -43,14 +55,17 @@ class Resource:
 
     typ: ResourceType
     project: Project
-    name: Optional[str] = None
-    version: Optional[str] = None
+    name: str
+    version: str
 
     def __init__(
         self,
         uri: str,
         typ: Optional[ResourceType] = None,
         project: Optional[Project] = None,
+        token: Optional[str] = None,
+        _skip_refine: bool = False,  # for unit test and resource building or copy(without local dir generated)
+        **kwargs: Any,
     ) -> None:
         """
         :param uri: resource name or uri or version
@@ -68,16 +83,20 @@ class Resource:
         :return: Resource instance
         """
         self._remote_info: Dict[str, Any] = {}
+        self.name = ""  # job has no name, init with empty string
+        self.version = ""  # some resource has no version, init with empty string
 
         # check if it is url from console
-        m = url_regex.match(uri)
+        m = rc_url_regex.match(uri)
+        if m is None:
+            m = job_url_regex.match(uri)
         if m is not None:
             info: Dict[str, str] = m.groupdict()
-            ins = Instance(f'{info["scheme"]}://{info["host"]}')
+            ins = Instance(f'{info["scheme"]}://{info["host"]}', token=token)
             self.project = Project(name=info["project"], instance=ins)
             self.typ = ResourceType(info["rc_type"][:-1])  # remove the last 's'
-            self.name = info.get("rc_id")
-            self.version = info.get("rc_version")
+            self.name = info.get("rc_id") or ""
+            self.version = info.get("rc_version") or ""
             self.refine_remote_rc_info()
             return
 
@@ -109,8 +128,11 @@ class Resource:
         if (typ is not None) and self.typ != typ:
             raise Exception(f"type mismatch: {self.typ} vs {typ}")
 
-        if not self.project.instance.is_local:
-            self.refine_remote_rc_info()
+        if not _skip_refine:
+            if not self.project.instance.is_local:
+                self.refine_remote_rc_info()
+            else:
+                self.refine_local_rc_info()
 
     def _parse_with_type(self, typ: ResourceType, uri: str) -> None:
         """
@@ -133,6 +155,7 @@ class Resource:
                 self._parse_by_version(parts[0])
             except NoMatchException:
                 self.name = parts[0]
+                self.version = ""
         elif len(parts) == 2:
             if parts[0] != "version":
                 # name/version
@@ -160,10 +183,18 @@ class Resource:
             p = f"{root.absolute()}/*/*/*/{ver}*"
             m = glob(p)
             if len(m) == 1:
-                _, typ, self.name, _, self.version = m[0].rsplit("/", 4)
+                _, typ, self.name, _, version = m[0].rsplit("/", 4)
+                self.version = self.path_to_version(version)
                 self.typ = ResourceType[typ]
             else:
-                raise NoMatchException(ver, list(m))
+                # job list has no name
+                m = glob(f"{root.absolute()}/job/*/{ver}*")
+                if len(m) == 1:
+                    _, typ, _, version = m[0].rsplit("/", 3)
+                    self.version = self.path_to_version(version)
+                    self.typ = ResourceType[typ]
+                else:
+                    raise NoMatchException(ver, list(m))
         else:
             # TODO use api to check if it is a name or version
             # assume is is name for now
@@ -188,6 +219,43 @@ class Resource:
         self.name = self._remote_info.get("name", self.name)
         self.version = self._remote_info.get("versionName", self.version)
 
+    def refine_local_rc_info(self) -> None:
+        root = Path(load_swcli_config()["storage"]["root"]) / self.project.name
+        if self.version == "latest" or (
+            self.version.startswith("v") and self.version[1:].isnumeric()
+        ):
+            if not self.name:
+                raise Exception("name is required for latest version")
+            # get version from manifest
+            manifest = root / self.typ.name / self.name / "_manifest.yaml"
+            if not manifest.exists():
+                raise Exception(f"manifest file not found: {manifest}")
+            content = load_yaml(manifest)
+            self.version = content.get("tags", {}).get(self.version, "")
+            return
+
+        if self.typ == ResourceType.job:
+            p = f"{root.absolute()}/{self.typ.name}/*/{self.version}*"
+            m = glob(p)
+            if len(m) == 1:
+                _, _, _, version = m[0].rsplit("/", 3)
+                self.version = self.path_to_version(version)
+            else:
+                raise NoMatchException(self.version, list(m))
+        else:
+            # storage-root/project/type/name/prefix/full-version
+            p = f"{root.absolute()}/{self.typ.name}/*/*/{self.version}*"
+            m = glob(p)
+            if len(m) == 1:
+                _, _, self.name, _, version = m[0].rsplit("/", 4)
+                self.version = self.path_to_version(version)
+            else:
+                raise NoMatchException(self.version, list(m))
+
+    def path_to_version(self, path: str) -> str:
+        # foobarbaz.swrt -> foobarbaz
+        return path.split(".")[0]
+
     def info(self) -> Dict[str, Any]:
         # TODO: support local resource
         return self._remote_info or {}
@@ -205,7 +273,25 @@ class Resource:
             obj_ver=self.version or "latest",
         )
 
+    def asdict(self) -> Dict:
+        return {
+            "project": self.project.name,
+            "name": self.name,
+            "version": self.version,
+            "type": self.typ.name,
+        }
+
     def __str__(self) -> str:
-        return f"project: {self.project}, name: {self.name}, version: {self.version}"
+        return "/".join(
+            [
+                self.instance.url,
+                "project",
+                self.project.name,
+                self.typ.value,
+                self.name,
+                "version",
+                self.version,
+            ]
+        )
 
     __repr__ = __str__

--- a/client/starwhale/base/uricomponents/resource.py
+++ b/client/starwhale/base/uricomponents/resource.py
@@ -221,6 +221,8 @@ class Resource:
 
     def refine_local_rc_info(self) -> None:
         root = Path(load_swcli_config()["storage"]["root"]) / self.project.name
+        if self.version == "":
+            self.version = "latest"
         if self.version == "latest" or (
             self.version.startswith("v") and self.version[1:].isnumeric()
         ):

--- a/client/starwhale/base/view.py
+++ b/client/starwhale/base/view.py
@@ -25,10 +25,10 @@ from starwhale.consts import (
     STANDALONE_INSTANCE,
     ENV_BUILD_BUNDLE_FIXED_VERSION_FOR_TEST,
 )
-from starwhale.base.uri import URI
-from starwhale.base.type import URIType
 from starwhale.utils.error import FieldTypeOrValueError
 from starwhale.utils.config import SWCliConfigMixed
+from starwhale.base.uricomponents.project import Project
+from starwhale.base.uricomponents.resource import Resource, ResourceType
 
 if t.TYPE_CHECKING:
     from rich.console import RenderableType
@@ -134,9 +134,9 @@ class BaseTermView(SWCliConfigMixed):
     @staticmethod
     def prepare_build_bundle(
         project: str, bundle_name: str, typ: str, auto_gen_version: bool = True
-    ) -> URI:
+    ) -> Resource:
         console.print(f":construction: start to build {typ} bundle...")
-        _project_uri = URI(project, expected_type=URIType.PROJECT)
+        project_uri = Project(project)
         if not bundle_name:
             raise FieldTypeOrValueError("no bundle_name")
 
@@ -147,12 +147,11 @@ class BaseTermView(SWCliConfigMixed):
                 or gen_uniq_version()
             )
 
-        _uri = URI.capsulate_uri(
-            instance=_project_uri.instance,
-            project=_project_uri.project,
-            obj_type=typ,
-            obj_name=bundle_name,
-            obj_ver=obj_ver,
+        _uri = Resource(
+            f"{bundle_name}/version/{obj_ver}",
+            project=project_uri,
+            typ=ResourceType(typ),
+            _skip_refine=True,
         )
         console.print(f":construction_worker: uri {_uri}")
         return _uri
@@ -320,8 +319,8 @@ class BaseTermView(SWCliConfigMixed):
         return result
 
     @staticmethod
-    def must_have_project(uri: URI) -> None:
-        if uri.project:
+    def must_have_project(uri: Project) -> None:
+        if uri.name:
             return
         console.print(
             "Please specify the project uri with --project or set the default project for current instance"

--- a/client/starwhale/cli/__init__.py
+++ b/client/starwhale/cli/__init__.py
@@ -2,7 +2,6 @@ import time
 import random
 
 import click
-from rich.traceback import install
 
 from starwhale.version import STARWHALE_VERSION
 from starwhale.utils.cli import AliasedGroup
@@ -61,4 +60,3 @@ cli = create_sw_cli()
 
 if __name__ == "__main__":
     cli()
-    install(width=10)

--- a/client/starwhale/cli/__init__.py
+++ b/client/starwhale/cli/__init__.py
@@ -2,6 +2,7 @@ import time
 import random
 
 import click
+from rich.traceback import install
 
 from starwhale.version import STARWHALE_VERSION
 from starwhale.utils.cli import AliasedGroup
@@ -60,3 +61,4 @@ cli = create_sw_cli()
 
 if __name__ == "__main__":
     cli()
+    install(width=10)

--- a/client/starwhale/core/dataset/cli.py
+++ b/client/starwhale/core/dataset/cli.py
@@ -6,12 +6,12 @@ import click
 from click_option_group import optgroup, MutuallyExclusiveOptionGroup
 
 from starwhale.consts import DefaultYAMLName, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
-from starwhale.base.uri import URI
-from starwhale.base.type import URIType, DatasetChangeMode
+from starwhale.base.type import DatasetChangeMode
 from starwhale.utils.cli import AliasedGroup
 from starwhale.utils.load import import_object
 from starwhale.utils.error import NotFoundError
 from starwhale.core.dataset.type import DatasetAttr, DatasetConfig
+from starwhale.base.uricomponents.resource import Resource, ResourceType
 
 from .view import get_term_view, DatasetTermView
 
@@ -107,7 +107,7 @@ def _build(
 def _diff(
     view: t.Type[DatasetTermView], base_uri: str, compare_uri: str, show_details: bool
 ) -> None:
-    view(base_uri).diff(URI(compare_uri, expected_type=URIType.DATASET), show_details)
+    view(base_uri).diff(Resource(compare_uri, typ=ResourceType.dataset), show_details)
 
 
 @dataset_cmd.command("list", aliases=["ls"])
@@ -175,10 +175,7 @@ def _info(view: t.Type[DatasetTermView], dataset: str) -> None:
         swcli dataset info mnist/version/v0 # show the specified version of mnist dataset
         swcli -o json dataset info mnist # show the latest version of mnist dataset in json format
     """
-    uri = URI(dataset, expected_type=URIType.DATASET)
-    if not uri.object.version:
-        uri.object.version = "latest"
-
+    uri = Resource(dataset, typ=ResourceType.dataset)
     view(uri).info()
 
 
@@ -230,10 +227,7 @@ def _history(
 @click.argument("dataset")
 @click.pass_obj
 def _summary(view: t.Type[DatasetTermView], dataset: str) -> None:
-    uri = URI(dataset, expected_type=URIType.DATASET)
-    if not uri.object.version:
-        uri.object.version = "latest"
-
+    uri = Resource(dataset, typ=ResourceType.dataset)
     view(uri).summary()
 
 

--- a/client/starwhale/core/dataset/copy.py
+++ b/client/starwhale/core/dataset/copy.py
@@ -28,12 +28,13 @@ from starwhale.consts import (
     DEFAULT_MANIFEST_NAME,
 )
 from starwhale.base.tag import StandaloneTag
-from starwhale.base.uri import URI, URIType
+from starwhale.base.uri import URIType
 from starwhale.utils.fs import ensure_file
-from starwhale.base.type import InstanceType, DatasetChangeMode
+from starwhale.base.type import DatasetChangeMode
 from starwhale.utils.error import NotFoundError
 from starwhale.base.bundle_copy import BundleCopy, _UploadPhase
 from starwhale.core.dataset.store import DatasetStorage
+from starwhale.base.uricomponents.resource import Resource
 
 from .tabular import TabularDataset, DatastoreRevision
 
@@ -42,37 +43,47 @@ _LOCAL_STORAGE_SCHEMES = ("", "file")
 
 
 class DatasetCopy(BundleCopy):
-    def __init__(self, src_uri: str, dest_uri: str, **kw: t.Any) -> None:
-        super().__init__(src_uri, dest_uri, typ=URIType.DATASET, **kw)
+    def __init__(self, src_uri: Resource, dest_uri: str, **kw: t.Any) -> None:
+        super().__init__(
+            src_uri,
+            dest_uri,
+            typ=URIType.DATASET,
+            **kw,
+        )
         self._max_workers = int(os.environ.get("SW_BUNDLE_COPY_THREAD_NUM", "5"))
         self._copy_mode = kw.get("mode", DatasetChangeMode.PATCH)
 
-    def _check_dataset_existed(self, uri: URI) -> bool:
-        dataset_name = uri.object.name or self.bundle_name
-        if uri.instance_type == InstanceType.CLOUD:
+    def _check_dataset_existed(self, uri: Resource) -> bool:
+        dataset_name = uri.name
+        if uri.instance.is_cloud:
+            # TODO simplify remote resource request without join uri manually
             ok, _ = self.do_http_request_simple_ret(
-                path=f"/project/{uri.project}/dataset/{dataset_name}",
+                path=f"/project/{uri.project.name}/dataset/{dataset_name}",
                 method=HTTPMethod.HEAD,
-                instance_uri=uri,
+                instance=uri.instance,
                 ignore_status_codes=[HTTPStatus.NOT_FOUND],
             )
             return ok
         else:
             dataset_dir = (
-                self._sw_config.rootdir / uri.project / "dataset" / dataset_name
+                self._sw_config.rootdir / uri.project.name / "dataset" / dataset_name
             )
             return (dataset_dir / DEFAULT_MANIFEST_NAME).exists()
 
     def do(self) -> None:
-        if not self.force and self._check_version_existed(self.dest_uri):
+        if (
+            not self.force
+            and self.dest_uri.version
+            and self._check_version_existed(self.dest_uri)
+        ):
             console.print(f":tea: {self.dest_uri} was already existed, skip copy")
             return
 
-        if not self._check_version_existed(self.src_uri):
-            raise NotFoundError(f"src dataset not found: {self.src_uri}")
+        if not self._check_version_existed(self.src_resource):
+            raise NotFoundError(f"src dataset not found: {self.src_resource}")
 
         console.print(
-            f":construction: start to copy[{self._copy_mode.value}] {self.src_uri} -> {self.dest_uri}"
+            f":construction: start to copy[{self._copy_mode.value}] {self.src_resource} -> {self.dest_uri}"
         )
 
         with Progress(
@@ -87,15 +98,15 @@ class DatasetCopy(BundleCopy):
             refresh_per_second=0.2,
         ) as progress:
             src = TabularDataset(
-                name=self.src_uri.object.name,
-                project=self.src_uri.project,
-                instance_name=self.src_uri.instance,
+                name=self.src_resource.name,
+                project=self.src_resource.project.name,
+                instance_name=self.src_resource.instance.url,
             )
 
             dest = TabularDataset(
-                name=self.dest_uri.object.name or self.src_uri.object.name,
-                project=self.dest_uri.project,
-                instance_name=self.dest_uri.instance,
+                name=self.dest_uri.name or self.src_resource.name,
+                project=self.dest_uri.project.name,
+                instance_name=self.dest_uri.instance.url,
             )
             try:
                 self._do_dataset_copy(src=src, dest=dest, progress=progress)
@@ -170,9 +181,9 @@ class DatasetCopy(BundleCopy):
         self, dataset_revision: str, info_revision: str
     ) -> None:
         r = self.do_http_request(
-            path=f"/project/{self.src_uri.project}/dataset/{self.src_uri.object.name}",
-            instance_uri=self.src_uri,
-            params={"versionUrl": self.src_uri.object.version},
+            path=f"/project/{self.src_resource.project.name}/dataset/{self.src_resource.name}",
+            instance=self.src_resource.instance,
+            params={"versionUrl": self.src_resource.version},
         ).json()
 
         manifest = yaml.safe_load(r["data"]["versionMeta"])
@@ -181,29 +192,23 @@ class DatasetCopy(BundleCopy):
             DatastoreRevision(data=dataset_revision, info=info_revision).asdict()
         )
 
-        _dest_uri = URI.capsulate_uri(
-            instance=STANDALONE_INSTANCE,
-            project=self.dest_uri.project,
-            obj_type=self.typ,
-            obj_name=self.dest_uri.object.name or self.bundle_name,
-            obj_ver=self.bundle_version,
-        )
-        snapshot_dir = self._get_versioned_resource_path(_dest_uri)
+        uri = self.dest_uri
+        snapshot_dir = self._get_versioned_resource_path(uri)
         ensure_file(
             snapshot_dir / DEFAULT_MANIFEST_NAME, yaml.safe_dump(manifest), parents=True
         )
 
-        StandaloneTag(_dest_uri).add_fast_tag()
+        StandaloneTag(uri).add_fast_tag()
 
     def _make_cloud_version(self, dataset_revision: str, info_revision: str) -> None:
-        dataset_name = self.dest_uri.object.name or self.src_uri.object.name
+        dataset_name = self.dest_uri.name or self.src_resource.name
         params = {
-            "swds": f"{dataset_name}:{self.bundle_name}",
+            "swds": f"{dataset_name}:{self.src_resource.name}",
             "project": self.dest_uri.project,
             "force": "1",  # use force=1 to make http retry happy, we check dataset existence in advance
         }
         url_path = self._get_remote_bundle_api_url()
-        snapshot_dir = self._get_versioned_resource_path(self.src_uri)
+        snapshot_dir = self._get_versioned_resource_path(self.src_resource)
         manifest = load_yaml(snapshot_dir / DEFAULT_MANIFEST_NAME)
         manifest[CREATED_AT_KEY] = now_str()
         manifest.update(
@@ -217,7 +222,7 @@ class DatasetCopy(BundleCopy):
             r = self.do_multipart_upload_file(
                 url_path=url_path,
                 file_path=tmp_path,
-                instance_uri=self.dest_uri,
+                instance=self.dest_uri.instance,
                 params={
                     "phase": _UploadPhase.MANIFEST,
                     "desc": FileDesc.MANIFEST.name,
@@ -228,7 +233,7 @@ class DatasetCopy(BundleCopy):
             self.do_http_request(
                 path=url_path,
                 method=HTTPMethod.POST,
-                instance_uri=self.dest_uri,
+                instance=self.dest_uri.instance,
                 data={
                     "phase": _UploadPhase.END,
                     "uploadId": r.json()["data"]["uploadId"],
@@ -276,9 +281,9 @@ class DatasetCopy(BundleCopy):
         local_blob_path = DatasetStorage._get_object_store_path(hash_name)
         if not local_blob_path.exists():
             self.do_download_file(
-                url_path=f"/project/{self.src_uri.project}/dataset/{self.src_uri.object.name}/blob",
+                url_path=f"/project/{self.src_resource.project.name}/dataset/{self.src_resource.name}/blob",
                 dest_path=local_blob_path,
-                instance_uri=self.src_uri,
+                instance=self.src_resource.instance,
                 progress=progress,
                 task_id=task_id,
             )
@@ -291,7 +296,7 @@ class DatasetCopy(BundleCopy):
         self, progress: Progress, local_hashed_uri: str
     ) -> t.Tuple[str, str]:
         local_blob_path = DatasetStorage._get_object_store_path(local_hashed_uri)
-        url_path = f"/project/{self.dest_uri.project}/dataset/{self.bundle_name}/hashedBlob/{local_hashed_uri}"
+        url_path = f"/project/{self.dest_uri.project.name}/dataset/{self.src_resource.name}/hashedBlob/{local_hashed_uri}"
         blob_size = local_blob_path.stat().st_size
 
         task_id = progress.add_task(
@@ -302,7 +307,7 @@ class DatasetCopy(BundleCopy):
 
         r = self.do_http_request(
             path=url_path,
-            instance_uri=self.dest_uri,
+            instance=self.dest_uri.instance,
             method=HTTPMethod.HEAD,
             ignore_status_codes=[HTTPStatus.NOT_FOUND],
         )
@@ -313,7 +318,7 @@ class DatasetCopy(BundleCopy):
         remote_uri = self.do_multipart_upload_file(
             url_path=url_path,
             file_path=local_blob_path,
-            instance_uri=self.dest_uri,
+            instance=self.dest_uri.instance,
             use_raise=True,
             progress=progress,
             task_id=task_id,

--- a/client/starwhale/core/dataset/type.py
+++ b/client/starwhale/core/dataset/type.py
@@ -15,7 +15,6 @@ import numpy
 
 from starwhale.utils import load_yaml, convert_to_bytes, validate_obj_name
 from starwhale.consts import SHORT_VERSION_CNT, DEFAULT_STARWHALE_API_VERSION
-from starwhale.base.uri import URI
 from starwhale.utils.fs import FilePosition
 from starwhale.base.mixin import ASDictMixin
 from starwhale.utils.error import (
@@ -25,6 +24,7 @@ from starwhale.utils.error import (
 )
 from starwhale.utils.retry import http_retry
 from starwhale.api._impl.data_store import SwObject, _TYPE_DICT
+from starwhale.base.uricomponents.resource import Resource
 
 D_FILE_VOLUME_SIZE = 64 * 1024 * 1024  # 64MB
 D_ALIGNMENT_SIZE = 128  # for page cache
@@ -218,7 +218,7 @@ class BaseArtifact(ASDictMixin, metaclass=ABCMeta):
         self.encoding = encoding
         self.link = link
         self._do_validate()
-        self.owner: t.Optional[t.Union[str, URI]] = None
+        self.owner: t.Optional[Resource] = None
 
     def _do_validate(self) -> None:
         ...
@@ -818,11 +818,11 @@ class Link(ASDictMixin, SwObject):
         size: int = -1,
         data_type: t.Optional[t.Union[BaseArtifact, t.Dict]] = None,
         use_plain_type: bool = False,
-        owner: t.Optional[t.Union[str, URI]] = None,
+        owner: t.Optional[Resource] = None,
         **kwargs: t.Any,
     ) -> None:
         self._type = "link"
-        self.owner = owner.raw if (owner and isinstance(owner, URI)) else owner
+        self.owner = owner
         self.uri = str(uri).strip()
         _up = urlparse(self.uri)
         self.scheme = _up.scheme
@@ -941,11 +941,11 @@ class DatasetConfig(ASDictMixin):
         self,
         name: str = "",
         handler: t.Any = "",
-        pkg_data: t.List[str] = [],
-        exclude_pkg_data: t.List[str] = [],
+        pkg_data: t.List[str] | None = None,
+        exclude_pkg_data: t.List[str] | None = None,
         desc: str = "",
         version: str = DEFAULT_STARWHALE_API_VERSION,
-        attr: t.Dict[str, t.Any] = {},
+        attr: t.Dict[str, t.Any] | None = None,
         project_uri: str = "",
         runtime_uri: str = "",
         **kw: t.Any,
@@ -954,9 +954,9 @@ class DatasetConfig(ASDictMixin):
         self.handler = handler
         self.desc = desc
         self.version = version
-        self.attr = DatasetAttr(**attr)
-        self.pkg_data = pkg_data
-        self.exclude_pkg_data = exclude_pkg_data
+        self.attr = DatasetAttr(**(attr or {}))
+        self.pkg_data = pkg_data or []
+        self.exclude_pkg_data = exclude_pkg_data or []
         self.project_uri = project_uri
         self.runtime_uri = runtime_uri
 

--- a/client/starwhale/core/instance/model.py
+++ b/client/starwhale/core/instance/model.py
@@ -24,7 +24,7 @@ class CloudInstance(Instance, CloudRequestMixed):
 
     @ignore_error("--")
     def _fetch_version(self) -> str:
-        return self.do_http_request("/system/version", instance_uri=self.uri).json()[  # type: ignore
+        return self.do_http_request("/system/version", instance=self.uri.instance).json()[  # type: ignore
             "data"
         ][
             "version"
@@ -36,10 +36,12 @@ class CloudInstance(Instance, CloudRequestMixed):
         return self.do_http_request(  # type: ignore
             "/system/agent",
             params={"pageSize": DEFAULT_PAGE_SIZE, "pageNum": DEFAULT_PAGE_IDX},
-            instance_uri=self.uri,
+            instance=self.uri.instance,
         ).json()["data"]["list"]
 
     @ignore_error({})
     def _fetch_current_user(self) -> t.Dict[str, t.Any]:
-        r = self.do_http_request("/user/current", instance_uri=self.uri).json()["data"]
+        r = self.do_http_request("/user/current", instance=self.uri.instance).json()[
+            "data"
+        ]
         return dict(name=r["name"], role=r["role"]["roleName"])

--- a/client/starwhale/core/job/store.py
+++ b/client/starwhale/core/job/store.py
@@ -2,11 +2,11 @@ import typing as t
 from pathlib import Path
 
 from starwhale.consts import RECOVER_DIRNAME, VERSION_PREFIX_CNT, DEFAULT_MANIFEST_NAME
-from starwhale.base.uri import URI
 from starwhale.utils.fs import guess_real_path
 from starwhale.base.type import URIType
 from starwhale.base.store import BaseStorage
 from starwhale.utils.config import SWCliConfigMixed
+from starwhale.base.uricomponents.project import Project
 
 
 class JobStorage(BaseStorage):
@@ -21,7 +21,7 @@ class JobStorage(BaseStorage):
         )
 
     def _guess(self) -> t.Tuple[Path, str]:
-        name = self.uri.object.name
+        name = self.uri.version
         _p, _v, _ok = guess_real_path(
             self.project_dir / URIType.JOB / name[:VERSION_PREFIX_CNT], name
         )
@@ -36,9 +36,11 @@ class JobStorage(BaseStorage):
         return self.loc / DEFAULT_MANIFEST_NAME
 
     @staticmethod
-    def iter_all_jobs(project_uri: URI) -> t.Generator[t.Tuple[Path, bool], None, None]:
+    def iter_all_jobs(
+        project_uri: Project,
+    ) -> t.Generator[t.Tuple[Path, bool], None, None]:
         sw = SWCliConfigMixed()
-        _job_dir = sw.rootdir / project_uri.project / URIType.JOB
+        _job_dir = sw.rootdir / project_uri.name / URIType.JOB
         for _path in _job_dir.glob(f"**/**/{DEFAULT_MANIFEST_NAME}"):
             yield _path, RECOVER_DIRNAME in _path.parts
 

--- a/client/starwhale/core/job/view.py
+++ b/client/starwhale/core/job/view.py
@@ -16,11 +16,12 @@ from starwhale.consts import (
     DEFAULT_REPORT_COLS,
     DEFAULT_MANIFEST_NAME,
 )
-from starwhale.base.uri import URI
-from starwhale.base.type import URIType, JobOperationType
+from starwhale.base.type import JobOperationType
 from starwhale.base.view import BaseTermView
 from starwhale.api._impl.metric import MetricKind
+from starwhale.base.uricomponents.project import Project
 from starwhale.base.uricomponents.instance import Instance
+from starwhale.base.uricomponents.resource import Resource, ResourceType
 
 from .model import Job
 
@@ -29,7 +30,7 @@ class JobTermView(BaseTermView):
     def __init__(self, job_uri: str) -> None:
         super().__init__()
         self.raw_uri = job_uri
-        self.uri = URI(job_uri, expected_type=URIType.JOB)
+        self.uri = Resource(job_uri, typ=ResourceType.job)
         self.job = Job.get_job(self.uri)
         self._action_run_map = {
             JobOperationType.CANCEL: self.job.cancel,
@@ -233,7 +234,7 @@ class JobTermView(BaseTermView):
         page: int = DEFAULT_PAGE_IDX,
         size: int = DEFAULT_PAGE_SIZE,
     ) -> t.Tuple[t.List[t.Any], t.Dict[str, t.Any]]:
-        _uri = URI(project_uri, expected_type=URIType.PROJECT)
+        _uri = Project(project_uri)
         cls.must_have_project(_uri)
         jobs, pager = Job.list(_uri, page, size)
         jobs = sort_obj_list(jobs, [Order("manifest.created_at", True)])

--- a/client/starwhale/core/model/store.py
+++ b/client/starwhale/core/model/store.py
@@ -75,11 +75,11 @@ class ModelStorage(BaseStorage):
     def snapshot_workdir(self) -> Path:
         if self.building:
             return self.tmp_dir
-        version = self.uri.object.version
+        version = self.uri.version
         return (
             self.project_dir
             / URIType.MODEL
-            / self.uri.object.name
+            / self.uri.name
             / version[:VERSION_PREFIX_CNT]
             / f"{version}{BundleType.MODEL}"
         )

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -22,26 +22,27 @@ from starwhale.consts import (
 )
 from starwhale.base.uri import URI
 from starwhale.utils.fs import cmp_file_content
-from starwhale.base.type import URIType, InstanceType
+from starwhale.base.type import URIType
 from starwhale.base.view import BaseTermView
 from starwhale.consts.env import SWEnv
 from starwhale.utils.error import NoSupportError, FieldTypeOrValueError
 from starwhale.core.model.store import ModelStorage
 from starwhale.core.runtime.model import StandaloneRuntime
 from starwhale.core.runtime.process import Process as RuntimeProcess
+from starwhale.base.uricomponents.project import Project
+from starwhale.base.uricomponents.resource import Resource, ResourceType
 
 from .model import Model, CloudModel, ModelConfig, ModelInfoFilter, StandaloneModel
 
 
 class ModelTermView(BaseTermView):
-    def __init__(self, model_uri: str | URI) -> None:
+    def __init__(self, model_uri: str | Resource) -> None:
         super().__init__()
 
-        if isinstance(model_uri, URI):
+        if isinstance(model_uri, Resource):
             self.uri = model_uri
         else:
-            self.uri = URI(model_uri, expected_type=URIType.MODEL)
-
+            self.uri = Resource(model_uri, ResourceType.model)
         self.model = Model.get_model(self.uri)
 
     @BaseTermView._simple_action_print
@@ -129,7 +130,7 @@ class ModelTermView(BaseTermView):
             console.print(handlers_content)
 
     @BaseTermView._only_standalone
-    def diff(self, compare_uri: URI, show_details: bool) -> None:
+    def diff(self, compare_uri: Resource, show_details: bool) -> None:
         r = self.model.diff(compare_uri)
         text_details: t.List[Panel] = []
         table = Table(box=box.SIMPLE, expand=False, show_lines=True)
@@ -141,7 +142,7 @@ class ModelTermView(BaseTermView):
             justify="left",
         )
         table.add_column(
-            f"compare: {compare_uri.object.version[:SHORT_VERSION_CNT]}",
+            f"compare: {compare_uri.version[:SHORT_VERSION_CNT]}",
             style="cyan",
             justify="left",
         )
@@ -185,7 +186,7 @@ class ModelTermView(BaseTermView):
     @BaseTermView._pager
     @BaseTermView._header
     def history(self, fullname: bool = False) -> t.List[t.Dict[str, t.Any]]:
-        fullname = fullname or self.uri.instance_type == InstanceType.CLOUD
+        fullname = fullname or self.uri.instance.is_cloud
         return self._print_history(
             title="Model History List", history=self.model.history(), fullname=fullname
         )
@@ -193,7 +194,7 @@ class ModelTermView(BaseTermView):
     @classmethod
     def run_in_server(
         cls,
-        project_uri: URI,
+        project_uri: Project,
         model_uri: str,
         dataset_uris: t.List[str],
         runtime_uri: str,
@@ -211,7 +212,7 @@ class ModelTermView(BaseTermView):
         if ok:
             console.print(":clap: success to create job")
             console.print(
-                f":bird: visit web: {project_uri.instance}/projects/{project_uri.project}/evaluations/{version_or_reason}"
+                f":bird: visit web: {project_uri.instance.url}/projects/{project_uri.name}/evaluations/{version_or_reason}"
             )
             console.print(
                 f":monkey: run command: [bold green]swcli job info {project_uri.full_uri}/job/{version_or_reason} [/]"
@@ -231,7 +232,7 @@ class ModelTermView(BaseTermView):
         version: str = "",
         run_handler: str = "",
         dataset_uris: t.Optional[t.List[str]] = None,
-        runtime_uri: t.Optional[URI] = None,
+        runtime_uri: t.Optional[Resource] = None,
         scheduler_run_args: t.Optional[t.Dict] = None,
         forbid_snapshot: bool = False,
         cleanup_snapshot: bool = True,
@@ -256,7 +257,7 @@ class ModelTermView(BaseTermView):
     def run_in_container(
         cls,
         model_src_dir: Path,
-        runtime_uri: t.Optional[URI] = None,
+        runtime_uri: t.Optional[Resource] = None,
         docker_image: str = "",
     ) -> None:
         # TODO: support to get job version for in container
@@ -264,10 +265,10 @@ class ModelTermView(BaseTermView):
             raise FieldTypeOrValueError("runtime_uri and docker_image both are none")
 
         if runtime_uri:
-            if runtime_uri.object.typ == URIType.RUNTIME:
+            if runtime_uri.typ == ResourceType.runtime:
                 runtime = StandaloneRuntime(runtime_uri)
                 docker_image = runtime.store.get_docker_base_image()
-            elif runtime_uri.object.typ == URIType.MODEL:
+            elif runtime_uri.typ == ResourceType.model:
                 model = StandaloneModel(runtime_uri)
                 docker_image = model.store.get_packaged_runtime_base_image()
             else:
@@ -289,7 +290,7 @@ class ModelTermView(BaseTermView):
         if in_production() or (os.path.exists(target) and os.path.isdir(target)):
             workdir = Path(target)
         else:
-            _uri = URI(target, URIType.MODEL)
+            _uri = Resource(target, ResourceType.model)
             _store = ModelStorage(_uri)
             workdir = _store.src_dir
         return workdir
@@ -305,9 +306,9 @@ class ModelTermView(BaseTermView):
         filters: t.Optional[t.Union[t.Dict[str, t.Any], t.List[str]]] = None,
     ) -> t.Tuple[t.List[t.Dict[str, t.Any]], t.Dict[str, t.Any]]:
         filters = filters or {}
-        _uri = URI(project_uri, expected_type=URIType.PROJECT)
+        _uri = Project(project_uri)
         cls.must_have_project(_uri)
-        fullname = fullname or (_uri.instance_type == InstanceType.CLOUD)
+        fullname = fullname or _uri.instance.is_cloud
         _models, _pager = Model.list(_uri, page, size, filters)
         _data = BaseTermView.list_data(_models, show_removed, fullname)
         return _data, _pager
@@ -323,7 +324,7 @@ class ModelTermView(BaseTermView):
         package_runtime: bool = False,
     ) -> None:
         if runtime_uri:
-            RuntimeProcess(uri=runtime_uri).run()
+            RuntimeProcess(uri=Resource(runtime_uri, typ=ResourceType.runtime)).run()
         else:
             model_uri = cls.prepare_build_bundle(
                 project=project,
@@ -353,7 +354,8 @@ class ModelTermView(BaseTermView):
         force: bool = False,
         dest_local_project_uri: str = "",
     ) -> None:
-        Model.copy(src_uri, dest_uri, force, dest_local_project_uri)
+        src = Resource(src_uri, typ=ResourceType.model)
+        Model.copy(src, dest_uri, force, dest_local_project_uri)
         console.print(":clap: copy done.")
 
     @BaseTermView._header
@@ -373,7 +375,7 @@ class ModelTermView(BaseTermView):
         cls,
         model_src_dir: Path,
         model_config: ModelConfig,
-        runtime_uri: URI,
+        runtime_uri: Resource,
         host: str,
         port: int,
     ) -> None:
@@ -446,7 +448,7 @@ class ModelTermViewJson(ModelTermView):
         self.pretty_json(info)
 
     def history(self, fullname: bool = False) -> None:
-        fullname = fullname or self.uri.instance_type == InstanceType.CLOUD
+        fullname = fullname or self.uri.instance.is_cloud
         self.pretty_json(BaseTermView.get_history_data(self.model.history(), fullname))
 
 

--- a/client/starwhale/core/project/view.py
+++ b/client/starwhale/core/project/view.py
@@ -15,6 +15,7 @@ from starwhale.consts import (
 from starwhale.base.uri import URI
 from starwhale.base.type import URIType
 from starwhale.base.view import BaseTermView
+from starwhale.base.uricomponents.project import Project as ProjectURI
 
 from .model import Project, ProjectObjType
 
@@ -23,7 +24,7 @@ class ProjectTermView(BaseTermView):
     def __init__(self, project_uri: str = "") -> None:
         super().__init__()
         self.raw_uri = project_uri
-        self.uri = URI(project_uri, expected_type=URIType.PROJECT)
+        self.uri = ProjectURI(project_uri)
         self.project = Project.get_project(self.uri)
 
     @BaseTermView._simple_action_print
@@ -65,8 +66,8 @@ class ProjectTermView(BaseTermView):
     def select(self) -> None:
         try:
             self.select_current_default(
-                instance=self.uri.instance_alias or self.uri.instance,
-                project=self.uri.project,
+                instance=self.uri.instance.alias,
+                project=self.uri.name,
             )
         except Exception as e:
             console.print(

--- a/client/starwhale/core/runtime/cli.py
+++ b/client/starwhale/core/runtime/cli.py
@@ -11,10 +11,10 @@ from starwhale.consts import (
     DEFAULT_PAGE_IDX,
     DEFAULT_PAGE_SIZE,
 )
-from starwhale.base.uri import URI
-from starwhale.base.type import URIType, RuntimeLockFileType
+from starwhale.base.type import RuntimeLockFileType
 from starwhale.utils.cli import AliasedGroup
 from starwhale.core.runtime.model import _SUPPORT_CUDA, _SUPPORT_CUDNN
+from starwhale.base.uricomponents.resource import Resource, ResourceType
 
 from .view import get_term_view, RuntimeTermView
 from .model import RuntimeInfoFilter
@@ -66,7 +66,7 @@ def _quickstart_from_uri(
     """
     p_workdir = Path(workdir).absolute()
     name = name or p_workdir.name
-    _uri = URI(uri, expected_type=URIType.RUNTIME)
+    _uri = Resource(uri, typ=ResourceType.runtime)
     RuntimeTermView.quickstart_from_uri(
         workdir=p_workdir,
         name=name,
@@ -425,10 +425,7 @@ def _info(
           swcli runtime info pytorch/version/v1 -of manifest # show _manifest.yaml content
           swcli runtime info pytorch/version/v1 -of all # show all info of the runtime
     """
-    uri = URI(runtime, expected_type=URIType.RUNTIME)
-    if not uri.object.version:
-        uri.object.version = "latest"
-
+    uri = Resource(runtime, ResourceType.runtime)
     view(uri).info(RuntimeInfoFilter(output_filter))
 
 
@@ -602,7 +599,7 @@ def _activate(uri: str, force_restore: bool) -> None:
 
     URI: Runtime uri in the standalone instance
     """
-    _uri = URI(uri, expected_type=URIType.RUNTIME)
+    _uri = Resource(uri, typ=ResourceType.runtime)
     RuntimeTermView.activate(_uri, force_restore)
 
 

--- a/client/starwhale/core/runtime/store.py
+++ b/client/starwhale/core/runtime/store.py
@@ -32,7 +32,7 @@ class RuntimeStorage(BaseStorage):
 
     @property
     def runtime_dir(self) -> Path:
-        return self.project_dir / URIType.RUNTIME / self.uri.object.name
+        return self.project_dir / URIType.RUNTIME / self.uri.name
 
     @property
     def manifest_path(self) -> Path:

--- a/client/tests/base/test_cloud.py
+++ b/client/tests/base/test_cloud.py
@@ -5,10 +5,10 @@ from requests_mock import Mocker
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from starwhale.consts import HTTPMethod
-from starwhale.base.uri import URI
 from starwhale.base.type import URIType
 from starwhale.base.cloud import CloudRequestMixed, CloudBundleModelMixin
 from starwhale.utils.config import SWCliConfigMixed
+from starwhale.base.uricomponents.project import Project
 
 
 class TestCloudRequestMixed(TestCase):
@@ -119,7 +119,7 @@ class TestCloudRequestMixed(TestCase):
         )
 
         cbm = CloudBundleModelMixin()
-        _uri = URI("http://1.1.1.1/project/sw", expected_type=URIType.PROJECT)
+        _uri = Project("http://1.1.1.1/project/sw")
         _models, _pager = cbm._fetch_bundle_all_list(_uri, uri_typ=URIType.MODEL)
 
         assert len(_models.items()) == 2
@@ -129,7 +129,7 @@ class TestCloudRequestMixed(TestCase):
         assert _pager["remain"] == 0
 
         cbm = CloudBundleModelMixin()
-        _uri = URI("http://1.1.1.1/project/sw", expected_type=URIType.PROJECT)
+        _uri = Project("http://1.1.1.1/project/sw")
         _models, _pager = cbm._fetch_bundle_all_list(
             _uri, uri_typ=URIType.MODEL, filter_dict={"name": "mnist"}
         )
@@ -140,7 +140,7 @@ class TestCloudRequestMixed(TestCase):
         assert _pager["remain"] == 0
 
         cbm = CloudBundleModelMixin()
-        _uri = URI("http://1.1.1.1/project/sw", expected_type=URIType.PROJECT)
+        _uri = Project("http://1.1.1.1/project/sw")
         _models, _pager = cbm._fetch_bundle_all_list(
             _uri, uri_typ=URIType.MODEL, filter_dict={"name": "mnist", "latest": True}
         )

--- a/client/tests/base/uricomponents/test_resource.py
+++ b/client/tests/base/uricomponents/test_resource.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from dataclasses import dataclass
 from unittest.mock import Mock, patch, MagicMock
 
@@ -26,34 +25,48 @@ class TestResource(TestCase):
         p.instance = MockLocalInstance()
         p.name = "self"
         p.path = ""
-        r = Resource(uri="mnist", typ=ResourceType.dataset, project=p)
+        r = Resource(
+            uri="mnist", typ=ResourceType.dataset, project=p, _skip_refine=True
+        )
         assert r.name == "mnist"
         assert r.typ == ResourceType.dataset
-        assert r.version is None
+        assert r.version == ""
         assert r.to_uri().raw == "local/project/self/dataset/mnist/version/latest"
 
         # {name}/version/{ver}
-        r = Resource(uri="mnist/version/foo", typ=ResourceType.dataset, project=p)
+        r = Resource(
+            uri="mnist/version/foo",
+            typ=ResourceType.dataset,
+            project=p,
+            _skip_refine=True,
+        )
         assert r.name == "mnist"
         assert r.typ == ResourceType.dataset
         assert r.version == "foo"
         assert r.to_uri().raw == "local/project/self/dataset/mnist/version/foo"
 
-        r = Resource(uri="foo/bar", typ=ResourceType.dataset, project=p)
+        r = Resource(
+            uri="foo/bar", typ=ResourceType.dataset, project=p, _skip_refine=True
+        )
         assert r.name == "foo"
         assert r.typ == ResourceType.dataset
         assert r.version == "bar"
         assert r.to_uri().raw == "local/project/self/dataset/foo/version/bar"
 
         with self.assertRaises(Exception):
-            Resource(uri="mnist/foo/bar", typ=ResourceType.dataset, project=p)
+            Resource(
+                uri="mnist/foo/bar",
+                typ=ResourceType.dataset,
+                project=p,
+                _skip_refine=True,
+            )
 
     @patch("starwhale.base.uricomponents.resource.Project.parse_from_full_uri")
     def test_with_full_uri(self, mock_parse: MagicMock) -> None:
         ins = mock_parse.return_value
         ins.path = "dataset/mnist/version/foo"
         uri = "local/project/self/dataset/mnist/version/foo"
-        r = Resource(uri)
+        r = Resource(uri, _skip_refine=True)
         assert r.name == "mnist"
         assert r.version == "foo"
         assert r.typ == ResourceType.dataset
@@ -69,9 +82,9 @@ class TestResource(TestCase):
             "storage": {"root": "/root"},
         }
         uri = "local/project/self/dataset/mnist"
-        r = Resource(uri)
+        r = Resource(uri, _skip_refine=True)
         assert r.name == "mnist"
-        assert r.version is None
+        assert r.version == ""
         assert r.typ == ResourceType.dataset
 
     @patch("starwhale.base.uricomponents.resource.glob")
@@ -125,8 +138,8 @@ class TestResource(TestCase):
             instance: str
             project: str
             typ: ResourceType
-            name: Optional[str] = None
-            version: Optional[str] = None
+            name: str = ""
+            version: str = ""
 
             def __eq__(self, other: Resource):
                 return (
@@ -200,7 +213,7 @@ class TestResource(TestCase):
         }
 
         for uri, expect in tests.items():
-            p = Resource(uri, typ=ResourceType.runtime)
+            p = Resource(uri, typ=ResourceType.runtime, _skip_refine=True)
             assert p.name == expect[0]
             assert p.project.name == expect[1]
             assert p.instance.alias == expect[2]

--- a/client/tests/core/test_project.py
+++ b/client/tests/core/test_project.py
@@ -6,7 +6,6 @@ from pyfakefs.fake_filesystem_unittest import TestCase
 from tests import get_predefined_config_yaml
 from starwhale.utils import config as sw_config
 from starwhale.consts import DEFAULT_PROJECT
-from starwhale.base.uri import URI
 from starwhale.utils.config import (
     SWCliConfigMixed,
     load_swcli_config,
@@ -15,6 +14,7 @@ from starwhale.utils.config import (
 from starwhale.core.project.view import ProjectTermView
 from starwhale.core.instance.view import InstanceTermView
 from starwhale.core.project.model import StandaloneProject
+from starwhale.base.uricomponents.project import Project
 
 _existed_config_contents = get_predefined_config_yaml()
 
@@ -32,12 +32,12 @@ class ProjectTestCase(TestCase):
     def test_standalone_model(self):
         _config = load_swcli_config()
 
-        sp = StandaloneProject(uri=URI("local/project/self"))
+        sp = StandaloneProject(uri=Project("local/project/self"))
         ok, reason = sp.create()
         assert not ok
         assert "existed" in reason
 
-        sp = StandaloneProject(uri=URI("local/project/test"))
+        sp = StandaloneProject(uri=Project("local/project/test"))
         ok, reason = sp.create()
         assert ok
         assert "created" in reason

--- a/example/mnist/mnist/custom_evaluator.py
+++ b/example/mnist/mnist/custom_evaluator.py
@@ -11,17 +11,16 @@ from PIL import Image as PILImage
 from torchvision import transforms
 
 from starwhale import (
-    URI,
     Image,
     Context,
     dataset,
     handler,
-    URIType,
     evaluation,
     pass_context,
     multi_classification,
 )
 from starwhale.api.service import api
+from starwhale.base.uricomponents.resource import Resource, ResourceType
 
 from .model import Net
 
@@ -40,7 +39,7 @@ class CustomPipelineHandler:
         print(f"start to run ppl@{context.version}-{context.total}-{context.index}...")
 
         for uri_str in context.dataset_uris:
-            _uri = URI(uri_str, expected_type=URIType.DATASET)
+            _uri = Resource(uri_str, typ=ResourceType.dataset)
             ds = dataset(_uri)
             ds.make_distributed_consumption(session_id=context.version)
             for rows in ds.batch_iter(self.batch_size):
@@ -50,7 +49,7 @@ class CustomPipelineHandler:
                     pred_value,
                     probability_matrix,
                 ) in zip(rows, pred_values, probability_matrixs):
-                    _unique_id = f"{_uri.object}_{_idx}"
+                    _unique_id = f"{_uri.version}_{_idx}"
 
                     evaluation.log(
                         category="results",

--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -262,7 +262,7 @@ class TestCli:
     def get_remote_job_status(self, job_id: str) -> t.Tuple[str, str]:
         while True:
             _remote_job = self.job_api.info(
-                f"{self.server_url}/project/{self.server_project}/job/{job_id}"
+                f"{self.server_url}/projects/{self.server_project}/jobs/{job_id}"
             )
             _job_status = (
                 _remote_job["manifest"]["jobStatus"]

--- a/scripts/client_test/cmds/artifacts_cmd.py
+++ b/scripts/client_test/cmds/artifacts_cmd.py
@@ -11,6 +11,7 @@ from starwhale.base.uri import URI
 from starwhale.base.type import URIType, DatasetChangeMode
 from starwhale.core.model.view import ModelTermView
 from starwhale.core.runtime.model import RuntimeConfig
+from starwhale.base.uricomponents.project import Project
 
 from . import CLI
 from .base.invoke import invoke
@@ -100,7 +101,7 @@ class Model(BaseArtifact):
         run_handler: str,
     ) -> t.Tuple[bool, str]:
         return ModelTermView.run_in_server(
-            project_uri=URI(project, expected_type=URIType.PROJECT),
+            project_uri=Project(project),
             model_uri=model_uri,
             dataset_uris=dataset_uris,
             runtime_uri=runtime_uri,


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
