### PR TITLE
bug(e2e): fix runtime build for e2e with no cache config

### DIFF
--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-import shutil
 import typing as t
 import logging
 import subprocess
@@ -184,10 +183,6 @@ class TestCli:
         runtime_yaml: str = "runtime.yaml",
     ) -> t.Any:
         self.select_local_instance()
-        runtime_cache_path = f"{workdir}/.starwhale"
-        if os.path.exists(runtime_cache_path):
-            shutil.rmtree(runtime_cache_path)
-
         _uri = Runtime.build(workdir=workdir, runtime_yaml=runtime_yaml)
         if self.server_url:
             self.runtime_api.copy(

--- a/scripts/client_test/cmds/artifacts_cmd.py
+++ b/scripts/client_test/cmds/artifacts_cmd.py
@@ -160,7 +160,16 @@ class Runtime(BaseArtifact):
         version = gen_uniq_version()
         yaml_path = os.path.join(workdir, runtime_yaml)
         config = RuntimeConfig.create_by_yaml(Path(yaml_path))
-        cmd = [CLI, "runtime", "build", "--yaml", yaml_path, "--name", config.name]
+        cmd = [
+            CLI,
+            "runtime",
+            "build",
+            "--yaml",
+            yaml_path,
+            "--name",
+            config.name,
+            "--no-cache",
+        ]
         ret_code, res = invoke(cmd, external_env={_ENV_FIXED_VERSION: version})
         assert ret_code == 0, res
         return URI(f"{config.name}/version/{version}", expected_type=URIType.RUNTIME)


### PR DESCRIPTION
## Description

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
