### PR TITLE
chore(sdk): PipelineHandler support `predict` and `evaluate` function interface

### DIFF
--- a/client/starwhale/api/_impl/job.py
+++ b/client/starwhale/api/_impl/job.py
@@ -263,14 +263,15 @@ class Handler(ASDictMixin):
                     and issubclass(v, PipelineHandler)
                     and v != PipelineHandler
                 ):
-                    ppl_func = getattr(v, "ppl")
-                    cmp_func = getattr(v, "cmp")
-                    Handler.register(replicas=2, name="ppl")(ppl_func)
+                    # compatible with old version: ppl and cmp function are renamed to predict and evaluate
+                    predict_func = getattr(v, "predict", None) or getattr(v, "ppl")
+                    evaluate_func = getattr(v, "evaluate", None) or getattr(v, "cmp")
+                    Handler.register(replicas=2, name="predict")(predict_func)
                     Handler.register(
                         replicas=1,
-                        needs=[ppl_func],
-                        name="cmp",
-                    )(cmp_func)
+                        needs=[predict_func],
+                        name="evaluate",
+                    )(evaluate_func)
 
 
 def generate_jobs_yaml(

--- a/client/starwhale/base/scheduler/task.py
+++ b/client/starwhale/base/scheduler/task.py
@@ -51,10 +51,10 @@ class TaskExecutor:
         return self.__status
 
     def _get_internal_func_name(self, func_name: str) -> str:
-        if func_name == "ppl":
-            return "_starwhale_internal_run_ppl"
-        elif func_name == "cmp":
-            return "_starwhale_internal_run_cmp"
+        if func_name in ("ppl", "predict"):
+            return "_starwhale_internal_run_predict"
+        elif func_name in ("cmp", "evaluate"):
+            return "_starwhale_internal_run_evaluate"
         else:
             raise RuntimeError(
                 f"failed to map func name({func_name}) into PipelineHandler internal func name"
@@ -68,8 +68,8 @@ class TaskExecutor:
         from starwhale.api._impl.evaluation import PipelineHandler
 
         patch_func_map = {
-            "ppl": lambda *args, **kwargs: ...,
-            "cmp": lambda *args, **kwargs: ...,
+            "predict": lambda *args, **kwargs: ...,
+            "evaluate": lambda *args, **kwargs: ...,
         }
 
         if func_name not in patch_func_map:
@@ -107,9 +107,9 @@ class TaskExecutor:
         if cls_ is None:
             func = getattr(module, self.step.func_name)
             if getattr(func, DecoratorInjectAttr.Evaluate, False):
-                self._run_in_pipeline_handler_cls(func, "cmp")
+                self._run_in_pipeline_handler_cls(func, "evaluate")
             elif getattr(func, DecoratorInjectAttr.Predict, False):
-                self._run_in_pipeline_handler_cls(func, "ppl")
+                self._run_in_pipeline_handler_cls(func, "predict")
             elif getattr(func, DecoratorInjectAttr.Step, False):
                 func()
             else:
@@ -127,17 +127,17 @@ class TaskExecutor:
                 with cls_() as instance:
                     func = getattr(instance, func_name)
                     if getattr(func, DecoratorInjectAttr.Evaluate, False):
-                        self._run_in_pipeline_handler_cls(func, "cmp")
+                        self._run_in_pipeline_handler_cls(func, "evaluate")
                     elif getattr(func, DecoratorInjectAttr.Predict, False):
-                        self._run_in_pipeline_handler_cls(func, "ppl")
+                        self._run_in_pipeline_handler_cls(func, "predict")
                     else:
                         func()
             else:
                 func = getattr(cls_(), func_name)
                 if getattr(func, DecoratorInjectAttr.Evaluate, False):
-                    self._run_in_pipeline_handler_cls(func, "cmp")
+                    self._run_in_pipeline_handler_cls(func, "evaluate")
                 elif getattr(func, DecoratorInjectAttr.Predict, False):
-                    self._run_in_pipeline_handler_cls(func, "ppl")
+                    self._run_in_pipeline_handler_cls(func, "predict")
                 else:
                     func()
 

--- a/client/starwhale/core/job/view.py
+++ b/client/starwhale/core/job/view.py
@@ -107,8 +107,8 @@ class JobTermView(BaseTermView):
 
         if "location" in _rt:
             console.rule("Process dirs")
-            console.print(f":cactus: ppl: {_rt['location']['ppl']}")
-            console.print(f":camel: cmp: {_rt['location']['cmp']}")
+            console.print(f":cactus: predict: {_rt['location']['predict']}")
+            console.print(f":camel: evaluate: {_rt['location']['evaluate']}")
 
         if "tasks" in _rt:
             self._print_tasks(_rt["tasks"][0])

--- a/client/tests/sdk/test_evaluation.py
+++ b/client/tests/sdk/test_evaluation.py
@@ -139,7 +139,7 @@ class TestModelPipelineHandler(TestCase):
         )
         Context.set_runtime_context(context)
         with SimpleHandler() as _handler:
-            _handler._starwhale_internal_run_cmp()
+            _handler._starwhale_internal_run_evaluate()
 
         status_file_path = os.path.join(_status_dir, "current")
         assert os.path.exists(status_file_path)
@@ -202,7 +202,7 @@ class TestModelPipelineHandler(TestCase):
         )
         Context.set_runtime_context(context)
         with SimpleHandler() as _handler:
-            _handler._starwhale_internal_run_ppl()
+            _handler._starwhale_internal_run_predict()
 
         m_eval_log.assert_called_once()
         status_file_path = os.path.join(_status_dir, "current")
@@ -300,7 +300,7 @@ class TestModelPipelineHandler(TestCase):
         Context.set_runtime_context(context)
         # mock
         with Dummy(flush_result=True) as _handler:
-            _handler._starwhale_internal_run_ppl()
+            _handler._starwhale_internal_run_predict()
 
         context = Context(
             workdir=Path(),
@@ -312,7 +312,7 @@ class TestModelPipelineHandler(TestCase):
         )
         Context.set_runtime_context(context)
         with Dummy() as _handler:
-            _handler._starwhale_internal_run_cmp()
+            _handler._starwhale_internal_run_evaluate()
 
 
 class TestEvaluationLogStore(BaseTestCase):

--- a/example/cifar10/cifar/evaluator.py
+++ b/example/cifar10/cifar/evaluator.py
@@ -21,7 +21,7 @@ class CIFAR10Inference(PipelineHandler):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = self._load_model(self.device)
 
-    def ppl(self, data: dict, **kw):
+    def predict(self, data: dict, **kw):
         data_tensor = self._pre(data["image"])
         output = self.model(data_tensor)
         return self._post(output)
@@ -33,7 +33,7 @@ class CIFAR10Inference(PipelineHandler):
         show_roc_auc=True,
         all_labels=[i for i in range(0, 10)],
     )
-    def cmp(self, ppl_result):
+    def evaluate(self, ppl_result):
         result, label, pr = [], [], []
         for _data in ppl_result:
             label.append(_data["ds_data"]["label"])
@@ -85,5 +85,5 @@ class CIFAR10Inference(PipelineHandler):
             "ship",
             "truck",
         )
-        _, prob = self.ppl(Image(fp=buf.getvalue()))
+        _, prob = self.predict(Image(fp=buf.getvalue()))
         return {classes[i]: p for i, p in enumerate(prob[0])}

--- a/example/mnist/mnist/evaluator.py
+++ b/example/mnist/mnist/evaluator.py
@@ -24,7 +24,7 @@ class MNISTInference(PipelineHandler):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = self._load_model(self.device)
 
-    def ppl(self, data: t.Dict[str, t.Any], **kw: t.Any) -> t.Tuple[float, t.List[float]]:  # type: ignore
+    def predict(self, data: t.Dict[str, t.Any], **kw: t.Any) -> t.Tuple[float, t.List[float]]:  # type: ignore
         data_tensor = self._pre(data["img"])
         output = self.model(data_tensor)
         return self._post(output)
@@ -33,7 +33,7 @@ class MNISTInference(PipelineHandler):
     def upload_bin_file(self, file: t.Any) -> t.Any:
         with open(file.name, "rb") as f:
             data = Image(f.read(), shape=(28, 28, 1))
-        _, prob = self.ppl({"img": data})
+        _, prob = self.predict({"img": data})
         return {i: p for i, p in enumerate(prob)}
 
     @multi_classification(
@@ -43,7 +43,7 @@ class MNISTInference(PipelineHandler):
         show_roc_auc=True,
         all_labels=[i for i in range(0, 10)],
     )
-    def cmp(
+    def evaluate(
         self, ppl_result: t.Iterator
     ) -> t.Tuple[t.List[int], t.List[int], t.List[t.List[float]]]:
         result, label, pr = [], [], []

--- a/example/ucf101/ucf101/evaluator.py
+++ b/example/ucf101/ucf101/evaluator.py
@@ -193,7 +193,7 @@ def ppl_pre(videos: t.List[Video], sampler, transforms) -> torch.Tensor:
 
 class UCF101PipelineHandler(PipelineHandler):
     def __init__(self):
-        super().__init__(ignore_error=False, ppl_batch_size=5)
+        super().__init__(ignore_error=False, predict_batch_size=5)
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = load_model(self.device)
         self.sampler = RandomSampling()


### PR DESCRIPTION
## Description
- depends on: https://github.com/star-whale/starwhale/pull/2186
- for `PipelineHandler` Class
  -  `ppl` -> `predict`, same name as @evaluation.predict decorator
  -  `cmp` -> `evaluate`, same name as @evaluation.evaluate decorator

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
