### PR TITLE
chore(datastore): change map resp layout and add type for null value

### DIFF
--- a/client/tests/sdk/test_data_store.py
+++ b/client/tests/sdk/test_data_store.py
@@ -13,7 +13,15 @@ from requests_mock import Mocker
 
 from starwhale.consts import HTTPMethod
 from starwhale.api._impl import data_store
-from starwhale.api._impl.data_store import INT64, ColumnSchema, TableWriterException
+from starwhale.api._impl.data_store import (
+    INT32,
+    INT64,
+    STRING,
+    SwType,
+    SwMapType,
+    ColumnSchema,
+    TableWriterException,
+)
 
 from .. import BaseTestCase
 
@@ -2360,6 +2368,22 @@ class TestScalarEncodeDecode(BaseTestCase):
             self.assertEqual(
                 tc[1], data_store.INT64.decode(tc[0]), f"INT64 encode {tc[0]} error"
             )
+
+
+def test_decode_schema_from_type_encoded_values():
+    value = {
+        "type": "MAP",
+        "value": [
+            {
+                "key": {"type": "INT32", "value": "00000001"},
+                "value": {"type": "STRING", "value": "foobar"},
+            }
+        ],
+    }
+    schema = SwType.decode_schema_from_type_encoded_value(value)
+    assert schema == SwMapType(INT32, STRING)
+    decoded = schema.decode_from_type_encoded_value(value)
+    assert decoded == {1: "foobar"}
 
 
 if __name__ == "__main__":

--- a/console/packages/starwhale-core/src/datastore/__tests__/model.test.ts
+++ b/console/packages/starwhale-core/src/datastore/__tests__/model.test.ts
@@ -17,12 +17,18 @@ describe('SwType class', () => {
     describe('decode_schema static method', () => {
         it("should return a new schema with value 'MAP' for input schema.type 'MAP'", () => {
             const schema = {
-                value: {
-                    '{type=INT64, value=1}': {
-                        type: 'STRING',
-                        value: 'bicm3c23utaujr5nvbgzwp3vmwlnhfgm3yzc2c3r',
+                value: [
+                    {
+                        key: {
+                            type: 'INT64',
+                            value: '1',
+                        },
+                        value: {
+                            type: 'STRING',
+                            value: 'bicm3c23utaujr5nvbgzwp3vmwlnhfgm3yzc2c3r',
+                        },
                     },
-                },
+                ],
                 type: 'MAP',
             }
             const expectedSchema = { '1': 'bicm3c23utaujr5nvbgzwp3vmwlnhfgm3yzc2c3r' }
@@ -94,16 +100,28 @@ describe('SwType class', () => {
                                 value: null,
                             },
                             extra_info: {
-                                value: {
-                                    '{type=STRING, value=bin_size}': {
-                                        type: 'INT64',
-                                        value: '1024',
+                                value: [
+                                    {
+                                        key: {
+                                            type: 'STRING',
+                                            value: 'bin_size',
+                                        },
+                                        value: {
+                                            type: 'INT64',
+                                            value: '1024',
+                                        },
                                     },
-                                    '{type=STRING, value=bin_offset}': {
-                                        type: 'INT64',
-                                        value: '9216',
+                                    {
+                                        key: {
+                                            type: 'STRING',
+                                            value: 'bin_offset',
+                                        },
+                                        value: {
+                                            type: 'INT64',
+                                            value: '9216',
+                                        },
                                     },
-                                },
+                                ],
                                 type: 'MAP',
                             },
                         },

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/BaseValue.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/BaseValue.java
@@ -41,6 +41,7 @@ public interface BaseValue extends Comparable<BaseValue> {
         if (value == null) {
             if (encodeWithType) {
                 var ret = new HashMap<String, Object>();
+                ret.put("type", ColumnType.UNKNOWN.name());
                 ret.put("value", null);
                 return ret;
             } else {

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/MapValue.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/MapValue.java
@@ -18,6 +18,7 @@ package ai.starwhale.mlops.datastore.type;
 
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -66,14 +67,21 @@ public class MapValue extends HashMap<BaseValue, BaseValue> implements BaseValue
 
     @Override
     public Object encode(boolean rawResult, boolean encodeWithType) {
-        var ret = new HashMap<>();
-        for (var entry : this.entrySet()) {
-            ret.put(BaseValue.encode(entry.getKey(), rawResult, encodeWithType),
-                    BaseValue.encode(entry.getValue(), rawResult, encodeWithType));
-        }
         if (encodeWithType) {
+            var ret = new ArrayList<>();
+            for (var entry : this.entrySet()) {
+                ret.add(Map.of(
+                        "key", BaseValue.encode(entry.getKey(), rawResult, true),
+                        "value", BaseValue.encode(entry.getValue(), rawResult, true)
+                ));
+            }
             return Map.of("type", this.getColumnType().name(), "value", ret);
         } else {
+            var ret = new HashMap<>();
+            for (var entry : this.entrySet()) {
+                ret.put(BaseValue.encode(entry.getKey(), rawResult, false),
+                        BaseValue.encode(entry.getValue(), rawResult, false));
+            }
             return ret;
         }
     }

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/DataStoreControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/DataStoreControllerTest.java
@@ -869,6 +869,7 @@ public class DataStoreControllerTest {
                             "b", Map.of("type", "INT32", "value", "4"),
                             "x", new HashMap<>() {
                                 {
+                                    put("type", "UNKNOWN");
                                     put("value", null);
                                 }
                             }))));

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
@@ -1437,6 +1437,7 @@ public class DataStoreTest {
     private static Object encodeValueWithType(ColumnSchema schema, Object value) {
         var ret = new HashMap<String, Object>();
         if (value == null) {
+            ret.put("type", "UNKNOWN");
             ret.put("value", null);
             return ret;
         }
@@ -1449,9 +1450,11 @@ public class DataStoreTest {
                 break;
             case MAP:
                 value = ((Map<?, ?>) value).entrySet().stream()
-                        .collect(Collectors.toMap(
-                                entry -> encodeValueWithType(schema.getKeySchema(), entry.getKey()),
-                                entry -> encodeValueWithType(schema.getValueSchema(), entry.getValue())));
+                        .map(entry -> Map.of(
+                                "key", encodeValueWithType(schema.getKeySchema(), entry.getKey()),
+                                "value", encodeValueWithType(schema.getValueSchema(), entry.getValue())))
+                        .collect(Collectors.toList());
+
                 break;
             case OBJECT:
                 ret.put("pythonType", schema.getPythonType());

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/BaseValueTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/BaseValueTest.java
@@ -444,6 +444,29 @@ public class BaseValueTest {
                 }));
         assertThat(BaseValue.encode(BaseValue.valueOf(Map.of(1, 2, 3, 4)), true, false),
                 is(Map.of("1", "2", "3", "4")));
+
+        var result = BaseValue.encode(BaseValue.valueOf(Map.of("a", 8, "b", List.of(9, 10, 11))), false, true);
+        var expected = Map.of(
+                "type", "MAP",
+                "value", List.of(
+                    Map.of(
+                        "key", Map.of("type", "STRING", "value", "a"),
+                        "value", Map.of("type", "INT32", "value", "00000008")
+                    ),
+                    Map.of(
+                        "key", Map.of("type", "STRING", "value", "b"),
+                        "value", Map.of(
+                            "type", "LIST",
+                            "value", List.of(
+                                Map.of("type", "INT32", "value", "00000009"),
+                                Map.of("type", "INT32", "value", "0000000a"),
+                                Map.of("type", "INT32", "value", "0000000b")
+                            )
+                        )
+                    )
+                )
+        );
+        assertThat(result, is(expected));
     }
 
     @Test
@@ -474,6 +497,7 @@ public class BaseValueTest {
         assertThat(BaseValue.encode(null, true, true),
                 is(new HashMap<>() {
                     {
+                        put("type", "UNKNOWN");
                         put("value", null);
                     }
                 }));
@@ -501,8 +525,10 @@ public class BaseValueTest {
                 is(Map.of("type", "TUPLE", "value", List.of(Map.of("type", "INT32", "value", "0")))));
         assertThat(BaseValue.encode(BaseValue.valueOf(Map.of("0", 0)), true, true),
                 is(Map.of("type", "MAP",
-                        "value", Map.of(Map.of("type", "STRING", "value", "0"),
-                                Map.of("type", "INT32", "value", "0")))));
+                        "value", List.of(
+                                Map.of(
+                                        "key", Map.of("type", "STRING", "value", "0"),
+                                        "value", Map.of("type", "INT32", "value", "0"))))));
         assertThat(BaseValue.encode(ObjectValue.valueOf("t", Map.of("0", 0)), true, true),
                 is(Map.of("type", "OBJECT",
                         "pythonType", "t",


### PR DESCRIPTION
## Description

- Add type `UNKNOWN` for null value
- map encode with type return value layout changed

from 
```json
{
    "type": "MAP",
    "value":
    {
        "{type=INT8, value=01}":
        {
            "type": "INT16",
            "value": "0002"
        }
    }
}
```

to 

```json
{
    "type": "MAP",
    "value":
    [
        {
            "key":
            {
                "type": "INT8",
                "value": "01"
            },
            "value":
            {
                "type": "INT16",
                "value": "0002"
            }
        }
    ]
}
```

## Modules
- [x] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
