### PR TITLE
fix(client): tune resource numberic limitation when refine

### DIFF
--- a/client/starwhale/base/uri/resource.py
+++ b/client/starwhale/base/uri/resource.py
@@ -229,9 +229,6 @@ class Resource:
         if not self.name or not self.version:
             # TODO guess by name or version only
             return
-        if not self.name.isnumeric() and not self.version.isnumeric():
-            # both are not numeric, assume it is already refined
-            return
 
         base_path = f"{self.instance.url}/api/{SW_API_VERSION}/project/{self.project.name}/{self.typ.value}/{self.name}"
         headers = {"Authorization": self.instance.token}

--- a/client/starwhale/base/uri/resource.py
+++ b/client/starwhale/base/uri/resource.py
@@ -229,6 +229,9 @@ class Resource:
         if not self.name or not self.version:
             # TODO guess by name or version only
             return
+        if self._remote_info:
+            # have remote info, assume it is already refined
+            return
 
         base_path = f"{self.instance.url}/api/{SW_API_VERSION}/project/{self.project.name}/{self.typ.value}/{self.name}"
         headers = {"Authorization": self.instance.token}

--- a/client/starwhale/core/model/copy.py
+++ b/client/starwhale/core/model/copy.py
@@ -111,7 +111,7 @@ class ModelCopy(BundleCopy):
                 dest_uri = Resource(
                     f"{self.dest_uri.project}/{SW_BUILT_IN}/version/{rt_version}",
                     typ=ResourceType.runtime,
-                    refine=True,
+                    refine=False,
                 )
 
                 def upload_runtime_tar(file_path: Path, progress: Progress) -> None:

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -47,7 +47,7 @@ class TestBundleCopy(TestCase):
         version = "ge3tkylgha2tenrtmftdgyjzni3dayq"
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/runtime/pytorch",
+            "http://1.1.1.1:8182/api/v1/project/myproject/runtime/pytorch",
             json={"data": {"id": 1, "versionName": version, "versionId": 100}},
             status_code=HTTPStatus.OK,
         )
@@ -258,7 +258,7 @@ class TestBundleCopy(TestCase):
         version = "ge3tkylgha2tenrtmftdgyjzni3dayq"
         rm.request(
             HTTPMethod.GET,
-            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist",
+            "http://1.1.1.1:8182/api/v1/project/myproject/model/mnist",
             json={"data": {"id": 1, "versionName": version, "versionId": 100}},
             status_code=HTTPStatus.OK,
         )

--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -46,6 +46,12 @@ class TestBundleCopy(TestCase):
     def test_runtime_copy_c2l(self, rm: Mocker, *args: t.Any) -> None:
         version = "ge3tkylgha2tenrtmftdgyjzni3dayq"
         rm.request(
+            HTTPMethod.GET,
+            f"http://1.1.1.1:8182/api/v1/project/myproject/runtime/pytorch",
+            json={"data": {"id": 1, "versionName": version, "versionId": 100}},
+            status_code=HTTPStatus.OK,
+        )
+        rm.request(
             HTTPMethod.HEAD,
             f"http://1.1.1.1:8182/api/v1/project/myproject/runtime/pytorch/version/{version}",
             json={"message": "existed"},
@@ -250,6 +256,12 @@ class TestBundleCopy(TestCase):
     @patch("starwhale.base.uri.resource.Resource._refine_local_rc_info")
     def test_model_copy_c2l(self, rm: Mocker, *args: MagicMock) -> None:
         version = "ge3tkylgha2tenrtmftdgyjzni3dayq"
+        rm.request(
+            HTTPMethod.GET,
+            f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist",
+            json={"data": {"id": 1, "versionName": version, "versionId": 100}},
+            status_code=HTTPStatus.OK,
+        )
         rm.request(
             HTTPMethod.HEAD,
             f"http://1.1.1.1:8182/api/v1/project/myproject/model/mnist/version/{version}",

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -994,9 +994,9 @@ class CloudModelTest(TestCase):
             "https://foo.com/api/v1/project/starwhale/model/mnist",
             json={
                 "data": {
-                    "versionId": 100,
+                    "versionId": "100",
                     "name": "mnist",
-                    "versionName": "123456",
+                    "versionName": "123456a",
                 }
             },
         )
@@ -1004,9 +1004,9 @@ class CloudModelTest(TestCase):
             "https://foo.com/api/v1/project/starwhale/dataset/mnist",
             json={
                 "data": {
-                    "versionId": 200,
+                    "versionId": "200",
                     "name": "mnist",
-                    "versionName": "223456",
+                    "versionName": "223456a",
                 }
             },
         )
@@ -1014,9 +1014,9 @@ class CloudModelTest(TestCase):
             "https://foo.com/api/v1/project/starwhale/runtime/mnist",
             json={
                 "data": {
-                    "versionId": 300,
+                    "versionId": "300",
                     "name": "mnist",
-                    "versionName": "323456",
+                    "versionName": "323456a",
                 }
             },
         )
@@ -1025,25 +1025,25 @@ class CloudModelTest(TestCase):
         )
         result, data = CloudModel.run(
             project_uri=Project("https://foo.com/project/starwhale"),
-            model_uri="mnist/version/123456",
-            dataset_uris=["mnist/version/223456"],
-            runtime_uri="mnist/version/323456",
+            model_uri="mnist/version/123456a",
+            dataset_uris=["mnist/version/223456a"],
+            runtime_uri="mnist/version/323456a",
             resource_pool="default",
             run_handler="test:predict",
         )
         assert result
         assert data == "success"
         assert rm.call_count == 4
-        assert rm.request_history[0].qs == {"versionurl": ["123456"]}
+        assert rm.request_history[0].qs == {"versionurl": ["123456a"]}
         assert rm.request_history[0].method == "GET"
-        assert rm.request_history[1].qs == {"versionurl": ["223456"]}
+        assert rm.request_history[1].qs == {"versionurl": ["223456a"]}
         assert rm.request_history[1].method == "GET"
-        assert rm.request_history[2].qs == {"versionurl": ["323456"]}
+        assert rm.request_history[2].qs == {"versionurl": ["323456a"]}
         assert rm.request_history[2].method == "GET"
         assert json.loads(rm.request_history[3].text) == {
-            "modelVersionUrl": 100,
-            "datasetVersionUrls": "200",
-            "runtimeVersionUrl": 300,
+            "modelVersionUrl": '100',
+            "datasetVersionUrls": '200',
+            "runtimeVersionUrl": '300',
             "resourcePool": "default",
             "handler": "test:predict",
         }

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -1041,9 +1041,9 @@ class CloudModelTest(TestCase):
         assert rm.request_history[2].qs == {"versionurl": ["323456a"]}
         assert rm.request_history[2].method == "GET"
         assert json.loads(rm.request_history[3].text) == {
-            "modelVersionUrl": '100',
-            "datasetVersionUrls": '200',
-            "runtimeVersionUrl": '300',
+            "modelVersionUrl": "100",
+            "datasetVersionUrls": "200",
+            "runtimeVersionUrl": "300",
             "resourcePool": "default",
             "handler": "test:predict",
         }

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -738,6 +738,12 @@ class TestDatasetType(TestCase):
         link = Link(
             uri="s3://minioadmin:minioadmin@10.131.0.1:9000/users/path/to/file",
         )
+
+        rm.request(
+            HTTPMethod.GET,
+            "http://127.0.0.1:8081/api/v1/project/test/dataset/mnist",
+            json={"data": {"id": 1, "versionName": "123456a", "versionId": 100}},
+        )
         link.owner = Resource(
             "http://127.0.0.1:8081/project/test/dataset/mnist/version/latest"
         )

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -818,6 +818,11 @@ class TestDatasetSDK(_DatasetSDKTestBase):
             status_code=HTTPStatus.NOT_FOUND,
         )
 
+        rm.request(
+            HTTPMethod.GET,
+            "http://1.1.1.1/api/v1/project/self/dataset/mnist",
+            json={"data": {"id": 1, "versionName": "123456a", "versionId": 100}},
+        )
         ds = dataset("http://1.1.1.1/projects/self/datasets/mnist/versions/latest")
         assert version_req.call_count == 1
 

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -812,16 +812,16 @@ class TestDatasetSDK(_DatasetSDKTestBase):
             },
         )
 
+        ds_version = "123456a"
         version_req = rm.request(
             HTTPMethod.HEAD,
-            "http://1.1.1.1/api/v1/project/self/dataset/mnist/version/latest",
+            f"http://1.1.1.1/api/v1/project/self/dataset/mnist/version/{ds_version}",
             status_code=HTTPStatus.NOT_FOUND,
         )
-
         rm.request(
             HTTPMethod.GET,
             "http://1.1.1.1/api/v1/project/self/dataset/mnist",
-            json={"data": {"id": 1, "versionName": "123456a", "versionId": 100}},
+            json={"data": {"id": 1, "versionName": ds_version, "versionId": 100}},
         )
         ds = dataset("http://1.1.1.1/projects/self/datasets/mnist/versions/latest")
         assert version_req.call_count == 1


### PR DESCRIPTION
## Description
Determine whether the resource refined, judge whether the remote_info exists.
 
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
