### PR TITLE
fix(client): parse full uri with type hint failed

### DIFF
--- a/client/starwhale/base/uri/resource.py
+++ b/client/starwhale/base/uri/resource.py
@@ -136,6 +136,7 @@ class Resource:
         :param uri:
             i.e.
             * mnist
+            * dataset/mnist
             * mnist/latest
             * version/latest
             * mnist/version/latest
@@ -144,6 +145,9 @@ class Resource:
         parts = uri.split("/")
         if len(parts) > 3:
             raise Exception(f"invalid uri {uri} when parse with type {typ}")
+
+        if parts[0] == typ.value:
+            parts = parts[1:]
 
         if len(parts) == 1:
             try:

--- a/client/tests/base/uri/test_resource.py
+++ b/client/tests/base/uri/test_resource.py
@@ -218,3 +218,30 @@ class TestResource(TestCase):
             assert p.name == expect[0]
             assert p.project.name == expect[1]
             assert p.instance.alias == expect[2]
+
+    @patch("starwhale.utils.config.load_swcli_config")
+    def test_remote_uri_with_type_part(self, m_conf: MagicMock) -> None:
+        m_conf.return_value = {
+            "instances": {
+                "foo": {"uri": "https://foo.com"},
+                "local": {"uri": "local"},
+            },
+        }
+        uri = Resource("cloud://foo/project/starwhale/dataset/mnist", _skip_refine=True)
+        assert uri.instance.alias == "foo"
+        assert uri.project.name == "starwhale"
+        assert uri.typ == ResourceType.dataset
+        assert uri.name == "mnist"
+        assert uri.version == ""
+
+        # specify type argument
+        uri = Resource(
+            "cloud://foo/project/starwhale/dataset/mnist",
+            typ=ResourceType.dataset,
+            _skip_refine=True,
+        )
+        assert uri.instance.alias == "foo"
+        assert uri.project.name == "starwhale"
+        assert uri.typ == ResourceType.dataset
+        assert uri.name == "mnist"
+        assert uri.version == ""


### PR DESCRIPTION
## Description

Fixes #2222

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
