### PR TITLE
fix(datastore): error when update table schema

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchema.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchema.java
@@ -256,6 +256,11 @@ public class ColumnSchema {
             if (this.type != null) {
                 this.singleType = false;
             }
+            this.keySchema = null;
+            this.valueSchema = null;
+            this.elementSchema = null;
+            this.attributesSchema = null;
+            this.pythonType = null;
             this.type = type;
         }
         switch (type) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchema.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchema.java
@@ -181,7 +181,7 @@ public class ColumnSchema {
         var type = ColumnType.valueOf(schema.getType());
         Wal.ColumnSchema.Builder ret = null;
         if (this.type != type) {
-            ret = Wal.ColumnSchema.newBuilder();
+            return new ColumnSchema(schema, this.index).toWal();
         }
         switch (type) {
             case LIST:
@@ -192,10 +192,7 @@ public class ColumnSchema {
                 }
                 var elementWal = elementSchema.getDiff(schema.getElementType());
                 if (elementWal != null) {
-                    if (ret == null) {
-                        ret = Wal.ColumnSchema.newBuilder();
-                    }
-                    ret.setElementType(elementWal);
+                    ret = Wal.ColumnSchema.newBuilder().setElementType(elementWal);
                 }
                 break;
             case MAP:
@@ -210,9 +207,7 @@ public class ColumnSchema {
                 var keyWal = keySchema.getDiff(schema.getKeyType());
                 var valueWal = valueSchema.getDiff(schema.getValueType());
                 if (keyWal != null || valueWal != null) {
-                    if (ret == null) {
-                        ret = Wal.ColumnSchema.newBuilder();
-                    }
+                    ret = Wal.ColumnSchema.newBuilder();
                     if (keyWal != null) {
                         ret.setKeyType(keyWal);
                     }
@@ -223,9 +218,7 @@ public class ColumnSchema {
                 break;
             case OBJECT:
                 if (!schema.getPythonType().equals(this.pythonType)) {
-                    if (ret == null) {
-                        ret = Wal.ColumnSchema.newBuilder();
-                    }
+                    ret = Wal.ColumnSchema.newBuilder();
                     ret.setPythonType(schema.getPythonType());
                 }
                 var attributesSchema = this.attributesSchema;
@@ -271,9 +264,7 @@ public class ColumnSchema {
                 if (this.elementSchema == null) {
                     this.elementSchema = new ColumnSchema("element", 0);
                 }
-                if (schema.hasElementType()) {
-                    this.elementSchema.update(schema.getElementType());
-                }
+                this.elementSchema.update(schema.getElementType());
                 break;
             case MAP:
                 if (this.keySchema == null) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchema.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchema.java
@@ -271,7 +271,9 @@ public class ColumnSchema {
                 if (this.elementSchema == null) {
                     this.elementSchema = new ColumnSchema("element", 0);
                 }
-                this.elementSchema.update(schema.getElementType());
+                if (schema.hasElementType()) {
+                    this.elementSchema.update(schema.getElementType());
+                }
                 break;
             case MAP:
                 if (this.keySchema == null) {

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/TableSchemaTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/TableSchemaTest.java
@@ -114,6 +114,13 @@ public class TableSchemaTest {
         walMap.put("list", newList);
         this.schema.update(diff);
         walMap.forEach((k, v) -> assertThat(this.schema.getColumnSchemaByName(k).toWal().build(), is(v.build())));
+
+        var listCol = this.schema.getColumnSchemaByName("list");
+        assertThat(listCol.getType(), is(ColumnType.STRING));
+        assertThat(listCol.getElementSchema(), nullValue());
+        assertThat(listCol.getKeySchema(), nullValue());
+        assertThat(listCol.getValueSchema(), nullValue());
+        assertThat(listCol.getPythonType(), nullValue());
     }
 
     @Test

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/TableSchemaTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/TableSchemaTest.java
@@ -77,12 +77,7 @@ public class TableSchemaTest {
         var schema = new TableSchema();
         var diff = schema.getDiff(this.desc);
         var expectedDiff = this.schema.toWal();
-        var listDiff = expectedDiff.getColumnsBuilder(2);
-        listDiff.setElementType(listDiff.getElementTypeBuilder().setColumnName(""));
-        var mapDiff = expectedDiff.getColumnsBuilder(3);
-        mapDiff.setKeyType(mapDiff.getKeyTypeBuilder().setColumnName(""))
-                .setValueType(mapDiff.getValueTypeBuilder().setColumnName(""));
-        assertThat(diff.build(), is(expectedDiff.setColumns(2, listDiff).setColumns(3, mapDiff).build()));
+        assertThat(diff.build(), is(expectedDiff.build()));
         schema.update(this.schema.toWal().build());
         assertThat(schema.toWal().build(), is(this.schema.toWal().build()));
     }
@@ -155,6 +150,7 @@ public class TableSchemaTest {
                 .setElementType(Wal.ColumnSchema.newBuilder()
                         .setColumnType("OBJECT")
                         .setPythonType("x")
+                        .setColumnName("element")
                         .addAttributes(Wal.ColumnSchema.newBuilder()
                                 .setColumnName("a")
                                 .setColumnType("INT32")
@@ -184,7 +180,7 @@ public class TableSchemaTest {
                         List.of(ColumnSchemaDesc.builder()
                                 .name("list")
                                 .type("LIST")
-                                .elementType(ColumnSchemaDesc.builder().type("INT32").build())
+                                .elementType(ColumnSchemaDesc.builder().type("INT32").name("ele").build())
                                 .build())))
                 .build();
         var newList = Wal.ColumnSchema.newBuilder()
@@ -193,6 +189,7 @@ public class TableSchemaTest {
                 .setColumnIndex(this.schema.getColumnSchemaByName("list").getIndex())
                 .setElementType(Wal.ColumnSchema.newBuilder()
                         .setColumnType("INT32")
+                        .setColumnName("ele")
                         .build());
         assertThat(diff, is(Wal.TableSchema.newBuilder().addColumns(newList).build()));
         var walMap = this.schema.getColumnSchemaList().stream()
@@ -209,7 +206,7 @@ public class TableSchemaTest {
                         List.of(ColumnSchemaDesc.builder()
                                 .name("map")
                                 .type("MAP")
-                                .keyType(ColumnSchemaDesc.builder().type("INT8").build())
+                                .keyType(ColumnSchemaDesc.builder().name("key").type("INT8").build())
                                 .valueType(ColumnSchemaDesc.builder().name("value").type("INT32").build())
                                 .build())))
                 .build();
@@ -218,6 +215,7 @@ public class TableSchemaTest {
                 .setColumnType("MAP")
                 .setColumnIndex(this.schema.getColumnSchemaByName("map").getIndex())
                 .setKeyType(Wal.ColumnSchema.newBuilder()
+                        .setColumnName("key")
                         .setColumnType("INT8")
                         .build());
         assertThat(diff, is(Wal.TableSchema.newBuilder().addColumns(newMap).build()));
@@ -237,7 +235,7 @@ public class TableSchemaTest {
                                 .name("map")
                                 .type("MAP")
                                 .keyType(ColumnSchemaDesc.builder().name("key").type("STRING").build())
-                                .valueType(ColumnSchemaDesc.builder().type("INT8").build())
+                                .valueType(ColumnSchemaDesc.builder().name("value").type("INT8").build())
                                 .build())))
                 .build();
         var newMap = Wal.ColumnSchema.newBuilder()
@@ -245,6 +243,7 @@ public class TableSchemaTest {
                 .setColumnType("MAP")
                 .setColumnIndex(this.schema.getColumnSchemaByName("map").getIndex())
                 .setValueType(Wal.ColumnSchema.newBuilder()
+                        .setColumnName("value")
                         .setColumnType("INT8")
                         .build());
         assertThat(diff, is(Wal.TableSchema.newBuilder().addColumns(newMap).build()));

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
@@ -366,7 +366,7 @@ public class MemoryTableImplTest {
                             ColumnSchemaDesc.builder().name("i").type("UNKNOWN").build(),
                             ColumnSchemaDesc.builder().name("j")
                                     .type("LIST")
-                                    .elementType(ColumnSchemaDesc.builder().type("INT32").build())
+                                    .elementType(ColumnSchemaDesc.builder().name("element").type("INT32").build())
                                     .build(),
                             ColumnSchemaDesc.builder().name("k")
                                     .type("OBJECT")
@@ -377,12 +377,12 @@ public class MemoryTableImplTest {
                             ColumnSchemaDesc.builder().name("l").type("FLOAT64").build(),
                             ColumnSchemaDesc.builder().name("m")
                                     .type("TUPLE")
-                                    .elementType(ColumnSchemaDesc.builder().type("INT32").build())
+                                    .elementType(ColumnSchemaDesc.builder().name("element").type("INT32").build())
                                     .build(),
                             ColumnSchemaDesc.builder().name("n")
                                     .type("MAP")
-                                    .keyType(ColumnSchemaDesc.builder().type("INT8").build())
-                                    .valueType(ColumnSchemaDesc.builder().type("INT16").build())
+                                    .keyType(ColumnSchemaDesc.builder().name("key").type("INT8").build())
+                                    .valueType(ColumnSchemaDesc.builder().name("value").type("INT16").build())
                                     .build())),
 
                     List.of(new HashMap<>() {
@@ -409,10 +409,10 @@ public class MemoryTableImplTest {
                             ColumnSchemaDesc.builder().name("key").type("INT32").build(),
                             ColumnSchemaDesc.builder().name("b").type("STRING").build(),
                             ColumnSchemaDesc.builder().name("f").type("LIST")
-                                    .elementType(ColumnSchemaDesc.builder().type("INT32").build())
+                                    .elementType(ColumnSchemaDesc.builder().name("element").type("INT32").build())
                                     .build(),
                             ColumnSchemaDesc.builder().name("i").type("TUPLE")
-                                    .elementType(ColumnSchemaDesc.builder().type("INT32").build())
+                                    .elementType(ColumnSchemaDesc.builder().name("element").type("INT32").build())
                                     .build(),
                             ColumnSchemaDesc.builder().name("j").type("INT32").build(),
                             ColumnSchemaDesc.builder().name("k")
@@ -423,8 +423,8 @@ public class MemoryTableImplTest {
                                     .build(),
                             ColumnSchemaDesc.builder().name("n")
                                     .type("MAP")
-                                    .keyType(ColumnSchemaDesc.builder().type("STRING").build())
-                                    .valueType(ColumnSchemaDesc.builder().type("INT16").build())
+                                    .keyType(ColumnSchemaDesc.builder().name("key").type("STRING").build())
+                                    .valueType(ColumnSchemaDesc.builder().name("value").type("INT16").build())
                                     .build())),
 
                     List.of(new HashMap<>() {
@@ -643,16 +643,16 @@ public class MemoryTableImplTest {
                             ColumnSchemaDesc.builder().name("i").type("UNKNOWN").build(),
                             ColumnSchemaDesc.builder().name("j")
                                     .type("LIST")
-                                    .elementType(ColumnSchemaDesc.builder().type("INT32").build())
+                                    .elementType(ColumnSchemaDesc.builder().name("element").type("INT32").build())
                                     .build(),
                             ColumnSchemaDesc.builder().name("k")
                                     .type("TUPLE")
-                                    .elementType(ColumnSchemaDesc.builder().type("INT32").build())
+                                    .elementType(ColumnSchemaDesc.builder().name("element").type("INT32").build())
                                     .build(),
                             ColumnSchemaDesc.builder().name("l")
                                     .type("MAP")
-                                    .keyType(ColumnSchemaDesc.builder().type("INT32").build())
-                                    .valueType(ColumnSchemaDesc.builder().type("INT32").build())
+                                    .keyType(ColumnSchemaDesc.builder().name("key").type("INT32").build())
+                                    .valueType(ColumnSchemaDesc.builder().name("value").type("INT32").build())
                                     .build(),
                             ColumnSchemaDesc.builder().name("m")
                                     .type("OBJECT")
@@ -663,9 +663,11 @@ public class MemoryTableImplTest {
                             ColumnSchemaDesc.builder().name("n")
                                     .type("LIST")
                                     .elementType(ColumnSchemaDesc.builder()
+                                            .name("element")
                                             .type("TUPLE")
                                             .elementType(ColumnSchemaDesc.builder()
                                                     .type("MAP")
+                                                    .name("element")
                                                     .keyType(ColumnSchemaDesc.builder()
                                                             .type("OBJECT")
                                                             .pythonType("tt")
@@ -683,7 +685,8 @@ public class MemoryTableImplTest {
                                                     .valueType(ColumnSchemaDesc.builder()
                                                             .type("LIST")
                                                             .elementType(
-                                                                    ColumnSchemaDesc.builder().type("INT32").build())
+                                                                    ColumnSchemaDesc.builder()
+                                                                            .name("element").type("INT32").build())
                                                             .build())
                                                     .build())
                                             .build())
@@ -734,7 +737,7 @@ public class MemoryTableImplTest {
                             ColumnSchemaDesc.builder().name("d").type("BOOL").build(),
                             ColumnSchemaDesc.builder().name("e")
                                     .type("LIST")
-                                    .elementType(ColumnSchemaDesc.builder().type("BOOL").build())
+                                    .elementType(ColumnSchemaDesc.builder().name("element").type("BOOL").build())
                                     .build())),
                     List.of(Map.of("key", "2", "d", "0", "e", List.of("0", "1"))));
             records.clear();


### PR DESCRIPTION
## Description

```bash
[update-table]Table:project/2/dataset/webqsp/_current/meta, resp code:500,                                                                                                          
 resp text: {"code":"internalServerError","message":"No enum constant ai.starwhale.mlops.datastore.ColumnType.","data":null},                                                                                        
 records: [{'id': 2, 'features/questionid': 'WebQTest-3', 'features/rawquestion': 'who plays ken barlow in coronation street?', 'features/processedquestion': 'who plays ken barlow in coronation street', 'features/
parses': [<starwhale.core.dataset.type.JsonDict object at 0x7f102b4ad7d0>]}] 
```

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
