### PR TITLE
feat(controller): support private resource pool

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobService.java
@@ -226,6 +226,11 @@ public class JobService {
             for (var step : steps) {
                 pool.validateResources(step.getResources());
             }
+            if (!pool.allowUser(user.getId())) {
+                throw new StarwhaleApiException(
+                        new SwValidationException(ValidSubject.JOB, "user is not allowed to use this resource pool"),
+                        HttpStatus.BAD_REQUEST);
+            }
         }
 
         JobFlattenEntity jobEntity = JobFlattenEntity.builder()

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/resourcepool/bo/ResourcePool.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/resourcepool/bo/ResourcePool.java
@@ -46,6 +46,10 @@ public class ResourcePool {
     // currently used for k8s annotations
     Map<String, String> metadata;
 
+    // private pool only used for internal
+    Boolean isPrivate;
+    List<Long> visibleUserIds;
+
     public static ResourcePool defaults() {
         return ResourcePool
                 .builder()
@@ -123,5 +127,15 @@ public class ResourcePool {
     public List<RuntimeResource> validateAndPatchResource(List<RuntimeResource> runtimeResources) {
         validateResources(runtimeResources);
         return patchResources(runtimeResources);
+    }
+
+    public boolean allowUser(Long userId) {
+        if (isPrivate != null && isPrivate) {
+            if (visibleUserIds == null || visibleUserIds.isEmpty()) {
+                return false;
+            }
+            return visibleUserIds.contains(userId);
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Description

Add two fields to the Resource Pool:
- isPrivate (bool) makes the pool private, and can not be listed when `visibleUserIds` is not specified
- visibleUserIds (array of long), used to configure which users can access this pool

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
