### PR TITLE
chore(client): tune conda log options for the pretty log output

### DIFF
--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -391,7 +391,7 @@ def conda_setup(
     if not name and not prefix:
         raise ParameterError("conda setup must set name or prefix")
 
-    cmd = [get_conda_bin(), "create", "--yes"]
+    cmd = [get_conda_bin(), "create", "--yes", "--quiet"]
     if name:
         cmd += ["--name", name]
 
@@ -471,6 +471,8 @@ def conda_env_update(
         get_conda_bin(),
         "env",
         "update",
+        "--verbose",
+        "--quiet",
         "--file",
         str(env_fpath),
         "--prefix",

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -163,6 +163,7 @@ class StandaloneRuntimeTestCase(TestCase):
             conda_bin_path,
             "create",
             "--yes",
+            "--quiet",
             "--prefix",
             conda_prefix_dir,
             f"python={get_python_version()}",
@@ -1707,11 +1708,21 @@ class StandaloneRuntimeTestCase(TestCase):
         conda_cmds = [cm[0][0] for cm in m_call.call_args_list]
         conda_prefix_dir = os.path.join(export_dir, "conda")
         assert conda_cmds == [
-            ["conda", "create", "--yes", "--prefix", conda_prefix_dir, "python=3.7"],
+            [
+                "conda",
+                "create",
+                "--yes",
+                "--quiet",
+                "--prefix",
+                conda_prefix_dir,
+                "python=3.7",
+            ],
             [
                 "conda",
                 "env",
                 "update",
+                "--verbose",
+                "--quiet",
                 "--file",
                 req_lock_fpath,
                 "--prefix",
@@ -1828,6 +1839,7 @@ class StandaloneRuntimeTestCase(TestCase):
                 "conda",
                 "create",
                 "--yes",
+                "--quiet",
                 "--prefix",
                 conda_prefix_dir,
                 "python=3.7",
@@ -1836,6 +1848,8 @@ class StandaloneRuntimeTestCase(TestCase):
                 "conda",
                 "env",
                 "update",
+                "--verbose",
+                "--quiet",
                 "--file",
                 conda_env_fpath,
                 "--prefix",


### PR DESCRIPTION
## Description
current log for conda:
![image](https://github.com/star-whale/starwhale/assets/590748/a8a91264-7068-4680-8868-a66f920ce791)

use conda `--quiet` to ignore the progress bar output.

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
