### PR TITLE
chore(ci): disable codecov fail if error

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -146,7 +146,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: standalone-python${{matrix.python-version}}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: unittests,standalone
           verbose: true
           directory: ./client

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -85,7 +85,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: console
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: unittests,console
           verbose: true
           directory: ./console/coverage

--- a/.github/workflows/server-ut-report.yml
+++ b/.github/workflows/server-ut-report.yml
@@ -9,7 +9,6 @@ on:
       - main
 
 jobs:
-
   filter:
     runs-on: ubuntu-latest
 
@@ -50,9 +49,9 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
-          cache: 'maven'
+          java-version: "11"
+          distribution: "adopt"
+          cache: "maven"
           server-id: starwhale # Value of the distributionManagement/repository/id field of the pom.xml
 
       - name: Build with Maven
@@ -65,7 +64,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: controller-ut
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: controller
           verbose: true
           directory: ./server


### PR DESCRIPTION
## Description
codecov is not stable, so make `fail_ci_if_error=false`

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
