### PR TITLE
fix: canceled job is not deleted

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/TaskStatusMachine.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/TaskStatusMachine.java
@@ -43,7 +43,7 @@ public class TaskStatusMachine {
             new SimpleEntry<>(PAUSED, Set.of(PREPARING, ASSIGNING, RUNNING, READY, CANCELED, SUCCESS)),
             new SimpleEntry<>(ASSIGNING, Set.of(CREATED, PREPARING, RUNNING, SUCCESS, FAIL, TO_CANCEL)),
             new SimpleEntry<>(PREPARING, Set.of(RUNNING, SUCCESS, FAIL, TO_CANCEL)),
-            new SimpleEntry<>(RUNNING, Set.of(SUCCESS, FAIL, TO_CANCEL)),
+            new SimpleEntry<>(RUNNING, Set.of(SUCCESS, FAIL, TO_CANCEL, CANCELED)),
             new SimpleEntry<>(TO_CANCEL, Set.of(CANCELLING, CANCELED, SUCCESS, FAIL)),
             new SimpleEntry<>(CANCELLING, Set.of(CANCELED, FAIL)),
             new SimpleEntry<>(CANCELED, Set.of()),


### PR DESCRIPTION
## Description


Before this pull request, when a `running` task is set to `canceled` the `TaskStatusMachine` considered it illegal. As a result, the logic that deletes the pod wouldn't be executed. This pull request makes this status transfer legal.

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
