### PR TITLE
e2e(console): add ui test to daily e2e sh

### DIFF
--- a/console/playwright/.env
+++ b/console/playwright/.env
@@ -3,6 +3,5 @@
 # DEBUG=true
 # DEBUG=pw:browser*
 LITE=false
-CLEAN_AUTH=false
 CLOSE_AFTER_TEST=false
 CLOSE_SAVE_VIDEO=true

--- a/console/playwright/.env
+++ b/console/playwright/.env
@@ -5,4 +5,4 @@
 LITE=false
 CLEAN_AUTH=false
 CLOSE_AFTER_TEST=false
-# CLOSE_SAVE_VIDEO=true
+CLOSE_SAVE_VIDEO=true

--- a/console/playwright/playwright.config.ts
+++ b/console/playwright/playwright.config.ts
@@ -3,7 +3,6 @@ import { devices } from '@playwright/test'
 import * as fse from 'fs-extra'
 import path from 'path'
 
-// process.env.PROXY = 'http://e2e.pre.intra.starwhale.ai/'
 const proxy = process.env.PROXY ?? ''
 
 /**
@@ -12,10 +11,7 @@ const proxy = process.env.PROXY ?? ''
  */
 require('dotenv').config()
 fse.ensureDir('test-storage')
-fse.ensureDir('test-storage')
-// fse.emptyDirSync('test-video')
-if (process.env.CLEAN_AUTH === 'true') fse.emptyDirSync('test-storage')
-
+fse.ensureDir('test-video')
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -40,7 +36,7 @@ const config: PlaywrightTestConfig = {
     /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 2 : 1,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: 'html',
+    reporter: process.env.CI ? 'github' : [['html', { open: 'never' }], ['list']],
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         viewport: { width: 1280, height: 960 },

--- a/console/playwright/playwright.config.ts
+++ b/console/playwright/playwright.config.ts
@@ -12,9 +12,9 @@ const proxy = process.env.PROXY ?? ''
  */
 require('dotenv').config()
 fse.ensureDir('test-storage')
+fse.ensureDir('test-storage')
 // fse.emptyDirSync('test-video')
 if (process.env.CLEAN_AUTH === 'true') fse.emptyDirSync('test-storage')
-else fse.ensureDir('test-storage')
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -23,7 +23,7 @@ const config: PlaywrightTestConfig = {
     testDir: './tests',
     // testIgnore: ['tests-examples/*'],
     /* Maximum time one test can run for. */
-    timeout: 20 * 1000,
+    timeout: 30 * 1000,
     expect: {
         /**
          * Maximum time expect() should wait for the condition to be met.
@@ -43,24 +43,23 @@ const config: PlaywrightTestConfig = {
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
-        viewport: { width: 1280, height: 720 },
+        viewport: { width: 1280, height: 960 },
 
         /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
         actionTimeout: 0,
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: process.env.PROXY ?? 'http://localhost:5177',
+        baseURL: process.env.PROXY ?? 'http://localhost:5173',
 
         acceptDownloads: true,
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-        trace: 'on-first-retry',
+        trace: 'on',
 
-        video: {
-            mode: 'on',
-            size: { width: 1024, height: 760 },
-        },
+        // video: {
+        //     mode: 'on',
+        //     size: { width: 1024, height: 760 },
+        // },
 
-        // screenshot: { mode: 'only-on-failure', fullPage: true },
         screenshot: { mode: 'on', fullPage: true },
     },
 

--- a/console/playwright/setup/index.ts
+++ b/console/playwright/setup/index.ts
@@ -6,13 +6,11 @@ import config from '../playwright.config'
 import { USERS, SELECTOR } from '../tests/config'
 export { expect } from '@playwright/test'
 
-console.log('---')
-
 export const test = baseTest.extend({
     admin: async ({ browser }, use) => {
         await use(await AdminPage.create(browser, 'admin'))
     },
-    user: async ({ browser }, use) => {
-        await use(await UserPage.create(browser, 'maintainer'))
+    guest: async ({ browser }, use) => {
+        await use(await UserPage.create(browser, 'guest'))
     },
 })

--- a/console/playwright/tests/auth.setup.ts
+++ b/console/playwright/tests/auth.setup.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import { test as setup, expect, Page } from '@playwright/test'
 import config from '../playwright.config'
 import { USERS, SELECTOR } from './config'
+import { takeScreenshot, wait } from './utils'
 
 USERS.map(async (user) => {
     // testInfo.project.outputDir
@@ -31,4 +32,16 @@ USERS.map(async (user) => {
             })
         }
     })
+})
+
+setup.afterAll(async ({ page }) => {
+    // if (process.env.CLOSE_SAVE_VIDEO === 'true') await page.video()?.saveAs(`test-video/admin.webm`)
+    if (process.env.CLOSE_AFTER_TEST === 'true') {
+        await wait(5000)
+        await page.context().close()
+    }
+})
+
+setup.afterEach(async ({ page }) => {
+    await takeScreenshot({ testcase: page, route: page.url() })
 })

--- a/console/playwright/tests/auth.setup.ts
+++ b/console/playwright/tests/auth.setup.ts
@@ -12,7 +12,6 @@ USERS.map(async (user) => {
     if (fs.existsSync(fileName)) return
 
     setup(`authenticate as ${user.role}`, async ({ page }) => {
-        console.log('-----------------------')
         await page.goto(config.use?.baseURL as string)
         await expect(page).toHaveTitle(/Starwhale Console/)
         await page.locator(SELECTOR.loginName).fill(user.username)
@@ -40,8 +39,4 @@ setup.afterAll(async ({ page }) => {
         await wait(5000)
         await page.context().close()
     }
-})
-
-setup.afterEach(async ({ page }) => {
-    await takeScreenshot({ testcase: page, route: page.url() })
 })

--- a/console/playwright/tests/config.ts
+++ b/console/playwright/tests/config.ts
@@ -3,7 +3,7 @@ export const CONFIG = {
 }
 export const USERS = [
     { role: 'admin', username: 'starwhale', password: 'abcd1234' },
-    { role: 'maintainer', username: 'lwz1', password: 'abcd1234' },
+    { role: 'guest', username: 'lwz1', password: 'abcd1234' },
 ]
 export const CONST = {
     user: {
@@ -21,6 +21,7 @@ export const CONST = {
     newUserName: 'lwz1',
     newUserPassword: 'abcd1234',
     datasetName: 'mnist_bin',
+    runtimeName: 'pytorch37',
 }
 export const ROUTES = {
     evaluations: `/projects/${CONST.projectId}/evaluations`,
@@ -37,6 +38,9 @@ export const ROUTES = {
     datasetVersionFiles: `/projects/${CONST.projectId}/datasets/1/versions/10/files`,
     adminUsers: `/admin/users`,
     adminSettings: `/admin/settings`,
+}
+export const API = {
+    project: `/api/v1/project/${CONST.projectId}`,
 }
 export const SELECTOR = {
     loginName: 'input[type="text"]',
@@ -67,8 +71,8 @@ export const SELECTOR = {
     tableCompare: '[class*=tableComparable]',
     headerFirst: '.table-headers .header-cell >> nth=0',
     headerFocused: '.header-cell--focused',
-    row1column1: '[data-row-index="0"] [data-column-index="0"]',
-    row2column1: '[data-row-index="1"] [data-column-index="0"]',
+    row1column1: '[data-row-index="0"][data-column-index="0"]',
+    row2column1: '[data-row-index="1"][data-column-index="0"]',
     // --- list ----
     listCreate: '[class*=cardHeadWrapper] >> :has-text("Create")',
     // --- evaluation result ----

--- a/console/playwright/tests/guest.spec.ts
+++ b/console/playwright/tests/guest.spec.ts
@@ -12,6 +12,10 @@ test.beforeAll(async ({ guest }) => {
     await expect(page).toHaveTitle(/Starwhale Console/)
 })
 
+// page.afterEach(async ({ page }) => {
+//     await takeScreenshot({ testcase: page, route: page.url() })
+// })
+
 test.describe('Login', () => {
     test('default route should be projects', async ({}) => {
         await page.waitForURL(/\/projects/, { timeout: 20000 })

--- a/console/playwright/tests/guest.spec.ts
+++ b/console/playwright/tests/guest.spec.ts
@@ -4,26 +4,13 @@ import { CONST, ROUTES, SELECTOR } from './config'
 import { getLastestRowID, getTableDisplayRow, selectOption, takeScreenshot, wait } from './utils'
 let page: Page
 
-test.beforeAll(async ({ user }) => {
-    page = user.page
+test.beforeAll(async ({ guest }) => {
+    page = guest.page
     await page.goto('/', {
         waitUntil: 'networkidle',
     })
     await expect(page).toHaveTitle(/Starwhale Console/)
 })
-
-test.afterEach(async () => {
-    await takeScreenshot({ testcase: page, route: page.url() })
-})
-
-// test.afterAll(async ({}) => {
-//     await wait(5000)
-
-//     if (process.env.CLOSE_AFTER_TEST === 'true') {
-//         await page.context().close()
-//         if (process.env.CLOSE_SAVE_VIDEO === 'true') await page.video()?.saveAs(`test-video/user.webm`)
-//     }
-// })
 
 test.describe('Login', () => {
     test('default route should be projects', async ({}) => {
@@ -162,62 +149,12 @@ test.describe('Evaluation', () => {
 
             const isChecked = await p.locator(SELECTOR.headerFirst).locator('label input').isChecked()
             if (isChecked) await p.locator(SELECTOR.headerFirst).locator('label').click()
-            await p.locator(SELECTOR.row1column1).locator('label').check()
-            await p.locator(SELECTOR.row2column1).locator('label').check()
-            await expect(page.getByText(/Compare Evaluations/)).toBeVisible()
-            await wait(1000)
-            await expect(page.locator(SELECTOR.headerFocused)).toHaveText(/mnist/)
-            await wait(1000)
+            await p.locator(SELECTOR.row1column1).locator('input').check()
+            await p.locator(SELECTOR.row2column1).locator('input').check()
+            await expect(page.getByText(/Compare/)).toBeVisible()
             await expect(await page.locator('.cell--neq').count()).toBeGreaterThan(0)
             await p.locator(SELECTOR.row1column1).locator('label').uncheck()
             await p.locator(SELECTOR.row2column1).locator('label').uncheck()
-        })
-    })
-})
-
-test.describe('Evaluation Create', () => {
-    let rowCount: any
-
-    test.beforeAll(async () => {
-        await page.goto(ROUTES.evaluations)
-        await wait(500)
-        rowCount = await getLastestRowID(page)
-        await page.getByRole('button', { name: /Create$/ }).click()
-        await expect(page).toHaveURL(ROUTES.evaluationNewJob)
-
-        await selectOption(page, SELECTOR.formItem('Resource Pool'), 'default')
-        await selectOption(page, SELECTOR.formItem('Model Name'), 'mnist')
-        await selectOption(page, SELECTOR.formItem('Dataset Name'), 'mnist')
-        await selectOption(page, SELECTOR.formItem('Runtime'), 'pytorch-mnist')
-        const versions = page.locator(SELECTOR.formItem('Version'))
-        const count = await versions.count()
-        for (let i = 0; i < count; i++) {
-            await expect(versions.nth(i)).not.toBeEmpty()
-        }
-    })
-    test.describe('Overview', () => {
-        test('should add resource', async () => {
-            const add = page.getByRole('button', { name: /Add/ }).first()
-            await expect(add).toBeVisible()
-
-            await add.click()
-            const resourceItem = (i: number, j: number) =>
-                `[class*=resource] >> nth=${i} >> [data-baseweb="form-control-container"] >> nth=${j} >> div`
-            await selectOption(page, resourceItem(0, 0), 'cpu')
-            await page.locator(resourceItem(0, 1)).locator('input').fill('1')
-            await page.locator(SELECTOR.formItem('Raw Type')).click()
-            await page.waitForSelector('.monaco-editor')
-            expect(page.locator('.view-lines')).toHaveText(
-                '- concurrency: 1  needs: []  resources:    - type: cpu      num: 1  job_name: default  step_name: ppl  task_num: 1- concurrency: 1  needs:    - ppl  resources: []  job_name: default  step_name: cmp  task_num: 1'
-            )
-        })
-    })
-
-    test.describe('Submit', () => {
-        test('should select lastest versions', async () => {
-            await page.getByRole('button', { name: 'Submit' }).click()
-            await expect(page).toHaveURL(ROUTES.evaluations)
-            await expect(await getLastestRowID(page)).toBeGreaterThan(rowCount)
         })
     })
 })
@@ -258,7 +195,7 @@ test.describe('Evaluation Results', () => {
         test('should show success task log', async () => {
             await page
                 .getByText(/View Logs/)
-                .first()
+                .last()
                 .click()
             await expect(page.locator('.tr--selected')).toBeDefined()
         })

--- a/console/playwright/tests/utils.ts
+++ b/console/playwright/tests/utils.ts
@@ -6,7 +6,15 @@ import { CONFIG } from './config'
 export async function selectOption(page: Page, selector: string, text: string | RegExp) {
     const ops = page.locator(selector)
     await ops.locator('div').first().click()
-    await page.getByRole('option').getByText(text).click()
+    await page.getByRole('option').getByText(text).first().click()
+    await expect(ops.getByText(text)).toBeTruthy()
+}
+
+export async function selectTreeOption(page: Page, selector: string, text: string | RegExp) {
+    const ops = page.locator(selector)
+    await ops.locator('div').first().click()
+    await page.getByRole('treeitem').first().locator('label').first().click()
+    await page.keyboard.press('Escape')
     await expect(ops.getByText(text)).toBeTruthy()
 }
 
@@ -35,5 +43,5 @@ export async function takeScreenshot({ testcase, route }: any) {
     await fse.ensureDir(path.dirname(screenshotPath))
     // const explicitScreenshotTarget = await page.$('[data-testid="screenshot-target"]');
     const screenshotTarget = testcase
-    await screenshotTarget.screenshot({ path: screenshotPath, type: 'jpg', fullPage: true })
+    await screenshotTarget.screenshot({ path: screenshotPath, type: 'jpeg', fullPage: true })
 }

--- a/console/src/domain/job/components/JobForm.tsx
+++ b/console/src/domain/job/components/JobForm.tsx
@@ -218,7 +218,7 @@ export default function JobForm({ job, onSubmit }: IJobFormProps) {
             </div>
             <Divider orientation='top'>{t('Model Information')}</Divider>
             <div className={styles.rowModel}>
-                <FormItem label={t('Version')} required name='modelVersionUrl'>
+                <FormItem label={t('Model Version')} required name='modelVersionUrl'>
                     <ModelTreeSelector projectId={projectId} onDataChange={setModelTree} />
                 </FormItem>
                 {modelVersionId && (

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -311,9 +311,8 @@ main() {
   check_controller_service
   client_test
   api_test
+  console_test
   kubectl scale deployment controller -n $SWNS --replicas=0
-
-  # console_test
 
 }
 

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -251,6 +251,7 @@ api_test() {
 console_test() {
   pushd ../../console/playwright
   yarn install
+  npx playwright install
   PROXY=$CONTROLLER_URL yarn test
   popd
 }


### PR DESCRIPTION
## Description
![image](https://github.com/star-whale/starwhale/assets/100347187/c46a4fac-f2b0-43ca-ba03-9bb4bc1eb6c9)


## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
