### PR TITLE
fix(datastore): fix faking object response of encoded type value

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -645,16 +645,21 @@ class SwObjectType(SwCompositeType):
 
     def encode_type_encoded_value(self, value: Any, raw_value: bool = False) -> Any:
         if value is None:
-            return {"type": str(self), "value": None}
-        if isinstance(value, dict):
+            return {"type": "OBJECT", "value": None}
+        if isinstance(value, self.raw_type):
             return {
                 "type": "OBJECT",
+                "pythonType": "LINK"
+                if self.raw_type is Link
+                else self.raw_type.__module__ + "." + self.raw_type.__name__,
                 "value": {
                     k: self.attrs[k].encode_type_encoded_value(v, raw_value)
-                    for k, v in value.items()
+                    for k, v in value.__dict__.items()
                 },
             }
-        raise RuntimeError(f"value should be a dict: {value}")
+        raise RuntimeError(
+            f"value should be of type {self.raw_type.__name__}, but is {value}"
+        )
 
     def decode_from_type_encoded_value(self, value: Any) -> Any:
         value = value["value"]

--- a/client/tests/web/test_server.py
+++ b/client/tests/web/test_server.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock, PropertyMock
 import httpx
 from fastapi.testclient import TestClient
 
+from starwhale import Link
 from starwhale.utils.fs import ensure_file
 from starwhale.web.server import Server
 from starwhale.base.uri.instance import Instance
@@ -90,6 +91,7 @@ def test_datastore_query_table(mock_scan: MagicMock):
             "f": [1, 2, 3],
             "g": (4, 5, 6),
             "h": {"i": 7},
+            "i": Link("foo"),
         }
     ]
     resp = client.post(
@@ -110,6 +112,27 @@ def test_datastore_query_table(mock_scan: MagicMock):
             "valueType": {"type": "INT64"},
             "type": "MAP",
         },
+        {
+            "name": "i",
+            "pythonType": "starwhale.core.dataset.type.Link",
+            "type": "OBJECT",
+            "attributes": [
+                {"name": "_type", "type": "STRING"},
+                {"name": "owner", "type": "UNKNOWN"},
+                {"name": "uri", "type": "STRING"},
+                {"name": "scheme", "type": "STRING"},
+                {"name": "offset", "type": "INT64"},
+                {"name": "size", "type": "INT64"},
+                {"name": "data_type", "type": "UNKNOWN"},
+                {"name": "_signed_uri", "type": "STRING"},
+                {
+                    "keyType": {"type": "UNKNOWN"},
+                    "name": "extra_info",
+                    "type": "MAP",
+                    "valueType": {"type": "UNKNOWN"},
+                },
+            ],
+        },
     ]
     assert resp.json()["data"]["records"] == [
         {
@@ -121,6 +144,7 @@ def test_datastore_query_table(mock_scan: MagicMock):
             "f": "[1, 2, 3]",
             "g": "(4, 5, 6)",
             "h": "{'i': 7}",
+            "i": "Link foo",
         }
     ]
 
@@ -147,6 +171,26 @@ def test_datastore_query_table(mock_scan: MagicMock):
             "keyType": {"type": "STRING"},
             "valueType": {"type": "INT64"},
             "type": "MAP",
+        },
+        "i": {
+            "attributes": [
+                {"name": "_type", "type": "STRING"},
+                {"name": "owner", "type": "UNKNOWN"},
+                {"name": "uri", "type": "STRING"},
+                {"name": "scheme", "type": "STRING"},
+                {"name": "offset", "type": "INT64"},
+                {"name": "size", "type": "INT64"},
+                {"name": "data_type", "type": "UNKNOWN"},
+                {"name": "_signed_uri", "type": "STRING"},
+                {
+                    "keyType": {"type": "UNKNOWN"},
+                    "name": "extra_info",
+                    "type": "MAP",
+                    "valueType": {"type": "UNKNOWN"},
+                },
+            ],
+            "pythonType": "starwhale.core.dataset.type.Link",
+            "type": "OBJECT",
         },
     }
     assert resp.json()["data"]["records"] == [
@@ -180,6 +224,21 @@ def test_datastore_query_table(mock_scan: MagicMock):
                         "value": {"type": "INT64", "value": "7"},
                     },
                 ],
+            },
+            "i": {
+                "type": "OBJECT",
+                "pythonType": "starwhale.core.dataset.type.Link",
+                "value": {
+                    "_signed_uri": {"type": "STRING", "value": ""},
+                    "_type": {"type": "STRING", "value": "link"},
+                    "data_type": {"type": "UNKNOWN", "value": "None"},
+                    "extra_info": {"type": "MAP", "value": []},
+                    "offset": {"type": "INT64", "value": "0"},
+                    "owner": {"type": "UNKNOWN", "value": "None"},
+                    "scheme": {"type": "STRING", "value": ""},
+                    "size": {"type": "INT64", "value": "-1"},
+                    "uri": {"type": "STRING", "value": "foo"},
+                },
             },
         }
     ]


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
