### PR TITLE
fix(client): web for job info works

### DIFF
--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -101,7 +101,7 @@ class BundleCopy(CloudRequestMixed):
         else:
             raise Exception("invalid dest_uri")  # this can not happen
 
-        if not self.dest_uri.version:
+        if not self.dest_uri.version or self.dest_uri.version == "latest":
             self.dest_uri.version = self.src_uri.version
         if self.dest_uri.version == "latest":
             self.dest_uri.version = ""

--- a/client/starwhale/core/job/view.py
+++ b/client/starwhale/core/job/view.py
@@ -92,7 +92,7 @@ class JobTermView(BaseTermView):
             # TODO support changing host and port
             host = "127.0.0.1"
             port = 8000
-            url = f"http://{host}:{port}/projects/{self.uri.project}/evaluations/{ver}/results?token=local"
+            url = f"http://{host}:{port}/projects/{self.uri.project.name}/evaluations/{ver}/results?token=local"
             console.print(f":tea: open {url} in browser")
             import uvicorn
 

--- a/client/starwhale/web/project.py
+++ b/client/starwhale/web/project.py
@@ -7,7 +7,7 @@ router = APIRouter()
 prefix = "project"
 
 project = {
-    "id": "1",
+    "id": "self",
     "name": "self",
     "privacy": "PRIVATE",
     "createdTime": 0,

--- a/client/tests/web/test_server.py
+++ b/client/tests/web/test_server.py
@@ -59,12 +59,12 @@ def test_datastore_list_tables(root: MagicMock, tmpdir: Path):
     assert resp.status_code == 200
     assert resp.json()["data"]["tables"] == []
 
-    ensure_file(tmpdir / "a" / "foo.bin", b"", parents=True)
-    ensure_file(tmpdir / "b" / "c" / "foo.bin", b"", parents=True)
+    ensure_file(tmpdir / "a" / "foo.sw-datastore.zip", b"", parents=True)
+    ensure_file(tmpdir / "b" / "c" / "foo.sw-datastore.zip", b"", parents=True)
 
     resp = client.post("/api/v1/datastore/listTables", content='{"prefix": ""}')
     assert resp.status_code == 200
-    assert set(resp.json()["data"]["tables"]) == {"a", "b/c"}
+    assert set(resp.json()["data"]["tables"]) == {"a/foo", "b/c/foo"}
 
 
 @patch("starwhale.api._impl.data_store.LocalDataStore.scan_tables")

--- a/console/src/components/BaseNavTabs.tsx
+++ b/console/src/components/BaseNavTabs.tsx
@@ -23,6 +23,9 @@ export function BaseNavTabs({ navItems, fill = 'intrinsic', tabsOverrides, tabOv
     const history = useHistory()
     const [, theme] = themedUseStyletron()
     const { activeItemPath } = useRouterActivePath(navItems)
+    if (!navItems || navItems.length === 0) {
+        return null
+    }
 
     return (
         <Tabs

--- a/console/src/hooks/useRouterActivePath.ts
+++ b/console/src/hooks/useRouterActivePath.ts
@@ -20,6 +20,14 @@ export function useRouterActivePath(navItems: any[]) {
         return $item?.url.pathname.split('/')
     }, [$item])
 
+    if (!paths) {
+        return {
+            item: null,
+            activeItemPath: null,
+            activeItemId: null,
+        }
+    }
+
     return {
         item: $item,
         activeItemPath: $item.path,

--- a/console/src/pages/Evaluation/EvaluationWidgetResults.tsx
+++ b/console/src/pages/Evaluation/EvaluationWidgetResults.tsx
@@ -259,6 +259,7 @@ function EvaluationWidgetResults() {
             return
         }
         fetchPanelSetting(projectId, storeKey).then((data) => {
+            if (!data) return
             // try simplified version for standalone usage
             const parsed = tryParseSimplified(JSON.parse(data)) ?? data
             const layout = { name: 'custom', content: parsed, label: t('panel.view.config.custom') }


### PR DESCRIPTION
## Description

- Fix generated URI for web browser
- Support `encodeWithType` and `rawResult` param in local fake server

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
