### PR TITLE
refactor(console): split the e2e test case according to different scenarios

### DIFF
--- a/console/playwright/playwright.config.ts
+++ b/console/playwright/playwright.config.ts
@@ -34,7 +34,7 @@ const config: PlaywrightTestConfig = {
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : 1,
+    workers: 3,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: process.env.CI ? 'github' : [['html', { open: 'never' }], ['list']],
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/console/playwright/tests/admin-setting.spec.ts
+++ b/console/playwright/tests/admin-setting.spec.ts
@@ -122,36 +122,3 @@ test.describe('Admin', () => {
         })
     })
 })
-
-test.describe('Evaluation Create', () => {
-    let rowCount: any
-
-    test.beforeAll(async () => {
-        await page.goto(ROUTES.evaluations)
-        await wait(500)
-        rowCount = await getLastestRowID(page)
-        await page.getByRole('button', { name: /Create$/ }).click()
-        await expect(page).toHaveURL(ROUTES.evaluationNewJob)
-    })
-
-    test('should form be selected', async () => {
-        await selectOption(page, SELECTOR.formItem('Resource Pool'), 'default')
-        await selectTreeOption(page, SELECTOR.formItem('Model Version'), /starwhale/)
-        await page.getByRole('button', { name: 'Select...' }).click()
-        await selectTreeOption(page, SELECTOR.formItem('Dataset Version'), /starwhale/)
-        // await selectTreeOption(page, SELECTOR.formItem('Runtime'), /starwhale/)
-        const versions = page.locator(SELECTOR.formItem('Version'))
-        const count = await versions.count()
-        for (let i = 0; i < count; i++) {
-            await expect(versions.nth(i)).not.toBeEmpty()
-        }
-    })
-
-    // test.describe('Submit', () => {
-    //     test('should select lastest versions', async () => {
-    //         await page.getByRole('button', { name: 'Submit' }).click()
-    //         await expect(page).toHaveURL(ROUTES.evaluations)
-    //         await expect(await getLastestRowID(page)).toBeGreaterThan(rowCount)
-    //     })
-    // })
-})

--- a/console/playwright/tests/guest-project.spec.ts
+++ b/console/playwright/tests/guest-project.spec.ts
@@ -1,0 +1,71 @@
+import { expect, Locator, Page } from '@playwright/test'
+import { test } from '../setup'
+import { CONST, ROUTES, SELECTOR } from './config'
+import { getLastestRowID, getTableDisplayRow, selectOption, takeScreenshot, wait } from './utils'
+let page: Page
+
+test.beforeAll(async ({ guest }) => {
+    page = guest.page
+    await page.goto('/', {
+        waitUntil: 'networkidle',
+    })
+    await expect(page).toHaveTitle(/Starwhale Console/)
+})
+
+test.describe('Login', () => {
+    test('default route should be projects', async ({}) => {
+        await page.waitForURL(/\/projects/, { timeout: 20000 })
+        await expect(page).toHaveURL(/\/projects/)
+    })
+
+    test('header show not have admin settings', async ({}) => {
+        await page.hover(SELECTOR.userWrapper)
+        await expect(page.locator(SELECTOR.userAvtarName)).toBeVisible()
+        await expect(page.locator(SELECTOR.userAvtarName)).toHaveText(CONST.user.userName)
+        await expect(page.locator(SELECTOR.authAdminSetting)).not.toBeVisible()
+        await page.mouse.move(0, 0)
+    })
+})
+
+test.describe('Project list', () => {
+    test('should project form modal act show,submit,close', async ({}) => {
+        const el = await page.waitForSelector(SELECTOR.projectCreate)
+        await el.click()
+        await page.waitForSelector(SELECTOR.projectForm)
+        await page.locator(SELECTOR.projectName).fill(CONST.user.projectName)
+        await page.locator(SELECTOR.projectDescription).fill(CONST.user.projectDescription)
+        await page.locator(SELECTOR.projectPrivacy).check()
+        await expect(page.locator(SELECTOR.projectName)).not.toBeEmpty()
+        await expect(page.locator(SELECTOR.projectDescription)).not.toBeEmpty()
+        await expect(page.locator(SELECTOR.projectPrivacy)).toBeChecked()
+        await page.locator(SELECTOR.projectSubmit).click()
+    })
+
+    test('check project list and delete project just created', async () => {
+        await page.waitForSelector(SELECTOR.projectCard)
+        const cardLength = await page.$$eval(SELECTOR.projectCard, (el) => el.length)
+        expect(cardLength).toBeGreaterThan(0)
+
+        const p = page.locator(
+            SELECTOR.projectCard + `:has(:has-text("${CONST.user.userName}/${CONST.user.projectName}"))`
+        )
+        await p.hover()
+        await expect(p.locator(SELECTOR.projectCardActions)).toBeVisible()
+        await p.locator(SELECTOR.projectCardActionDelete).click()
+        await page.waitForSelector(SELECTOR.projectCardDeleteConfirm)
+        await page.locator(SELECTOR.projectModelInput).fill(CONST.user.projectName)
+        await page.locator(SELECTOR.projectCardDeleteConfirm).click()
+        await expect(p).not.toBeVisible()
+    })
+
+    test('should project navigate to evaluations when click project name', async () => {
+        await page.locator(SELECTOR.projectCardLink).click()
+        await expect(page).toHaveURL(ROUTES.evaluations)
+    })
+})
+
+// test.describe('Auth', () => {
+//     test('none admin should have no create button', async () => {
+//         await expect(page.locator(SELECTOR.listCreate)).toBeHidden()
+//     })
+// })


### PR DESCRIPTION
## Description

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
