### PR TITLE
chore(client): ignore conda env by default when building model

### DIFF
--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -769,7 +769,7 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
         Args:
             workdir: source code dir
             model_config: model config
-            add_all: copy all files, include python cache files(defined in BuiltinPyExcludes) and venv files
+            add_all: copy all files, include python cache files(defined in BuiltinPyExcludes) and venv or conda files
         Returns: None
         """
         console.print(
@@ -791,7 +791,7 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
             src_dir=workdir.resolve(),
             dst_dir=self.store.src_dir.resolve(),
             excludes=excludes,
-            ignore_venv=not add_all,
+            ignore_venv_or_conda=not add_all,
         )
         for i in ignored:
             console.info(f"ignored : {str(i)}")

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -744,11 +744,13 @@ def get_user_runtime_python_bin(py_env: str) -> str:
 
 
 def check_valid_venv_prefix(prefix: t.Union[str, Path]) -> bool:
-    return (Path(prefix) / "pyvenv.cfg").exists()
+    expect = Path(prefix) / "pyvenv.cfg"
+    return expect.exists() and expect.is_file()
 
 
 def check_valid_conda_prefix(prefix: t.Union[str, Path]) -> bool:
-    return (Path(prefix) / "conda-meta").exists()
+    expect = Path(prefix) / "conda-meta"
+    return expect.exists() and expect.is_dir()
 
 
 def guess_python_env_mode(prefix: t.Union[str, Path]) -> str:

--- a/client/tests/base/test_store.py
+++ b/client/tests/base/test_store.py
@@ -43,32 +43,50 @@ def test_local_file_object_store(
     workdir = tmp_path / "workdir"
     venv = workdir / "venv"
     # simulate a venv in the working dir
-    (venv / "bin").mkdir(parents=True)
-    (venv / "bin" / "python").touch()
-    (venv / "bin" / "activate").touch()
+    venv.mkdir(parents=True, exist_ok=True)
+    (venv / "pyvenv.cfg").touch()
+    # simulate a conda env in the working dir
+    conda = workdir / "conda"
+    conda.mkdir(parents=True, exist_ok=True)
+    (conda / "conda-meta").mkdir(parents=True, exist_ok=True)
+    # make a fake file in the conda meta dir, make sure the copy touches the dir
+    (conda / "conda-meta" / "fake").touch()
+
     # user script
     (workdir / "main.py").touch()
 
-    venv_files = {
-        dst / "venv" / "bin",
-        dst / "venv" / "bin" / "python",
-        dst / "venv" / "bin" / "activate",
+    env_files = {
+        dst / "venv",
+        dst / "venv" / "pyvenv.cfg",
+        dst / "conda",
+        dst / "conda" / "conda-meta",
+        dst / "conda" / "conda-meta" / "fake",
     }
 
     shutil.rmtree(dst)
-    # do not ignore venv
-    store.copy_dir(workdir, dst, [], ignore_venv=False)
+    # do not ignore env paths
+    sz, ignores = store.copy_dir(workdir, dst, [], ignore_venv_or_conda=False)
     assert (dst / "main.py").exists()
-    assert all(f.exists() for f in venv_files)
+    assert all(f.exists() for f in env_files)
+    assert sz == (dst / "main.py").stat().st_size + sum(
+        f.stat().st_size for f in [venv / "pyvenv.cfg", conda / "conda-meta" / "fake"]
+    )
+    assert ignores == []
 
     shutil.rmtree(dst)
-    # ignore venv
-    store.copy_dir(workdir, dst, [], ignore_venv=True)
+    # ignore env paths
+    sz, ignores = store.copy_dir(workdir, dst, [], ignore_venv_or_conda=True)
     assert (dst / "main.py").exists()
-    assert not any(f.exists() for f in venv_files)
+    assert not any(f.exists() for f in env_files)
+    assert sz == (dst / "main.py").stat().st_size
+    assert set(ignores) == {venv, conda}
 
     shutil.rmtree(dst)
-    # ignore venv with exclude
-    store.copy_dir(workdir, dst, ["venv/*"], ignore_venv=False)
+    # ignore env paths with exclude
+    sz, ignores = store.copy_dir(
+        workdir, dst, ["venv/*", "conda/*"], ignore_venv_or_conda=False
+    )
     assert (dst / "main.py").exists()
-    assert not any(f.exists() for f in venv_files)
+    assert not any(f.exists() for f in env_files)
+    assert sz == (dst / "main.py").stat().st_size
+    assert set(ignores) == {venv / "pyvenv.cfg", conda / "conda-meta" / "fake"}

--- a/client/tests/core/test_runtime_process.py
+++ b/client/tests/core/test_runtime_process.py
@@ -136,7 +136,7 @@ class RuntimeProcessTestCase(TestCase):
 
         m_restore.reset_mock()
         m_extract.reset_mock()
-        ensure_file(conda_dir / "conda-meta", "")
+        ensure_file(conda_dir / "conda-meta" / "fake", "", parents=True)
 
         with patch.object(sys, "argv", run_argv):
             p = Process(uri, force_restore=False)


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
