### PR TITLE
chore(client): do not refine by default when parse uri str

### DIFF
--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -118,7 +118,6 @@ class Dataset:
             "/version/".join(filter(bool, [self._uri.name, ver])),
             typ=ResourceType.dataset,
             project=copy.deepcopy(self._uri.project),
-            _skip_refine=True,
         )
 
         if create not in (
@@ -1034,7 +1033,7 @@ class Dataset:
 
         """
         if isinstance(uri, str):
-            _uri = Resource(uri, typ=ResourceType.dataset, _skip_refine=True)
+            _uri = Resource(uri, typ=ResourceType.dataset, refine=False)
         elif isinstance(uri, Resource) and uri.typ == ResourceType.dataset:
             _uri = uri
         else:

--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -63,7 +63,9 @@ class BundleCopy(CloudRequestMixed):
         **kw: t.Any,
     ) -> None:
         self.src_uri: Resource = (
-            Resource(src_uri, typ=typ) if isinstance(src_uri, str) else src_uri
+            Resource(src_uri, typ=typ, refine=True)
+            if isinstance(src_uri, str)
+            else src_uri
         )
         if not self.src_uri.version:
             self.src_uri.version = "latest"
@@ -82,7 +84,7 @@ class BundleCopy(CloudRequestMixed):
         dest = dest_uri
         if isinstance(dest_uri, str):
             try:
-                dest = Resource(dest_uri, typ=typ, project=project, _skip_refine=True)
+                dest = Resource(dest_uri, typ=typ, project=project, refine=False)
             except Exception as e:
                 if str(e).startswith("invalid uri"):
                     dest = Project(dest_uri)
@@ -94,7 +96,7 @@ class BundleCopy(CloudRequestMixed):
                 name=self.src_uri.name,
                 typ=typ,
                 project=dest,
-                _skip_refine=True,
+                refine=False,
             )
         elif isinstance(dest, Resource):
             self.dest_uri = dest

--- a/client/starwhale/base/uri/exceptions.py
+++ b/client/starwhale/base/uri/exceptions.py
@@ -7,6 +7,11 @@ class NoMatchException(Exception):
         super().__init__(message)
 
 
+class VerifyException(Exception):
+    def __init__(self, msg: str = "") -> None:
+        super().__init__(msg)
+
+
 class UriTooShortException(Exception):
     def __init__(self, expect: int, get: int, msg: str = "") -> None:
         super().__init__(

--- a/client/starwhale/base/view.py
+++ b/client/starwhale/base/view.py
@@ -151,7 +151,6 @@ class BaseTermView(SWCliConfigMixed):
             f"{bundle_name}/version/{obj_ver}",
             project=project_uri,
             typ=typ,
-            _skip_refine=True,
         )
         console.print(f":construction_worker: uri {_uri}")
         return _uri

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -40,7 +40,7 @@ class ModelTermView(BaseTermView):
         if isinstance(model_uri, Resource):
             self.uri = model_uri
         else:
-            self.uri = Resource(model_uri, ResourceType.model)
+            self.uri = Resource(model_uri, ResourceType.model, refine=True)
         self.model = Model.get_model(self.uri)
 
     @BaseTermView._simple_action_print

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -41,7 +41,7 @@ class TestBundleCopy(TestCase):
         self._sw_config.select_current_default("local", "self")
 
     @Mocker()
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     def test_runtime_copy_c2l(self, rm: Mocker, *args: t.Any) -> None:
         version = "ge3tkylgha2tenrtmftdgyjzni3dayq"
         rm.request(
@@ -246,7 +246,7 @@ class TestBundleCopy(TestCase):
     @Mocker()
     @patch("starwhale.core.model.copy.load_yaml")
     @patch("starwhale.core.model.copy.extract_tar")
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     def test_model_copy_c2l(self, rm: Mocker, *args: MagicMock) -> None:
         version = "ge3tkylgha2tenrtmftdgyjzni3dayq"
         rm.request(
@@ -474,7 +474,7 @@ class TestBundleCopy(TestCase):
         assert head_request.call_count == 1
         assert upload_request.call_count == 3
 
-    def _prepare_local_dataset(self) -> t.Union[str, str]:
+    def _prepare_local_dataset(self) -> t.Tuple[str, str]:
         name = "mnist"
         version = "ge3tkylgha2tenrtmftdgyjzni3dayq"
         swds_path = (
@@ -518,7 +518,7 @@ class TestBundleCopy(TestCase):
 
     @Mocker()
     @patch("starwhale.core.dataset.copy.TabularDataset.scan")
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     def test_dataset_copy_c2l(self, rm: Mocker, *args: MagicMock) -> None:
         version = "ge3tkylgha2tenrtmftdgyjzni3dayq"
         rm.request(
@@ -556,7 +556,7 @@ class TestBundleCopy(TestCase):
             json={"data": {"versionMeta": yaml.safe_dump({"version": version})}},
         )
 
-        cloud_uri = (
+        cloud_uri = Resource(
             f"cloud://pre-bare/project/myproject/dataset/mnist/version/{version}"
         )
 
@@ -613,7 +613,7 @@ class TestBundleCopy(TestCase):
             ).do()
 
     @Mocker()
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.core.dataset.copy.TabularDataset.put")
     @patch("starwhale.core.dataset.copy.TabularDataset.scan")
     @patch("starwhale.core.dataset.copy.TabularDataset.delete")
@@ -645,7 +645,9 @@ class TestBundleCopy(TestCase):
             f"http://1.1.1.1:8182/api/v1/project/mnist/dataset/{name}/version/{version}/file",
             json={"data": {"uploadId": 1}},
         )
-        src_uri = f"local/project/self/mnist/version/{version}"
+        src_uri = Resource(
+            f"local/project/self/dataset/mnist/version/{version}", refine=True
+        )
         dest_uri = "cloud://pre-bare/project/mnist"
 
         head_request = rm.request(
@@ -804,7 +806,7 @@ class TestBundleCopy(TestCase):
             )
             try:
                 DatasetCopy(
-                    src_uri=case["src_uri"],
+                    src_uri=Resource(case["src_uri"], typ=ResourceType.dataset),
                     dest_uri=case["dest_uri"],
                     mode=case["mode"],
                 ).do()
@@ -861,7 +863,7 @@ class TestBundleCopy(TestCase):
         bc.do()
 
     @Mocker()
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     def test_download_bundle_file(self, rm: Mocker, *args: t.Any) -> None:
         version = "112233"
         version_name = "runtime-version"

--- a/client/tests/base/test_tag.py
+++ b/client/tests/base/test_tag.py
@@ -36,7 +36,6 @@ class StandaloneTagTestCase(TestCase):
             Resource(
                 "mnist/version/me3dmn3gg4ytanrtmftdgyjzpbrgimi",
                 typ=ResourceType.model,
-                _skip_refine=True,
             )
         )
 
@@ -73,7 +72,6 @@ class StandaloneTagTestCase(TestCase):
             Resource(
                 "mnist/version/gnstmntggi4tinrtmftdgyjzo5wwy2y",
                 typ=ResourceType.model,
-                _skip_refine=True,
             )
         )
         st.add(["latest", "test2", "test"])
@@ -95,11 +93,7 @@ class StandaloneTagTestCase(TestCase):
     def test_auto_fast_tag(self, mock_ins: MagicMock) -> None:
         mock_ins.return_value = {"type": "standalone", "uri": "local"}
         version = "me3dmn3gg4ytanrtmftdgyjzpbrgimi"
-        st = StandaloneTag(
-            Resource(
-                f"mnist/version/{version}", typ=ResourceType.model, _skip_refine=True
-            )
-        )
+        st = StandaloneTag(Resource(f"mnist/version/{version}", typ=ResourceType.model))
         assert st._get_manifest()["fast_tag_seq"] == -1
         st.add_fast_tag()
         assert st._get_manifest()["fast_tag_seq"] == 0

--- a/client/tests/base/uri/test_resource.py
+++ b/client/tests/base/uri/test_resource.py
@@ -27,7 +27,10 @@ class TestResource(TestCase):
         p.name = "self"
         p.path = ""
         r = Resource(
-            uri="mnist", typ=ResourceType.dataset, project=p, _skip_refine=True
+            uri="mnist",
+            typ=ResourceType.dataset,
+            project=p,
+            refine=False,
         )
         assert r.name == "mnist"
         assert r.typ == ResourceType.dataset
@@ -39,7 +42,6 @@ class TestResource(TestCase):
             uri="mnist/version/foo",
             typ=ResourceType.dataset,
             project=p,
-            _skip_refine=True,
         )
         assert r.name == "mnist"
         assert r.typ == ResourceType.dataset
@@ -47,7 +49,9 @@ class TestResource(TestCase):
         assert r.full_uri == "local/project/self/dataset/mnist/version/foo"
 
         r = Resource(
-            uri="foo/bar", typ=ResourceType.dataset, project=p, _skip_refine=True
+            uri="foo/bar",
+            typ=ResourceType.dataset,
+            project=p,
         )
         assert r.name == "foo"
         assert r.typ == ResourceType.dataset
@@ -59,7 +63,6 @@ class TestResource(TestCase):
                 uri="mnist/foo/bar",
                 typ=ResourceType.dataset,
                 project=p,
-                _skip_refine=True,
             )
 
     @patch("starwhale.base.uri.resource.Project.parse_from_full_uri")
@@ -67,7 +70,7 @@ class TestResource(TestCase):
         ins = mock_parse.return_value
         ins.path = "dataset/mnist/version/foo"
         uri = "local/project/self/dataset/mnist/version/foo"
-        r = Resource(uri, _skip_refine=True)
+        r = Resource(uri, refine=False)
         assert r.name == "mnist"
         assert r.version == "foo"
         assert r.typ == ResourceType.dataset
@@ -83,7 +86,7 @@ class TestResource(TestCase):
             "storage": {"root": "/root"},
         }
         uri = "local/project/self/dataset/mnist"
-        r = Resource(uri, _skip_refine=True)
+        r = Resource(uri, refine=False)
         assert r.name == "mnist"
         assert r.version == ""
         assert r.typ == ResourceType.dataset
@@ -214,7 +217,7 @@ class TestResource(TestCase):
         }
 
         for uri, expect in tests.items():
-            p = Resource(uri, typ=ResourceType.runtime, _skip_refine=True)
+            p = Resource(uri, typ=ResourceType.runtime)
             assert p.name == expect[0]
             assert p.project.name == expect[1]
             assert p.instance.alias == expect[2]
@@ -227,7 +230,7 @@ class TestResource(TestCase):
                 "local": {"uri": "local"},
             },
         }
-        uri = Resource("cloud://foo/project/starwhale/dataset/mnist", _skip_refine=True)
+        uri = Resource("cloud://foo/project/starwhale/dataset/mnist", refine=False)
         assert uri.instance.alias == "foo"
         assert uri.project.name == "starwhale"
         assert uri.typ == ResourceType.dataset
@@ -238,7 +241,7 @@ class TestResource(TestCase):
         uri = Resource(
             "cloud://foo/project/starwhale/dataset/mnist",
             typ=ResourceType.dataset,
-            _skip_refine=True,
+            refine=False,
         )
         assert uri.instance.alias == "foo"
         assert uri.project.name == "starwhale"

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -48,7 +48,7 @@ class StandaloneDatasetTestCase(TestCase):
         self.setUpPyfakefs()
         sw_config._config = {}
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.api._impl.dataset.model.Dataset.commit")
     @patch("starwhale.api._impl.dataset.model.Dataset.__setitem__")
     def test_function_handler_make_swds(
@@ -173,7 +173,7 @@ class StandaloneDatasetTestCase(TestCase):
         assert call_args[1].handler == handler_func
         assert call_args[1].attr.volume_size == D_FILE_VOLUME_SIZE
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     def test_build_workflow(self, *args: t.Any) -> None:
         class _MockBuildExecutor:
             def __iter__(self) -> t.Generator:
@@ -258,7 +258,7 @@ class StandaloneDatasetTestCase(TestCase):
         # make sure tmp dir is empty
         assert len(os.listdir(sw.rootdir / SW_TMP_DIR_NAME)) == 0
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     def test_head(self, *args: t.Any) -> None:
         from starwhale.api._impl.dataset import Dataset as SDKDataset
 
@@ -305,7 +305,7 @@ class StandaloneDatasetTestCase(TestCase):
         DatasetTermViewJson(dataset_uri).head(1, show_raw_data=False)
         DatasetTermViewJson(dataset_uri).head(2, show_raw_data=True)
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     def test_from_json(self, *args: t.Any) -> None:
         from starwhale.api._impl.dataset import Dataset as SDKDataset
 

--- a/client/tests/core/test_dataset_store.py
+++ b/client/tests/core/test_dataset_store.py
@@ -63,7 +63,7 @@ class TestDatasetBackend(TestCase):
         dataset_uri = Resource(
             "http://127.0.0.1:1234/project/self/dataset/mnist/version/1122334455667788",
             typ=ResourceType.dataset,
-            _skip_refine=True,
+            refine=False,
         )
         obj = SignedUrlBackend(dataset_uri)._make_file((Link(data_uri), 0, -1))
         assert obj.read(1) == b"a"

--- a/client/tests/core/test_eval.py
+++ b/client/tests/core/test_eval.py
@@ -81,7 +81,10 @@ class StandaloneEvaluationJobTestCase(TestCase):
         m_get.return_value = {}
         m_get_metrics.return_value = {"kind": "multi_classification"}
 
-        uri = Resource(self.job_name[:5], typ=ResourceType.job, _skip_refine=True)
+        uri = Resource(
+            self.job_name[:5],
+            typ=ResourceType.job,
+        )
         job = StandaloneJob(uri)
         info = job.info()
 
@@ -112,7 +115,6 @@ class StandaloneEvaluationJobTestCase(TestCase):
         uri = Resource(
             f"local/project/self/{ResourceType.job.value}/{self.job_name[:6]}",
             typ=ResourceType.job,
-            _skip_refine=True,
         )
         job = StandaloneJob(uri)
 
@@ -157,7 +159,6 @@ class StandaloneEvaluationJobTestCase(TestCase):
         uri = Resource(
             f"local/project/self/{ResourceType.job.value}/{self.job_name}",
             typ=ResourceType.job,
-            _skip_refine=True,
         )
         job = StandaloneJob(uri)
 
@@ -249,9 +250,7 @@ class CloudJobTestCase(TestCase):
             text=_task_list,
         )
 
-        info = CloudJob(
-            Resource(self.job_uri, typ=ResourceType.job, _skip_refine=True)
-        ).info()
+        info = CloudJob(Resource(self.job_uri, typ=ResourceType.job)).info()
         print(f"info oo :{info}")
         assert len(info["tasks"][0]) == 3
         assert info["tasks"][0][0]["taskStatus"] == "SUCCESS"
@@ -266,11 +265,11 @@ class CloudJobTestCase(TestCase):
     @Mocker()
     @patch("starwhale.core.job.view.console.print")
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     def test_actions(self, rm: Mocker, m_console: MagicMock):

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -183,8 +183,8 @@ class StandaloneRuntimeTestCase(TestCase):
             )
         )
 
-    @patch("starwhale.base.uri.resource.Resource.refine_remote_rc_info")
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_remote_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.utils.config.load_swcli_config")
     @patch("starwhale.core.runtime.model.StandaloneRuntime.restore")
     @patch("starwhale.base.bundle.extract_tar")
@@ -268,7 +268,7 @@ class StandaloneRuntimeTestCase(TestCase):
         assert m_extract.call_count == 1
         assert m_restore.call_args[0] == (extract_dir, venv_dir)
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.utils.venv.check_call")
     @patch("starwhale.core.runtime.model.guess_current_py_env")
     @patch("starwhale.core.runtime.model.get_user_python_version")
@@ -378,7 +378,7 @@ class StandaloneRuntimeTestCase(TestCase):
             "name": "starwhale",
         }
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.utils.venv.check_call")
     @patch("starwhale.core.runtime.model.guess_current_py_env")
     @patch("starwhale.core.runtime.model.get_user_python_version")
@@ -495,7 +495,7 @@ class StandaloneRuntimeTestCase(TestCase):
             "name": "test",
         }
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.utils.venv.check_call")
     @patch("starwhale.core.runtime.model.guess_current_py_env")
     @patch("starwhale.core.runtime.model.get_user_python_version")
@@ -600,7 +600,7 @@ class StandaloneRuntimeTestCase(TestCase):
             "name": "starwhale",
         }
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.utils.venv.subprocess.check_output", autospec=True)
     def test_build_from_env_exceptions(
         self, m_check_output: MagicMock, *args: t.Any
@@ -635,7 +635,7 @@ class StandaloneRuntimeTestCase(TestCase):
                 conda_name="not-found-name",
             )
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.utils.venv.check_call")
     @patch("starwhale.utils.venv.get_user_runtime_python_bin")
     @patch("starwhale.utils.venv.subprocess.check_output")
@@ -721,7 +721,7 @@ class StandaloneRuntimeTestCase(TestCase):
         self.fs.create_file(
             os.path.join(workdir, ".starwhale/lock/conda-sw-lock.yaml"), contents=""
         )
-        uri = Resource(name, typ=ResourceType.runtime, _skip_refine=True)
+        uri = Resource(name, typ=ResourceType.runtime)
         sr = StandaloneRuntime(uri)
         with self.assertRaisesRegex(
             RuntimeError, "has already been added into the runtime.yaml"
@@ -730,7 +730,7 @@ class StandaloneRuntimeTestCase(TestCase):
                 workdir=workdir, yaml_path=os.path.join(workdir, "runtime.yaml")
             )
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.utils.venv.check_call")
     @patch("starwhale.utils.venv.get_user_runtime_python_bin")
     @patch("starwhale.utils.venv.subprocess.check_output")
@@ -781,7 +781,7 @@ class StandaloneRuntimeTestCase(TestCase):
         )
         self.fs.create_file(os.path.join(workdir, "dummy.whl"), contents="")
 
-        uri = Resource(name, typ=ResourceType.runtime, _skip_refine=True)
+        uri = Resource(name, typ=ResourceType.runtime)
         sr = StandaloneRuntime(uri)
         sr.build_from_runtime_yaml(
             workdir=workdir, yaml_path=os.path.join(workdir, runtime_yaml_name)
@@ -885,7 +885,6 @@ class StandaloneRuntimeTestCase(TestCase):
         uri = Resource(
             f"{name}/version/{build_version[:6]}",
             typ=ResourceType.runtime,
-            _skip_refine=True,
         )
         sr = StandaloneRuntime(uri)
         info = sr.info()
@@ -992,7 +991,7 @@ class StandaloneRuntimeTestCase(TestCase):
         assert not os.path.exists(recover_snapshot_path)
         assert not os.path.exists(swrt_snapshot_path)
 
-        uri = Resource(name, typ=ResourceType.runtime, _skip_refine=True)
+        uri = Resource(name, typ=ResourceType.runtime)
         sr = StandaloneRuntime(uri)
         sr.build_from_runtime_yaml(
             workdir=workdir,
@@ -1051,7 +1050,7 @@ class StandaloneRuntimeTestCase(TestCase):
 
         name = "rttest"
 
-        uri = Resource(name, typ=ResourceType.runtime, _skip_refine=True)
+        uri = Resource(name, typ=ResourceType.runtime)
         sr = StandaloneRuntime(uri)
         sr.build_from_python_env(mode="conda", runtime_name=name)
         sr.info()
@@ -1153,7 +1152,7 @@ class StandaloneRuntimeTestCase(TestCase):
         ]
 
         name = "error_demo_runtime"
-        uri = Resource(name, typ=ResourceType.runtime, _skip_refine=True)
+        uri = Resource(name, typ=ResourceType.runtime, refine=False)
         sr = StandaloneRuntime(uri)
 
         m_check_call.side_effect = subprocess.CalledProcessError(
@@ -1197,7 +1196,7 @@ class StandaloneRuntimeTestCase(TestCase):
         m_py_ver.return_value = "fake.ver"
 
         name = "demo_runtime"
-        uri = Resource(name, typ=ResourceType.runtime, _skip_refine=True)
+        uri = Resource(name, typ=ResourceType.runtime)
         sr = StandaloneRuntime(uri)
         with self.assertRaisesRegex(ConfigFormatError, "only support Python"):
             sr.build_from_python_env(runtime_name=name, mode="conda")
@@ -1306,7 +1305,7 @@ class StandaloneRuntimeTestCase(TestCase):
         venv_prefix = "/bar"
         ensure_dir(venv_prefix)
         self.fs.create_file(os.path.join(venv_prefix, "pyvenv.cfg"))
-        uri = Resource(name, typ=ResourceType.runtime, _skip_refine=True)
+        uri = Resource(name, typ=ResourceType.runtime, refine=False)
         sr = StandaloneRuntime(uri)
         sr.build_from_python_env(
             runtime_name=name, mode="venv", venv_prefix=venv_prefix
@@ -1339,7 +1338,7 @@ class StandaloneRuntimeTestCase(TestCase):
 
         name = "demo_runtime"
         docker_image = "user-defined-image:latest"
-        uri = Resource(name, typ=ResourceType.runtime, _skip_refine=True)
+        uri = Resource(name, typ=ResourceType.runtime)
         sr = StandaloneRuntime(uri)
         sr.build_from_docker_image(image=docker_image, runtime_name=name)
 
@@ -1739,7 +1738,7 @@ class StandaloneRuntimeTestCase(TestCase):
             ],
         ]
 
-    @patch("starwhale.base.uri.resource.Resource.refine_local_rc_info")
+    @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     @patch("starwhale.core.runtime.model.platform.machine")
     @patch("starwhale.utils.fs.tarfile.open")
     @patch("starwhale.utils.venv.check_call")
@@ -2438,9 +2437,7 @@ class StandaloneRuntimeTestCase(TestCase):
         name = "rttest"
         version = "112233"
         image = "docker.io/t1/t2"
-        uri = Resource(
-            f"{name}/version/{version}", typ=ResourceType.runtime, _skip_refine=True
-        )
+        uri = Resource(f"{name}/version/{version}", typ=ResourceType.runtime)
         manifest = self.get_mock_manifest()
         manifest["version"] = version
         manifest["configs"]["docker"]["image"] = image
@@ -2469,9 +2466,7 @@ class StandaloneRuntimeTestCase(TestCase):
         name = "rttest"
         version = "112233"
         image = "docker.io/t1/t2"
-        uri = Resource(
-            f"{name}/version/{version}", typ=ResourceType.runtime, _skip_refine=True
-        )
+        uri = Resource(f"{name}/version/{version}", typ=ResourceType.runtime)
         manifest = self.get_mock_manifest()
         manifest["version"] = version
         manifest["configs"]["docker"]["image"] = image
@@ -2525,9 +2520,7 @@ class StandaloneRuntimeTestCase(TestCase):
         assert "--push" in build_cmd
         assert f"--file {dockerfile_path}" in build_cmd
 
-        uri = Resource(
-            f"{name}/version/{version}", typ=ResourceType.runtime, _skip_refine=True
-        )
+        uri = Resource(f"{name}/version/{version}", typ=ResourceType.runtime)
         RuntimeTermView(uri).dockerize(
             tags=("t1", "t2", "t3"),  # type: ignore
             push=False,
@@ -2569,9 +2562,7 @@ class StandaloneRuntimeTestCase(TestCase):
         ensure_dir(venv_dir)
 
         m_detect.return_value = ["zsh", "/usr/bin/zsh"]
-        uri = Resource(
-            f"{name}/version/{version}", typ=ResourceType.runtime, _skip_refine=True
-        )
+        uri = Resource(f"{name}/version/{version}", typ=ResourceType.runtime)
         StandaloneRuntime.activate(uri=uri)
         assert m_execl.call_args[0][0] == "/usr/bin/zsh"
         assert not m_extract.called
@@ -2612,9 +2603,7 @@ class StandaloneRuntimeTestCase(TestCase):
     def test_property(self) -> None:
         name = "rttest"
         version = "123"
-        uri = Resource(
-            f"{name}/version/{version}", typ=ResourceType.runtime, _skip_refine=True
-        )
+        uri = Resource(f"{name}/version/{version}", typ=ResourceType.runtime)
         rs = RuntimeStorage(uri)
 
         sw = SWCliConfigMixed()

--- a/client/tests/core/test_runtime_process.py
+++ b/client/tests/core/test_runtime_process.py
@@ -34,9 +34,7 @@ class RuntimeProcessTestCase(TestCase):
         m_call: MagicMock,
         m_mode: MagicMock,
     ) -> None:
-        uri = Resource(
-            "runtime-test/version/1234", typ=ResourceType.runtime, _skip_refine=True
-        )
+        uri = Resource("runtime-test/version/1234", typ=ResourceType.runtime)
         store = RuntimeStorage(uri)
         venv_dir = store.export_dir / "venv"
         ensure_dir(venv_dir)
@@ -100,9 +98,7 @@ class RuntimeProcessTestCase(TestCase):
         m_mode: MagicMock,
         m_conda_bin: MagicMock,
     ) -> None:
-        uri = Resource(
-            "model-test/version/1234", typ=ResourceType.model, _skip_refine=True
-        )
+        uri = Resource("model-test/version/1234", typ=ResourceType.model)
         store = ModelStorage(uri)
         conda_dir = store.packaged_runtime_export_dir / "conda"
         ensure_dir(conda_dir)
@@ -194,15 +190,9 @@ class RuntimeProcessTestCase(TestCase):
         with self.assertRaisesRegex(
             FieldTypeOrValueError, "is not a valid uri, only support"
         ):
-            Process(
-                Resource(
-                    "mnist/version/latest", typ=ResourceType.dataset, _skip_refine=True
-                )
-            ).run()
+            Process(Resource("mnist/version/latest", typ=ResourceType.dataset)).run()
 
-        uri = Resource(
-            "runtime-test/version/1234", typ=ResourceType.runtime, _skip_refine=True
-        )
+        uri = Resource("runtime-test/version/1234", typ=ResourceType.runtime)
         store = RuntimeStorage(uri)
         ensure_dir(store.export_dir / "venv")
         m_mode.return_value = "venv"

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -128,7 +128,7 @@ class TestDatasetCopy(BaseTestCase):
     @patch("os.environ", {})
     @Mocker()
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     def test_upload(self, rm: Mocker) -> None:
@@ -139,9 +139,7 @@ class TestDatasetCopy(BaseTestCase):
         swds_config = DatasetConfig(
             name=dataset_name, handler=iter_complex_annotations_swds
         )
-        dataset_uri = Resource(
-            dataset_name, typ=ResourceType.dataset, _skip_refine=True
-        )
+        dataset_uri = Resource(dataset_name, typ=ResourceType.dataset)
         sd = StandaloneDataset(dataset_uri)
         sd.build(config=swds_config)
         dataset_version = sd._version
@@ -289,7 +287,7 @@ class TestDatasetCopy(BaseTestCase):
     @patch("os.environ", {})
     @Mocker()
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     def test_download(self, rm: Mocker) -> None:
@@ -448,7 +446,6 @@ class TestDatasetCopy(BaseTestCase):
             dc = DatasetCopy(
                 src_uri=Resource(
                     f"{instance_uri}/project/{cloud_project}/dataset/{dataset_name}/version/{dataset_version}",
-                    _skip_refine=True,
                 ),
                 dest_uri="",
                 dest_local_project_uri="self",
@@ -691,7 +688,7 @@ class TestDatasetType(TestCase):
 
     @patch("starwhale.core.dataset.store.boto3.resource")
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     def test_link_standalone(self, m_boto3: MagicMock) -> None:
@@ -744,7 +741,6 @@ class TestDatasetType(TestCase):
             uri="s3://minioadmin:minioadmin@10.131.0.1:9000/users/path/to/file",
             owner=Resource(
                 "http://127.0.0.1:8081/project/test/dataset/mnist/version/latest",
-                _skip_refine=True,
             ),
         )
 
@@ -782,11 +778,11 @@ class TestDatasetSessionConsumption(TestCase):
     @patch("starwhale.utils.config.load_swcli_config")
     @patch("starwhale.core.dataset.tabular.DatastoreWrapperDataset.scan_id")
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     def test_get_consumption(self, m_scan_id: MagicMock, m_conf: MagicMock) -> None:
@@ -835,11 +831,11 @@ class TestDatasetSessionConsumption(TestCase):
 
     @patch("starwhale.core.dataset.tabular.DatastoreWrapperDataset.scan_id")
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     def test_standalone_tdsc_multi_thread(self, m_scan_id: MagicMock) -> None:
@@ -893,11 +889,11 @@ class TestDatasetSessionConsumption(TestCase):
     @patch.dict(os.environ, {})
     @patch("starwhale.utils.config.load_swcli_config")
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     def test_cloud_tdsc(self, rm: Mocker, m_conf: MagicMock) -> None:
@@ -921,7 +917,6 @@ class TestDatasetSessionConsumption(TestCase):
                     "mnist/version/latest",
                     typ=ResourceType.dataset,
                     project=Project("cloud://test/project/p"),
-                    _skip_refine=True,
                 ),
                 "",
             )
@@ -968,11 +963,11 @@ class TestDatasetSessionConsumption(TestCase):
     @patch("starwhale.utils.config.load_swcli_config")
     @patch("starwhale.core.dataset.tabular.DatastoreWrapperDataset.scan_id")
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     def test_standalone_tdsc(self, m_scan_id: MagicMock, m_conf: MagicMock) -> None:
@@ -992,7 +987,8 @@ class TestDatasetSessionConsumption(TestCase):
         with self.assertRaises(FieldTypeOrValueError):
             StandaloneTDSC(
                 dataset_uri=Resource(
-                    "mnist/version/123", typ=ResourceType.dataset, _skip_refine=True
+                    "mnist/version/123",
+                    typ=ResourceType.dataset,
                 ),
                 session_id="1",
                 batch_size=-1,
@@ -1002,7 +998,6 @@ class TestDatasetSessionConsumption(TestCase):
             StandaloneTDSC(
                 dataset_uri=Resource(
                     "http://1.1.1.1:8082/project/starwhale/dataset/mnist/version/latest",
-                    _skip_refine=True,
                 ),
                 session_id="1",
             )
@@ -1011,7 +1006,8 @@ class TestDatasetSessionConsumption(TestCase):
 
         tdsc = StandaloneTDSC(
             dataset_uri=Resource(
-                "mnist/version/123", typ=ResourceType.dataset, _skip_refine=True
+                "mnist/version/123",
+                typ=ResourceType.dataset,
             ),
             session_id="1",
             batch_size=10,
@@ -1238,7 +1234,8 @@ class TestTabularDataset(TestCase):
         m_scan.side_effect = [rows, rows, [{"id": 0, "features/value": 1}]]
         with TabularDataset.from_uri(
             Resource(
-                "mnist/version/123456", typ=ResourceType.dataset, _skip_refine=True
+                "mnist/version/123456",
+                typ=ResourceType.dataset,
             )
         ) as td:
             rs = [i for i in td.scan()]
@@ -1439,7 +1436,7 @@ class TestRotatedBinWriter(TestCase):
 
 class TestMappingDatasetBuilder(BaseTestCase):
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     def setUp(self) -> None:

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -88,7 +88,7 @@ class _DatasetSDKTestBase(BaseTestCase):
         return (Path(ROOT_DIR) / "data" / "simple.wav").read_bytes()
 
 
-@patch("starwhale.base.uri.resource.Resource.refine_local_rc_info", MagicMock())
+@patch("starwhale.base.uri.resource.Resource._refine_local_rc_info", MagicMock())
 class TestDatasetSDK(_DatasetSDKTestBase):
     def test_create_from_empty(self) -> None:
         ds = dataset("mnist")
@@ -1317,8 +1317,8 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         assert ds._dataset_builder.signature_bins_meta[0].size == 48
 
 
-@patch("starwhale.base.uri.resource.Resource.refine_local_rc_info", MagicMock())
-@patch("starwhale.base.uri.resource.Resource.refine_remote_rc_info", MagicMock())
+@patch("starwhale.base.uri.resource.Resource._refine_local_rc_info", MagicMock())
+@patch("starwhale.base.uri.resource.Resource._refine_remote_rc_info", MagicMock())
 class TestPytorch(_DatasetSDKTestBase):
     def test_skip_default_transform_without_batch(self) -> None:
         existed_ds_uri = self._init_simple_dataset_with_str_id()
@@ -1474,11 +1474,11 @@ class TestPytorch(_DatasetSDKTestBase):
         assert list(item["img"].size()) == [2, 2, 2, 3]
 
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     def test_audio_transform(self) -> None:
@@ -1618,11 +1618,11 @@ class TestTensorflow(_DatasetSDKTestBase):
             tf_dataset._inspect_spec([{"a": 1}, {"a": 2}])
 
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     def test_tf_dataset_drop_index(self) -> None:
@@ -1643,11 +1643,11 @@ class TestTensorflow(_DatasetSDKTestBase):
         assert len(items) == len(ds)
 
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     def test_tf_dataset_with_index(self) -> None:

--- a/client/tests/sdk/test_evaluation.py
+++ b/client/tests/sdk/test_evaluation.py
@@ -97,7 +97,8 @@ class TestModelPipelineHandler(TestCase):
 
         _loader = get_data_loader(
             dataset_uri=Resource(
-                "mnist/version/latest", typ=ResourceType.dataset, _skip_refine=True
+                "mnist/version/latest",
+                typ=ResourceType.dataset,
             ),
         )
         assert isinstance(_loader, DataLoader)
@@ -156,11 +157,11 @@ class TestModelPipelineHandler(TestCase):
     @patch("starwhale.api._impl.wrapper.Evaluation.log_result")
     @patch("starwhale.core.dataset.model.StandaloneDataset.summary")
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     def test_ppl(
@@ -187,7 +188,10 @@ class TestModelPipelineHandler(TestCase):
         m_ds_info.return_value = TabularDatasetInfo(mapping={"id": 0, "value": 1})
 
         datastore_dir = DatasetStorage(
-            Resource(self.dataset_uri_raw, typ=ResourceType.dataset, _skip_refine=True)
+            Resource(
+                self.dataset_uri_raw,
+                typ=ResourceType.dataset,
+            )
         )
         data_dir = datastore_dir.data_dir
         ensure_dir(data_dir)
@@ -218,11 +222,11 @@ class TestModelPipelineHandler(TestCase):
     @patch("starwhale.core.dataset.tabular.DatastoreWrapperDataset.scan")
     @patch("starwhale.core.dataset.model.StandaloneDataset.summary")
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_remote_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_remote_rc_info",
         MagicMock(),
     )
     @patch(
-        "starwhale.base.uri.resource.Resource.refine_local_rc_info",
+        "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
     def test_deserializer(
@@ -288,7 +292,10 @@ class TestModelPipelineHandler(TestCase):
         m_scan_id.return_value = [{"id": 0}]
 
         datastore_dir = DatasetStorage(
-            Resource(self.dataset_uri_raw, typ=ResourceType.dataset, _skip_refine=True)
+            Resource(
+                self.dataset_uri_raw,
+                typ=ResourceType.dataset,
+            )
         )
         ensure_file(datastore_dir.manifest_path, "", parents=True)
 
@@ -370,9 +377,7 @@ class TestModelPipelineHandler(TestCase):
             DummyWithOnlyVarPositional,
         ]
         Context.set_runtime_context(Context(version="123", project="test"))
-        uri = Resource(
-            "mnist/version/123456", typ=ResourceType.dataset, _skip_refine=True
-        )
+        uri = Resource("mnist/version/123456", typ=ResourceType.dataset, refine=False)
         for h in handlers:
             h()._do_predict(
                 data=DataRow._Features({"label": 1}),

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -37,7 +37,6 @@ class TestDataLoader(TestCase):
         self.dataset_uri = Resource(
             "mnist/version/1122334455667788",
             typ=ResourceType.dataset,
-            _skip_refine=True,
         )
         self.swds_dir = os.path.join(ROOT_DIR, "data", "dataset", "swds")
         self.fs.add_real_directory(self.swds_dir)
@@ -334,7 +333,7 @@ class TestDataLoader(TestCase):
         dataset_uri = Resource(
             f"http://127.0.0.1:1234/project/self/dataset/mnist/version/{version}",
             typ=ResourceType.dataset,
-            _skip_refine=True,
+            refine=False,
         )
 
         os.environ[SWEnv.instance_token] = "123"
@@ -516,7 +515,6 @@ class TestDataLoader(TestCase):
         dataset_uri = Resource(
             "http://localhost/projects/x/datasets/mnist/versions/1122",
             typ=ResourceType.dataset,
-            _skip_refine=True,
         )
         m_scan_batch.return_value = [
             [

--- a/scripts/client_test/cmds/artifacts_cmd.py
+++ b/scripts/client_test/cmds/artifacts_cmd.py
@@ -190,7 +190,9 @@ class Runtime(BaseArtifact):
             config.name,
             "--no-cache",
         ]
-        ret_code, res = invoke(cmd, external_env={_ENV_FIXED_VERSION: version})
+        ret_code, res = invoke(
+            cmd, external_env={_ENV_FIXED_VERSION: version}, log=True
+        )
         assert ret_code == 0, res
         return Resource(f"{config.name}/version/{version}", typ=ResourceType.runtime)
 


### PR DESCRIPTION
## Description

- Suppress the exception when refining the URI
- Do not set the resource version to `latest` when no version specified

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
