### PR TITLE
chore(runtime): add pip compatible dependencies check for runtime build from existed env

### DIFF
--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -699,6 +699,11 @@ def get_python_version() -> str:
     return f"{sys.version_info.major}.{sys.version_info.minor}"
 
 
+def pip_compatible_dependencies_check(py_bin: t.Optional[str] = None) -> None:
+    py_bin = py_bin or sys.executable
+    check_call([py_bin, "-m", "pip", "check"])
+
+
 def get_python_version_by_bin(py_bin: str) -> str:
     console.info(f"{py_bin}: python version")
     output = subprocess.check_output(


### PR DESCRIPTION
## Description
related: https://github.com/star-whale/starwhale/issues/2202

![image](https://github.com/star-whale/starwhale/assets/590748/20a6ec5c-951f-4024-ad19-829d48103192)

Runtime build from the existed env(conda/venv/shell) should make the pip nstalled packages compatible dependencies.

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
