### PR TITLE
feat(dataset): support `--patch`/`--overwrite` options for dataset copy command

### DIFF
--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -30,7 +30,7 @@ from starwhale.consts import (
 from starwhale.version import STARWHALE_VERSION
 from starwhale.base.uri import URI, URIType
 from starwhale.utils.fs import copy_file, empty_dir, ensure_dir, ensure_file
-from starwhale.base.type import InstanceType
+from starwhale.base.type import InstanceType, DatasetChangeMode
 from starwhale.base.cloud import CloudRequestMixed
 from starwhale.utils.error import NoSupportError
 from starwhale.utils.config import SWCliConfigMixed
@@ -943,11 +943,31 @@ class Dataset:
         """
         return self.__has_committed
 
-    def copy(self, dest_uri: str, dest_local_project_uri: str = "") -> None:
+    def copy(
+        self,
+        dest_uri: str,
+        dest_local_project_uri: str = "",
+        force: bool = False,
+        mode: str = DatasetChangeMode.PATCH.value,
+    ) -> None:
+        """Copy dataset to another instance.
+
+        Args:
+            dest_uri: (str, required) destination dataset uri
+            dest_local_project_uri: (str, optional) destination local project uri
+            force: (bool, optional) force to copy
+            mode: (str, optional) copy mode, default is 'patch'. Mode choices are: 'patch', 'overwrite'.
+              `patch` mode: only update the changed rows and columns for the remote dataset;
+              `overwrite` mode: update records and delete extraneous rows from the remote dataset
+        Returns:
+            None
+        """
         CoreDataset.copy(
             str(self.uri),
             dest_uri,
             dest_local_project_uri=dest_local_project_uri,
+            force=force,
+            mode=DatasetChangeMode(mode),
         )
 
     @classmethod

--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -229,7 +229,7 @@ class BundleCopy(CloudRequestMixed):
 
     def do(self) -> None:
         remote_url = self._get_remote_bundle_console_url()
-        if self._check_version_existed(self.dest_uri) and not self.force:
+        if not self.force and self._check_version_existed(self.dest_uri):
             console.print(f":tea: {remote_url} was already existed, skip copy")
             return
 

--- a/client/starwhale/base/type.py
+++ b/client/starwhale/base/type.py
@@ -74,3 +74,9 @@ class DependencyType(Enum):
     CONDA_ENV_FILE = "conda_env_file"
     WHEEL = "wheel"
     NATIVE_FILE = "native_file"
+
+
+@unique
+class DatasetChangeMode(Enum):
+    PATCH = "patch"
+    OVERWRITE = "overwrite"

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -20,7 +20,7 @@ from starwhale.consts import (
 from starwhale.base.tag import StandaloneTag
 from starwhale.base.uri import URI
 from starwhale.utils.fs import move_dir, empty_dir
-from starwhale.base.type import URIType, BundleType, InstanceType
+from starwhale.base.type import URIType, BundleType, InstanceType, DatasetChangeMode
 from starwhale.base.cloud import CloudRequestMixed, CloudBundleModelMixin
 from starwhale.utils.http import ignore_error
 from starwhale.base.bundle import BaseBundle, LocalStorageBundleMixin
@@ -79,12 +79,15 @@ class Dataset(BaseBundle, metaclass=ABCMeta):
         cls,
         src_uri: str,
         dest_uri: str,
+        mode: DatasetChangeMode = DatasetChangeMode.PATCH,
         dest_local_project_uri: str = "",
+        force: bool = False,
     ) -> None:
         dc = DatasetCopy(
-            src_uri,
-            dest_uri,
-            URIType.DATASET,
+            src_uri=src_uri,
+            dest_uri=dest_uri,
+            force=force,
+            mode=mode,
             dest_local_project_uri=dest_local_project_uri,
         )
         dc.do()

--- a/client/starwhale/core/dataset/view.py
+++ b/client/starwhale/core/dataset/view.py
@@ -9,7 +9,7 @@ from rich.pretty import Pretty
 from starwhale.utils import console, pretty_bytes, pretty_merge_list
 from starwhale.consts import DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE, SHORT_VERSION_CNT
 from starwhale.base.uri import URI
-from starwhale.base.type import URIType, InstanceType
+from starwhale.base.type import URIType, InstanceType, DatasetChangeMode
 from starwhale.base.view import BaseTermView
 from starwhale.core.dataset.type import DatasetConfig
 from starwhale.core.runtime.process import Process as RuntimeProcess
@@ -176,9 +176,17 @@ class DatasetTermView(BaseTermView):
         cls,
         src_uri: str,
         dest_uri: str,
+        mode: DatasetChangeMode = DatasetChangeMode.PATCH,
         dest_local_project_uri: str = "",
+        force: bool = False,
     ) -> None:
-        Dataset.copy(src_uri, dest_uri, dest_local_project_uri)
+        Dataset.copy(
+            src_uri=src_uri,
+            dest_uri=dest_uri,
+            mode=mode,
+            dest_local_project_uri=dest_local_project_uri,
+            force=force,
+        )
         console.print(":clap: copy done")
 
     @BaseTermView._header

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -203,7 +203,7 @@ class TestDatasetCopy(BaseTestCase):
             dc = DatasetCopy(
                 src_uri=f"{dataset_name}/version/{dataset_version}",
                 dest_uri=f"{instance_uri}/project/{cloud_project}",
-                typ=URIType.DATASET,
+                force=True,
             )
             dc.do()
 
@@ -412,7 +412,6 @@ class TestDatasetCopy(BaseTestCase):
                 src_uri=f"{instance_uri}/project/{cloud_project}/dataset/{dataset_name}/version/{dataset_version}",
                 dest_uri="",
                 dest_local_project_uri="self",
-                typ=URIType.DATASET,
             )
             dc.do()
 

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -1151,7 +1151,7 @@ class TestDatasetSDK(_DatasetSDKTestBase):
             json={"data": {"uploadId": 1}},
         )
 
-        ds.copy("cloud://test/project/self")
+        ds.copy("cloud://test/project/self", force=True)
         assert make_version_req.call_count == 2
         assert upload_blob_req.call_count == 1
 

--- a/scripts/client_test/cmds/artifacts_cmd.py
+++ b/scripts/client_test/cmds/artifacts_cmd.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from starwhale.utils import gen_uniq_version
 from starwhale.consts import ENV_BUILD_BUNDLE_FIXED_VERSION_FOR_TEST
 from starwhale.base.uri import URI
-from starwhale.base.type import URIType
+from starwhale.base.type import URIType, DatasetChangeMode
 from starwhale.core.model.view import ModelTermView
 from starwhale.core.runtime.model import RuntimeConfig
 
@@ -152,8 +152,20 @@ class Dataset(BaseArtifact):
         assert ret_code == 0, res
         return URI(f"{name}/version/{version}", expected_type=URIType.DATASET)
 
-    def copy(self, src_uri: str, target_project: str) -> None:
+    def copy(
+        self,
+        src_uri: str,
+        target_project: str,
+        force: bool = False,
+        mode: DatasetChangeMode = DatasetChangeMode.PATCH,
+    ) -> None:
         _args = [CLI, self.name, "copy", src_uri, target_project]
+        if force:
+            _args.append("--force")
+        if mode == DatasetChangeMode.PATCH:
+            _args.append("--patch")
+        else:
+            _args.append("--overwrite")
         _ret_code, _res = invoke(_args)
         assert _ret_code == 0, _res
 
@@ -181,7 +193,13 @@ class Runtime(BaseArtifact):
         assert ret_code == 0, res
         return URI(f"{config.name}/version/{version}", expected_type=URIType.RUNTIME)
 
-    def copy(self, src_uri: str, target_project: str, force: bool) -> None:
+    def copy(
+        self,
+        src_uri: str,
+        target_project: str,
+        force: bool,
+        mode: DatasetChangeMode = DatasetChangeMode.PATCH,
+    ) -> None:
         _args = [CLI, self.name, "copy", src_uri, target_project]
         if force:
             _args.append("--force")


### PR DESCRIPTION
## Description
- changes:
  - support `--patch`/`--overwrite` options for dataset copy command
  - support copy into the remote existed dataset.
  - support `--force` option for copy the existed dataset version.
- demo show:
  - ![SPdHXm704m](https://user-images.githubusercontent.com/590748/234527648-a6000551-02f6-4ff3-83f8-7c68bcd90d15.jpg)
  - ![image](https://user-images.githubusercontent.com/590748/234532377-030913db-fde3-44a2-84c3-8fd09db4fec6.png)

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
