### PR TITLE
fix(sdk): change the default id format for predict result

### DIFF
--- a/client/starwhale/api/_impl/evaluation.py
+++ b/client/starwhale/api/_impl/evaluation.py
@@ -222,7 +222,13 @@ class PipelineHandler(metaclass=ABCMeta):
             ds.make_distributed_consumption(session_id=self.context.version)
             dataset_info = ds.info
             cnt = 0
-            idx_prefix = _uri.info().get("id") or _uri.name
+            if _uri.instance.is_local:
+                idx_prefix = f"{_uri.project.name}_{_uri.name}"
+            else:
+                print(f"url:{uri_str}, r info:{_uri.info()}")
+                idx_prefix = _uri.info().get("id")
+                if not idx_prefix:
+                    raise KeyError("fetch dataset id error")
             for rows in ds.batch_iter(self.predict_batch_size):
                 _start = time.time()
                 _exception = None

--- a/client/starwhale/api/_impl/evaluation.py
+++ b/client/starwhale/api/_impl/evaluation.py
@@ -224,7 +224,6 @@ class PipelineHandler(metaclass=ABCMeta):
             if _uri.instance.is_local:
                 idx_prefix = f"{_uri.project.name}_{_uri.name}"
             else:
-                print(f"url:{uri_str}, r info:{_uri.info()}")
                 idx_prefix = _uri.info().get("id")
                 if not idx_prefix:
                     raise KeyError("fetch dataset id error")

--- a/client/starwhale/api/_impl/evaluation.py
+++ b/client/starwhale/api/_impl/evaluation.py
@@ -222,7 +222,7 @@ class PipelineHandler(metaclass=ABCMeta):
             ds.make_distributed_consumption(session_id=self.context.version)
             dataset_info = ds.info
             cnt = 0
-            idx_prefix = f"{_uri.name}-{_uri.version[:SHORT_VERSION_CNT]}"
+            idx_prefix = _uri.info().get("id") or _uri.name
             for rows in ds.batch_iter(self.predict_batch_size):
                 _start = time.time()
                 _exception = None

--- a/client/starwhale/api/_impl/evaluation.py
+++ b/client/starwhale/api/_impl/evaluation.py
@@ -224,9 +224,10 @@ class PipelineHandler(metaclass=ABCMeta):
             if _uri.instance.is_local:
                 idx_prefix = f"{_uri.project.name}_{_uri.name}"
             else:
-                idx_prefix = _uri.info().get("id")
-                if not idx_prefix:
+                r_id = _uri.info().get("id")
+                if not r_id:
                     raise KeyError("fetch dataset id error")
+                idx_prefix = str(r_id)
             for rows in ds.batch_iter(self.predict_batch_size):
                 _start = time.time()
                 _exception = None

--- a/client/starwhale/api/_impl/evaluation.py
+++ b/client/starwhale/api/_impl/evaluation.py
@@ -16,7 +16,6 @@ from starwhale.utils import console, now_str
 from starwhale.consts import (
     RunStatus,
     CURRENT_FNAME,
-    SHORT_VERSION_CNT,
     DecoratorInjectAttr,
 )
 from starwhale.utils.fs import ensure_dir, ensure_file

--- a/client/starwhale/api/_impl/evaluation.py
+++ b/client/starwhale/api/_impl/evaluation.py
@@ -13,11 +13,7 @@ import dill
 import jsonlines
 
 from starwhale.utils import console, now_str
-from starwhale.consts import (
-    RunStatus,
-    CURRENT_FNAME,
-    DecoratorInjectAttr,
-)
+from starwhale.consts import RunStatus, CURRENT_FNAME, DecoratorInjectAttr
 from starwhale.utils.fs import ensure_dir, ensure_file
 from starwhale.api._impl import wrapper
 from starwhale.base.type import RunSubDirType, PredictLogMode
@@ -222,7 +218,8 @@ class PipelineHandler(metaclass=ABCMeta):
             dataset_info = ds.info
             cnt = 0
             if _uri.instance.is_local:
-                idx_prefix = f"{_uri.project.name}_{_uri.name}"
+                # avoid confusion with underscores in project names
+                idx_prefix = f"{_uri.project.name}/{_uri.name}"
             else:
                 r_id = _uri.info().get("id")
                 if not r_id:

--- a/client/tests/sdk/test_evaluation.py
+++ b/client/tests/sdk/test_evaluation.py
@@ -424,7 +424,7 @@ class TestModelPipelineHandler(TestCase):
                 _handler._starwhale_internal_run_predict()
 
             log_result = m_log_result.call_args[0][0]
-            assert log_result["id"].startswith("self_mnist_")
+            assert log_result["id"].startswith("self/mnist_")
             assert log_result["_mode"] == "plain"
             assert log_result["_index"] == 0
             assert log_result["output"] == {"result": "ok"}

--- a/client/tests/sdk/test_evaluation.py
+++ b/client/tests/sdk/test_evaluation.py
@@ -340,7 +340,7 @@ class TestModelPipelineHandler(TestCase):
                 _handler._starwhale_internal_run_predict()
 
             log_result = m_log_result.call_args[0][0]
-            assert log_result["id"].startswith("mnist-")
+            assert log_result["id"].startswith("mnist_")
             assert log_result["_mode"] == "plain"
             assert log_result["_index"] == 0
             assert log_result["output"] == {"result": "ok"}

--- a/client/tests/sdk/test_evaluation.py
+++ b/client/tests/sdk/test_evaluation.py
@@ -26,7 +26,6 @@ from starwhale.utils.retry import http_retry
 from starwhale.base.context import Context, pass_context
 from starwhale.core.job.store import JobStorage
 from starwhale.base.uri.project import Project
-from starwhale.base.uri.instance import Instance
 from starwhale.base.uri.resource import Resource, ResourceType
 from starwhale.core.dataset.type import Link, DatasetSummary, GrayscaleImage
 from starwhale.core.dataset.store import ObjectStore, DatasetStorage

--- a/client/tests/sdk/test_evaluation.py
+++ b/client/tests/sdk/test_evaluation.py
@@ -6,22 +6,27 @@ import uuid
 import errno
 import shutil
 import typing as t
+import tempfile
+from http import HTTPStatus
 from pathlib import Path
 from contextlib import contextmanager
 from unittest.mock import patch, MagicMock
 
 import dill
 import jsonlines
+import requests_mock
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from starwhale.utils import gen_uniq_version
-from starwhale.consts import DEFAULT_PROJECT
+from starwhale.consts import HTTPMethod, ENV_POD_NAME, DEFAULT_PROJECT
 from starwhale.utils.fs import ensure_dir, ensure_file
 from starwhale.base.type import RunSubDirType
 from starwhale.utils.error import ParameterError
 from starwhale.utils.retry import http_retry
 from starwhale.base.context import Context, pass_context
 from starwhale.core.job.store import JobStorage
+from starwhale.base.uri.project import Project
+from starwhale.base.uri.instance import Instance
 from starwhale.base.uri.resource import Resource, ResourceType
 from starwhale.core.dataset.type import Link, DatasetSummary, GrayscaleImage
 from starwhale.core.dataset.store import ObjectStore, DatasetStorage
@@ -138,7 +143,8 @@ class TestModelPipelineHandler(TestCase):
         self.project = DEFAULT_PROJECT
         self.eval_id = "mm3wky3dgbqt"
 
-        self.dataset_uri_raw = f"mnist/version/{gen_uniq_version()}"
+        self.dataset_version = gen_uniq_version()
+        self.dataset_uri_raw = f"mnist/version/{self.dataset_version}"
         self.swds_dir = os.path.join(ROOT_DIR, "data", "dataset", "swds")
         self.fs.add_real_directory(self.swds_dir)
 
@@ -248,6 +254,85 @@ class TestModelPipelineHandler(TestCase):
             handler._starwhale_internal_run_evaluate()
 
     @contextmanager
+    def _mock_ppl_prepare_data_in_cloud(self) -> t.Any:
+        with patch(
+            "starwhale.base.uri.resource.Resource._refine_local_rc_info"
+        ) as _, patch(
+            "starwhale.core.dataset.model.CloudDataset.summary"
+        ) as m_summary, patch(
+            "starwhale.api._impl.dataset.Dataset.batch_iter"
+        ) as m_ds, patch(
+            "starwhale.api._impl.dataset.Dataset.info"
+        ) as m_ds_info, patch(
+            "starwhale.api._impl.wrapper.Evaluation.log_result"
+        ) as m_log_result, patch(
+            "starwhale.utils.config.load_swcli_config"
+        ) as m_config, patch.dict(
+            os.environ, {ENV_POD_NAME: "test-pod-1"}
+        ), requests_mock.Mocker() as rm:
+            m_config.return_value = {
+                "current_instance": "cloud",
+                "instances": {
+                    "cloud": {"uri": "https://localhost:80", "sw_token": "bar"},
+                    "local": {"uri": "local"},
+                },
+                "storage": {"root": tempfile.gettempdir()},
+            }
+
+            _logdir = JobStorage.local_run_dir(self.project, self.eval_id)
+            _run_dir = _logdir / RunSubDirType.RUNLOG / "ppl" / "0"
+            _status_dir = _run_dir / RunSubDirType.STATUS
+
+            m_summary.return_value = DatasetSummary(
+                rows=1,
+            )
+
+            m_ds.return_value = [
+                [
+                    DataRow(
+                        0,
+                        {
+                            "image": GrayscaleImage(link=Link("")),
+                            "label": 0,
+                            "annotation": "a",
+                        },
+                    )
+                ]
+            ]
+            m_ds_info.return_value = TabularDatasetInfo(mapping={"id": 0, "value": 1})
+
+            rm.request(
+                HTTPMethod.HEAD,
+                f"https://localhost:80/api/v1/project/starwhale/dataset/mnist/version/{self.dataset_version}",
+                json={"message": "found"},
+                status_code=HTTPStatus.OK,
+            )
+            rm.get(
+                "https://localhost:80/api/v1/project/starwhale/dataset/mnist",
+                json={
+                    "data": {
+                        "id": 11,
+                        "versionId": 22,
+                        "name": "mnist",
+                        "versionName": self.dataset_version,
+                    }
+                },
+            )
+            context = Context(
+                workdir=Path(),
+                project=Project("https://localhost:80/project/starwhale").full_uri,
+                version=self.eval_id,
+                dataset_uris=[
+                    f"https://localhost:80/project/starwhale/dataset/{self.dataset_uri_raw}"
+                ],
+                step="ppl",
+                index=0,
+            )
+            Context.set_runtime_context(context)
+
+            yield _status_dir, m_log_result
+
+    @contextmanager
     def _mock_ppl_prepare_data(self) -> t.Any:
         with patch(
             "starwhale.base.uri.resource.Resource._refine_local_rc_info",
@@ -340,7 +425,7 @@ class TestModelPipelineHandler(TestCase):
                 _handler._starwhale_internal_run_predict()
 
             log_result = m_log_result.call_args[0][0]
-            assert log_result["id"].startswith("mnist_")
+            assert log_result["id"].startswith("self_mnist_")
             assert log_result["_mode"] == "plain"
             assert log_result["_index"] == 0
             assert log_result["output"] == {"result": "ok"}
@@ -351,6 +436,20 @@ class TestModelPipelineHandler(TestCase):
             status_file_path = os.path.join(status_dir, "current")
             assert os.path.exists(status_file_path)
             assert "success" in open(status_file_path).read()
+
+    def test_ppl_with_plain_mode_in_cloud(self) -> None:
+        with self._mock_ppl_prepare_data_in_cloud() as (status_dir, m_log_result):
+            with PlainHandler() as _handler:
+                _handler._starwhale_internal_run_predict()
+
+            log_result = m_log_result.call_args[0][0]
+            assert log_result["id"].startswith("11_")
+            assert log_result["_mode"] == "plain"
+            assert log_result["_index"] == 0
+            assert log_result["output"] == {"result": "ok"}
+            assert isinstance(log_result["input/image"], GrayscaleImage)
+            assert log_result["input/label"] == 0
+            assert "input/annotation" not in log_result
 
     def test_ppl(self) -> None:
         with self._mock_ppl_prepare_data() as (status_dir, m_log_result):


### PR DESCRIPTION
## Description
Tune predict result id from "{dataset_name}-{version}__#@#_{ds_index}" to "{dataset_id or name}__#@#_{ds_index}" in cloud and "{project}/{dataset name}__#@#_{ds_index}" in standalone

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [x] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
