### PR TITLE
enhance(client): tune copy dir performance without recording ignored files

### DIFF
--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -787,14 +787,12 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
         console.debug(
             f"copy dir: {workdir} -> {self.store.src_dir}, excludes: {excludes}"
         )
-        total_size, ignored = self._object_store.copy_dir(
+        total_size = self._object_store.copy_dir(
             src_dir=workdir.resolve(),
             dst_dir=self.store.src_dir.resolve(),
             excludes=excludes,
             ignore_venv_or_conda=not add_all,
         )
-        for i in ignored:
-            console.info(f"ignored : {str(i)}")
         console.print(
             f":file_folder: source code files size: {pretty_bytes(total_size)}"
         )

--- a/client/tests/base/test_store.py
+++ b/client/tests/base/test_store.py
@@ -65,28 +65,28 @@ def test_local_file_object_store(
 
     shutil.rmtree(dst)
     # do not ignore env paths
-    sz, ignores = store.copy_dir(workdir, dst, [], ignore_venv_or_conda=False)
+    sz = store.copy_dir(workdir, dst, [], ignore_venv_or_conda=False)
     assert (dst / "main.py").exists()
     assert all(f.exists() for f in env_files)
     assert sz == (dst / "main.py").stat().st_size + sum(
         f.stat().st_size for f in [venv / "pyvenv.cfg", conda / "conda-meta" / "fake"]
     )
-    assert ignores == []
 
     shutil.rmtree(dst)
     # ignore env paths
-    sz, ignores = store.copy_dir(workdir, dst, [], ignore_venv_or_conda=True)
+    sz = store.copy_dir(workdir, dst, [], ignore_venv_or_conda=True)
     assert (dst / "main.py").exists()
     assert not any(f.exists() for f in env_files)
     assert sz == (dst / "main.py").stat().st_size
-    assert set(ignores) == {venv, conda}
+    ignored = (dst / "venv", dst / "conda" / "conda-meta")
+    assert all(not f.exists() for f in ignored)
 
     shutil.rmtree(dst)
     # ignore env paths with exclude
-    sz, ignores = store.copy_dir(
-        workdir, dst, ["venv/*", "conda/*"], ignore_venv_or_conda=False
-    )
+    sz = store.copy_dir(workdir, dst, ["venv/*", "conda/*"], ignore_venv_or_conda=False)
     assert (dst / "main.py").exists()
     assert not any(f.exists() for f in env_files)
     assert sz == (dst / "main.py").stat().st_size
-    assert set(ignores) == {venv / "pyvenv.cfg", conda / "conda-meta" / "fake"}
+    assert dst / "venv"
+    ignored = (dst / "venv" / "pyvenv.cfg", dst / "conda" / "conda-meta" / "fake")
+    assert all(not f.exists() for f in ignored)

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -112,7 +112,7 @@ class StandaloneModelTestCase(TestCase):
         m_stat.return_value.st_size = 1
         m_blake_file.return_value = "123456"
         m_walker_files.return_value = []
-        m_copy_dir.return_value = (0, [])
+        m_copy_dir.return_value = 0
 
         svc = MagicMock(spec=Service)
         svc.get_spec.return_value = {}


### PR DESCRIPTION
## Description
For speech_command examples:
- previous: 1h
```
[2023-05-16 01:06:02.531850] 🔈 |DEBUG| cmd: ['swcli', 'project', 'select', 'self'], env: None
[2023-05-16 01:06:03.773885] 🔈 |DEBUG| cmd: ['swcli', 'model', 'build', '/starwhale/example/speech_command', '--name', 'speech_command'], env: {'SW_BUILD_BUNDLE_FIXED_VERSION_FOR_TEST': 'jhbt3dz673di6plwrpz5vng6xgmmgm5srjbepmgn'}
[2023-05-16 02:06:06.130374] 🔈 |DEBUG| cmd: ['swcli', 'model', 'copy', 'local/project/self/model/speech_command/version/jhbt3dz673di6plwrpz5vng6xgmmgm5srjbepmgn', 'cloud://server/project/starwhale', '--force'], env: None
```
- current: 14s
```console
❯ time swcli -vvv model build .
[2023-05-16 09:59:28.245063] 👾 verbosity: 3, log level: DEBUG
[2023-05-16 09:59:28.248410] 🚧 start to build ResourceType.model bundle...
[2023-05-16 09:59:28.249808] ❓ |WARN| refine resource speech_command/version/jjysepwdelz6ioaoh77iqd5tf6cfy7wvduvi2zpg failed: Can not find the exact match item jjysepwdelz6ioaoh77iqd5tf6cfy7wvduvi2zpg, found: []
[2023-05-16 09:59:28.250460] 👷 uri local/project/self/model/speech_command/version/jjysepwdelz6ioaoh77iqd5tf6cfy7wvduvi2zpg
[2023-05-16 09:59:28.252271] 🔈 |DEBUG| 🆕 version jjysepwdelz6
[2023-05-16 09:59:28.252791] 📁 workdir: /home/tianwei/.starwhale/.tmp/tmp21a6gv47
[2023-05-16 09:59:28.253143] 🦚 copy source code files: . -> /home/tianwei/.starwhale/.tmp/tmp21a6gv47/src
[2023-05-16 09:59:28.253502] 🔈 |DEBUG| copy dir: . -> /home/tianwei/.starwhale/.tmp/tmp21a6gv47/src, excludes: ['venv/*', '.git/*', '.history*', '.vscode/*', '.venv/*', 'data/*', '.idea/*', '*.py', '__pycache__/', '*.py', '*$py.class']
[2023-05-16 09:59:34.354226] 📁 source code files size: 79.12KB
[2023-05-16 09:59:34.355493] 🚀 generate jobs yaml from modules: ['sc.evaluator'] , package rootdir: .
[2023-05-16 09:59:41.604479] 💡 |INFO| 🧺 resource files size: 83.99KB
[2023-05-16 09:59:41.731024] 💯 finish gen resource @ /home/tianwei/.starwhale/self/model/speech_command/jj/jjysepwdelz6ioaoh77iqd5tf6cfy7wvduvi2zpg.swmp
swcli -vvv model build .  9.85s user 3.32s system 88% cpu 14.913 total
  ``` 

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
