### PR TITLE
fix(controller): the startup hangs when loading lots of wal files

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/WalManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/WalManager.java
@@ -179,15 +179,16 @@ public class WalManager extends Thread {
                                                     100, 2.0, 0.5, 10000))
                                             .build()),
                                     () -> {
-                                        var input = WalManager.this.storageAccessService.get(this.currentFile);
-                                        int len = Math.toIntExact(input.getSize());
-                                        var ret = new byte[len];
-                                        var n = input.readNBytes(ret, 0, len);
-                                        if (n != len) {
-                                            throw new RuntimeException(
+                                        try (var input = WalManager.this.storageAccessService.get(this.currentFile)) {
+                                            int len = Math.toIntExact(input.getSize());
+                                            var ret = new byte[len];
+                                            var n = input.readNBytes(ret, 0, len);
+                                            if (n != len) {
+                                                throw new RuntimeException(
                                                     MessageFormat.format("expected size {0}, actual {1}", len, n));
+                                            }
+                                            return ret;
                                         }
-                                        return ret;
                                     })
                             .apply();
                 } catch (Throwable e) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
@@ -709,9 +709,8 @@ public class ModelService {
     }
 
     private String getManifest(ModelVersionEntity modelVersionEntity) {
-        try {
-            var p = String.format(FORMATTER_STORAGE_PATH, modelVersionEntity.getStoragePath(), MODEL_MANIFEST);
-            var is = storageAccessService.get(p);
+        var p = String.format(FORMATTER_STORAGE_PATH, modelVersionEntity.getStoragePath(), MODEL_MANIFEST);
+        try (var is = storageAccessService.get(p)) {
             return IOUtils.toString(is, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new SwProcessException(ErrorType.STORAGE, "get manifest error", e);
@@ -755,8 +754,7 @@ public class ModelService {
                 @Override
                 public TarFileUtil.TarEntry next() {
                     var filePath = files.remove(0);
-                    try {
-                        var inputStream = storageAccessService.get(filePath);
+                    try (var inputStream = storageAccessService.get(filePath)) {
                         length[0] += inputStream.getSize();
                         return TarFileUtil.TarEntry.builder()
                                 .inputStream(inputStream)

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/aliyun/StorageAccessServiceAliyun.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/aliyun/StorageAccessServiceAliyun.java
@@ -22,6 +22,7 @@ import ai.starwhale.mlops.storage.StorageAccessService;
 import ai.starwhale.mlops.storage.StorageObjectInfo;
 import ai.starwhale.mlops.storage.s3.S3Config;
 import ai.starwhale.mlops.storage.util.MetaHelper;
+import com.aliyun.oss.ClientBuilderConfiguration;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClientBuilder;
 import com.aliyun.oss.OSSErrorCode;
@@ -56,8 +57,11 @@ public class StorageAccessServiceAliyun implements StorageAccessService {
     public StorageAccessServiceAliyun(S3Config s3Config) {
         this.bucket = s3Config.getBucket();
         this.partSize = s3Config.getHugeFilePartSize();
+
+        var config = new ClientBuilderConfiguration();
+        config.setRequestTimeoutEnabled(true);
         this.ossClient = new OSSClientBuilder()
-                .build(s3Config.getEndpoint(), s3Config.getAccessKey(), s3Config.getSecretKey());
+                .build(s3Config.getEndpoint(), s3Config.getAccessKey(), s3Config.getSecretKey(), config);
     }
 
     @Override


### PR DESCRIPTION
## Description

The reason: we forgot to close the input stream when reading lots of wal file

Fixes:
- make aliyun client timeout enabled
- close the input streams

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
