### PR TITLE
 enhance(sdk): enhance model build sdk for searching modules

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -194,4 +194,4 @@ jobs:
         env:
           GITHUB_ACTION: 1
           PYTHON_VERSION: ${{matrix.python-version}}
-        run: bash scripts/client_test/cli_test.sh simple
+        run: bash scripts/client_test/cli_test.sh sdk simple

--- a/client/starwhale/base/bundle.py
+++ b/client/starwhale/base/bundle.py
@@ -140,7 +140,7 @@ class BaseBundle(metaclass=ABCMeta):
             dst = self.store.snapshot_workdir  # type: ignore
             ensure_dir(dst.parent)
             os.rename(src, dst)
-            console.print(f"finish gen resource @ {dst}")
+            console.print(f":100: finish gen resource @ {dst}")
 
         with ExitStack() as stack:
             stack.callback(when_exit)
@@ -173,7 +173,7 @@ class LocalStorageBundleMixin:
             self._version = gen_uniq_version()
 
         self.uri.object.version = self._version  # type:ignore
-        console.print(f":new: version {self._version[:SHORT_VERSION_CNT]}")  # type: ignore
+        console.debug(f":new: version {self._version[:SHORT_VERSION_CNT]}")  # type: ignore
         self._manifest["version"] = self._version
         self._manifest[CREATED_AT_KEY] = now_str()
 

--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -741,7 +741,7 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
 
     def _copy_src(self, workdir: Path, model_config: ModelConfig) -> None:
         console.print(
-            f":thumbs_up: try to copy source code files: {workdir} -> {self.store.src_dir}"
+            f":peacock: copy source code files: {workdir} -> {self.store.src_dir}"
         )
 
         excludes = None

--- a/client/starwhale/utils/__init__.py
+++ b/client/starwhale/utils/__init__.py
@@ -197,7 +197,7 @@ def get_current_shell() -> str:
 def disable_progress_bar() -> t.Generator[None, None, None]:
     old_flag = os.environ.get(ENV_DISABLE_PROGRESS_BAR, "")
 
-    os.environ[ENV_DISABLE_PROGRESS_BAR] = "0"
+    os.environ[ENV_DISABLE_PROGRESS_BAR] = "1"
     try:
         yield
     finally:

--- a/client/tests/sdk/test_job.py
+++ b/client/tests/sdk/test_job.py
@@ -593,6 +593,38 @@ def run(): ...
             ]
         }
 
+    def test_handler_with_other_decorator(self) -> None:
+        content = """
+from starwhale import handler, pass_context
+
+@handler(replicas=2)
+@pass_context
+def handle(context): ...
+        """
+
+        self._ensure_py_script(content)
+        yaml_path = self.workdir / "job.yaml"
+        generate_jobs_yaml([self.module_name], self.workdir, yaml_path)
+
+        jobs_info = load_yaml(yaml_path)
+        assert jobs_info == {
+            "mock_user_module:handle": [
+                {
+                    "cls_name": "",
+                    "concurrency": 1,
+                    "extra_args": [],
+                    "extra_kwargs": {},
+                    "func_name": "handle",
+                    "module_name": "mock_user_module",
+                    "name": "mock_user_module:handle",
+                    "needs": [],
+                    "replicas": 2,
+                    "resources": [],
+                    "show_name": "handle",
+                }
+            ]
+        }
+
     def test_handler_deco(self) -> None:
         content = """
 from starwhale import handler

--- a/example/mnist/mnist/plain_evaluator.py
+++ b/example/mnist/mnist/plain_evaluator.py
@@ -7,7 +7,9 @@ import gradio
 from PIL import Image as PILImage
 from torchvision import transforms
 
-from starwhale import Image, evaluation, multi_classification
+from starwhale import Image
+from starwhale import model as starwhale_model
+from starwhale import evaluation, multi_classification
 from starwhale.api.service import api
 
 try:
@@ -78,9 +80,28 @@ def load_model() -> Net:
     model = Net().to(device)
     model.load_state_dict(
         torch.load(  # type: ignore
-            str(Path(__file__).parent.parent / "models" / "mnist_cnn.pt"),
+            str(ROOTDIR / "models" / "mnist_cnn.pt"),
             map_location=device,
         )
     )
     model.eval()
     return model
+
+
+if __name__ == "__main__":
+    # use imported modules as search modules
+    starwhale_model.build(workdir=ROOTDIR)
+
+    # use function object as search modules
+    #    starwhale_model.build(
+    #        name="mnist",
+    #        workdir=ROOTDIR,
+    #        modules=[predict_image, evaluate_results],
+    #    )
+
+    # use import-path str as search modules
+    # starwhale_model.build(
+    #    name="mnist",
+    #    workdir=ROOTDIR,
+    #    modules=["mnist.plain_evaluator"],
+    # )

--- a/example/mnist/model2.yaml
+++ b/example/mnist/model2.yaml
@@ -1,7 +1,0 @@
-version: 1.0
-name: mnist
-
-run:
-  handler: mnist.evaluator:MNISTInference
-
-desc: mnist by pytorch

--- a/scripts/client_test/cli_test.sh
+++ b/scripts/client_test/cli_test.sh
@@ -29,5 +29,6 @@ swcli --version
 popd
 
 bash "$SCRIPT_DIR"/update_controller_setting.sh
-python3 "$SCRIPT_DIR"/cli_test.py "$1"
-
+for i in $@; do
+    python3 "$SCRIPT_DIR"/cli_test.py $i || exit 1
+done

--- a/scripts/client_test/cmds/base/invoke.py
+++ b/scripts/client_test/cmds/base/invoke.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import Dict, List, Tuple, Optional
+from typing import Any, Dict, List, Tuple, Optional
 
 from starwhale.utils import console
 
@@ -17,6 +17,13 @@ def invoke_with_react(args: List[str], input_content: str = "yes") -> Tuple[int,
     if _err:
         console.warning(f"args:{args}, error is:{_err}")
     return p.returncode, _stdout
+
+
+def check_invoke(*args: Any, **kwargs: Any) -> None:
+    code, _stdout = invoke(*args, **kwargs)
+    assert (
+        code == 0
+    ), f"invoke failed, code:{code}, stdout:{_stdout}, args: {args}, kwargs: {kwargs}"
 
 
 def invoke(

--- a/scripts/example/src/sdk_model_build.py
+++ b/scripts/example/src/sdk_model_build.py
@@ -1,0 +1,23 @@
+import typing as t
+from pathlib import Path
+
+from starwhale import model, Context, handler, pass_context
+
+try:
+    from .evaluator import predict
+except ImportError:
+    from evaluator import predict
+
+
+ROOTDIR = Path(__file__).parent.parent
+
+
+@handler(replicas=1)
+@pass_context
+def context_handle(ctx: Context) -> t.Any:
+    print(ctx)
+
+
+model.build(name="ctx_handle", modules=[context_handle, predict], workdir=ROOTDIR)
+
+model.build(name="ctx_handle_no_modules", workdir=ROOTDIR)


### PR DESCRIPTION
## Description
- changes:
  - Unwrap decorated functions: @pass_context and other decorators can be added for the @handler functions.
  - Ignore the `__main__` module.
  - Tune related-rootdir search modules path for the imported modules scenario.
  - Allow modle build function to be called at the module level, rather than in a cycle call scenario. See the example: https://asciinema.org/a/582707
  - Clarify which modules require explicit arguments and which can be imported implicitly by the model build SDK.
  - Update mnist example and add SDK e2e test.
-  [![asciicast](https://asciinema.org/a/582707.svg)](https://asciinema.org/a/582707)

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [x] add necessary doc
