### PR TITLE
enhance(e2e): tune github e2e run logs

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -162,16 +162,20 @@ jobs:
           eval $(minikube docker-env)
           bash start_test.sh build_runtime_image
 
-      - name: List minikube images
-        run: minikube image ls --format table
-
       - name: Wait and check starwhale service
         working-directory: ./scripts/e2e_test
         run: bash start_test.sh check_controller_service
 
       - name: Test by client side
         working-directory: ./scripts/e2e_test
-        run: bash start_test.sh client_test || (bash start_test.sh show_minikube_jobs_log ; exit 1)
+        run: bash start_test.sh client_test
+
+      - name: Post output client-side test logs
+        if: failure()
+        working-directory: ./scripts/e2e_test
+        run: |
+          minikube image ls --format table
+          bash start_test.sh show_minikube_jobs_log
 
       - name: Test by api side
         working-directory: ./scripts/e2e_test

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -53,6 +53,7 @@ show_minikube_jobs_log() {
     echo "--> show pods events:"
     kubectl -n $SWNS get jobs -o wide
     kubectl -n $SWNS describe jobs
+    kubectl -n $SWNS logs --tail 10000 -l job-name --all-containers --prefix
 }
 
 start_nexus() {
@@ -214,7 +215,7 @@ check_controller_service() {
             fi
             sleep 5
     done
-    nohup kubectl port-forward --namespace $SWNS svc/controller $PORT_CONTROLLER:$PORT_CONTROLLER &
+    nohup kubectl port-forward --namespace $SWNS svc/controller $PORT_CONTROLLER:$PORT_CONTROLLER > /dev/null 2>&1 &
 }
 
 client_test() {
@@ -230,9 +231,7 @@ client_test() {
     unset https_proxy
     bash scripts/client_test/cli_test.sh all
   else
-    if ! bash scripts/client_test/cli_test.sh simple; then
-      scripts/e2e_test/check_job.sh 127.0.0.1:$PORT_CONTROLLER || exit 1
-    fi
+    timeout 15m bash scripts/client_test/cli_test.sh simple || exit 1
   fi
   popd
   popd


### PR DESCRIPTION
## Description

- changes:    
    - add timeout for client test
    - ignore kubectl port-forward useless log
    - add post run for client test, which will show all jobs log
    - add retry for remote job status checking

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
