### PR TITLE
bug(client): fix multi conda pkgs installation error

### DIFF
--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -355,16 +355,12 @@ class CondaPkgDependency(ASDictMixin, BaseDependency):
         return DependencyType.CONDA_PKG
 
     def conda_install(self, src_dir: Path, env_dir: Path, configs: t.Dict) -> None:
-        _conda_pkgs = " ".join([repr(_p) for _p in self.deps if _p])
-        _conda_pkgs = _conda_pkgs.strip()
-        if _conda_pkgs:
-            console.debug(f"conda install: {_conda_pkgs}")
-            conda_install_req(
-                req=_conda_pkgs,
-                prefix_path=env_dir,
-                use_pip_install=False,
-                configs=configs,
-            )
+        conda_install_req(
+            req=self.deps,
+            prefix_path=env_dir,
+            use_pip_install=False,
+            configs=configs,
+        )
 
     def venv_install(self, src_dir: Path, env_dir: Path, configs: t.Dict) -> None:
         console.warning("no support install conda pkg in the venv environment")

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -1921,7 +1921,8 @@ class StandaloneRuntimeTestCase(TestCase):
                 "conda-forge",
                 "--yes",
                 "--override-channels",
-                "'c' 'd'",
+                "c",
+                "d",
             ],
             [
                 f"{conda_prefix_dir}/bin/python3",
@@ -2154,7 +2155,7 @@ class StandaloneRuntimeTestCase(TestCase):
             ensure_file(
                 path,
                 content=yaml.safe_dump(
-                    {"name": "test", "dependencies": ["b", {"pip": ["a"]}]}
+                    {"name": "test", "dependencies": ["b", "d", {"pip": ["a", "c"]}]}
                 ),
             )
 
@@ -2168,7 +2169,7 @@ class StandaloneRuntimeTestCase(TestCase):
                 {
                     "name": "test",
                     "mode": "conda",
-                    "dependencies": [{"pip": ["a"]}, {"conda": ["b"]}],
+                    "dependencies": [{"pip": ["a", "c"]}, {"conda": ["b", "d"]}],
                 }
             ),
         )
@@ -2196,7 +2197,7 @@ class StandaloneRuntimeTestCase(TestCase):
 
         StandaloneRuntime.lock(target_dir, yaml_path)
 
-        assert m_call.call_count == 3
+        assert m_call.call_count == 4
         assert m_call.call_args_list[0][0][0] == [
             "conda",
             "run",
@@ -2213,6 +2214,20 @@ class StandaloneRuntimeTestCase(TestCase):
         ]
         assert m_call.call_args_list[1][0][0] == [
             "conda",
+            "run",
+            "--live-stream",
+            "--prefix",
+            sw_conda_dir,
+            "python3",
+            "-m",
+            "pip",
+            "install",
+            "--exists-action",
+            "w",
+            "c",
+        ]
+        assert m_call.call_args_list[2][0][0] == [
+            "conda",
             "install",
             "--prefix",
             sw_conda_dir,
@@ -2220,10 +2235,11 @@ class StandaloneRuntimeTestCase(TestCase):
             "conda-forge",
             "--yes",
             "--override-channels",
-            "'b'",
+            "b",
+            "d",
         ]
 
-        assert m_call.call_args_list[2][0][0][:6] == [
+        assert m_call.call_args_list[3][0][0][:6] == [
             "conda",
             "env",
             "export",
@@ -2236,7 +2252,10 @@ class StandaloneRuntimeTestCase(TestCase):
             target_dir, ".starwhale", "lock", RuntimeLockFileType.CONDA
         )
         content = load_yaml(lock_yaml_path)
-        assert content == {"dependencies": ["b", {"pip": ["a"]}], "name": "test"}
+        assert content == {
+            "dependencies": ["b", "d", {"pip": ["a"]}],
+            "name": "test",
+        }
 
     @patch("os.environ", {})
     @patch("starwhale.core.runtime.model.get_conda_prefix_path")
@@ -2279,6 +2298,7 @@ class StandaloneRuntimeTestCase(TestCase):
         assert content == {
             "dependencies": [
                 "b",
+                "d",
                 {
                     "pip": [
                         "a",
@@ -2326,7 +2346,7 @@ class StandaloneRuntimeTestCase(TestCase):
             target_dir, ".starwhale", "lock", RuntimeLockFileType.CONDA
         )
         content = load_yaml(lock_yaml_path)
-        assert content == {"dependencies": ["b"], "name": "test"}
+        assert content == {"dependencies": ["b", "d"], "name": "test"}
 
     @patch("os.environ", {})
     @patch("starwhale.utils.venv.check_call")
@@ -2369,6 +2389,20 @@ class StandaloneRuntimeTestCase(TestCase):
         ]
         assert m_call.call_args_list[1][0][0] == [
             "conda",
+            "run",
+            "--live-stream",
+            "--prefix",
+            conda_dir,
+            "python3",
+            "-m",
+            "pip",
+            "install",
+            "--exists-action",
+            "w",
+            "c",
+        ]
+        assert m_call.call_args_list[2][0][0] == [
+            "conda",
             "install",
             "--prefix",
             conda_dir,
@@ -2376,10 +2410,11 @@ class StandaloneRuntimeTestCase(TestCase):
             "conda-forge",
             "--yes",
             "--override-channels",
-            "'b'",
+            "b",
+            "d",
         ]
 
-        assert m_call.call_args_list[2][0][0][:6] == [
+        assert m_call.call_args_list[3][0][0][:6] == [
             "conda",
             "env",
             "export",
@@ -2410,6 +2445,7 @@ class StandaloneRuntimeTestCase(TestCase):
         content = load_yaml(lock_yaml_path)
         assert content["dependencies"] == [
             "b",
+            "d",
             {"pip": ["a", "mock @ git+https://abc.com/mock.git@main"]},
         ]
 

--- a/client/tests/utils/test_venv.py
+++ b/client/tests/utils/test_venv.py
@@ -1,13 +1,21 @@
 import os
 from pathlib import Path
-from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from starwhale.utils.venv import _do_pip_install_req, parse_python_version
+from pyfakefs.fake_filesystem_unittest import TestCase
+
+from starwhale.utils.venv import (
+    conda_install_req,
+    _do_pip_install_req,
+    parse_python_version,
+)
 from starwhale.utils.error import FormatError
 
 
 class TestVenv(TestCase):
+    def setUp(self) -> None:
+        self.setUpPyfakefs()
+
     def test_parse_python_version(self) -> None:
         ts = {
             "python3": {
@@ -42,6 +50,73 @@ class TestVenv(TestCase):
         self.assertRaises(FormatError, parse_python_version, "")
 
     @patch("starwhale.utils.venv.check_call")
+    def test_conda_install(self, m_call: MagicMock) -> None:
+        conda_install_req(
+            req=["starwhale==0.2.0", "numpy"],
+            env_name="conda-env",
+            use_pip_install=False,
+            configs={"conda": {"channels": ["nvidia", "pytorch"]}},
+        )
+        assert m_call.call_args[0][0] == [
+            "conda",
+            "install",
+            "--name",
+            "conda-env",
+            "--channel",
+            "nvidia",
+            "--channel",
+            "pytorch",
+            "--yes",
+            "--override-channels",
+            "starwhale==0.2.0",
+            "numpy",
+        ]
+
+        conda_install_req(
+            req="starwhale==0.2.0",
+            prefix_path=Path("/tmp/conda-env"),
+            use_pip_install=False,
+        )
+        assert m_call.call_args[0][0] == [
+            "conda",
+            "install",
+            "--prefix",
+            "/tmp/conda-env",
+            "--channel",
+            "conda-forge",
+            "--yes",
+            "--override-channels",
+            "starwhale==0.2.0",
+        ]
+
+        req_fname = "/tmp/requirements.txt"
+        self.fs.create_file(req_fname, contents="")
+
+        conda_install_req(
+            req=["starwhale==0.2.0", Path(req_fname), "numpy", req_fname],
+            prefix_path=Path("/tmp/conda-env"),
+        )
+        assert m_call.call_args[0][0] == [
+            "conda",
+            "run",
+            "--live-stream",
+            "--prefix",
+            "/tmp/conda-env",
+            "python3",
+            "-m",
+            "pip",
+            "install",
+            "--exists-action",
+            "w",
+            "starwhale==0.2.0",
+            "-r",
+            req_fname,
+            "numpy",
+            "-r",
+            req_fname,
+        ]
+
+    @patch("starwhale.utils.venv.check_call")
     def test_pip_install(self, m_call: MagicMock) -> None:
         _do_pip_install_req(
             prefix_cmd=["venv/bin/pip"],
@@ -69,9 +144,12 @@ class TestVenv(TestCase):
         os.environ["SW_PYPI_EXTRA_INDEX_URL"] = "https://e3.com https://e4.com"
         os.environ["SW_PYPI_TRUSTED_HOST"] = "e2.com e3.com e4.com"
 
+        req_fname = "/tmp/requirements.txt"
+        self.fs.create_file(req_fname, contents="")
+
         _do_pip_install_req(
             prefix_cmd=["venv/bin/pip"],
-            req=Path("/tmp/requirements.txt"),
+            req=Path(req_fname),
             pip_config={
                 "index_url": "https://e1.com",
                 "trusted_host": ["e1.com"],
@@ -90,5 +168,34 @@ class TestVenv(TestCase):
             "--trusted-host",
             "e2.com e3.com e4.com e1.com",
             "-r",
-            "/tmp/requirements.txt",
+            req_fname,
+        ]
+
+        _do_pip_install_req(
+            prefix_cmd=["venv/bin/pip"],
+            req=["starwhale==0.2.0", Path(req_fname), "numpy", req_fname],
+            enable_pre=True,
+            pip_config={
+                "index_url": "https://e1.com",
+                "trusted_host": ["e1.com"],
+            },
+        )
+        assert m_call.call_args[0][0] == [
+            "venv/bin/pip",
+            "install",
+            "--exists-action",
+            "w",
+            "--index-url",
+            "https://e2.com",
+            "--extra-index-url",
+            "https://e3.com https://e4.com https://e1.com",
+            "--trusted-host",
+            "e2.com e3.com e4.com e1.com",
+            "--pre",
+            "starwhale==0.2.0",
+            "-r",
+            req_fname,
+            "numpy",
+            "-r",
+            req_fname,
         ]

--- a/scripts/example/runtime_conda.yaml
+++ b/scripts/example/runtime_conda.yaml
@@ -2,6 +2,7 @@ api_version: 1.1
 dependencies:
   - conda:
       - numpy
+      - requests
   - pip:
       - git+https://github.com/star-whale/starwhale.git@94eeff7863b61480ffb83d055d79eeb6ceb1bd21#subdirectory=example/runtime/pytorch/dummy
   - wheels:


### PR DESCRIPTION
## Description
error message:
```
[2023-05-19 14:21:24.408722] 🔈 |DEBUG| conda install: 'cuda-toolkit=11.7.1' 'torch=2.0.1' 'pytorch-cuda=11.7'                                                                                                                                                                    
[2023-05-19 14:21:24.418724] 🔈 |DEBUG| cmd: ['/mnt/data/renyanda/anaconda3/bin/conda', 'install', '--prefix', '/mnt/data/tianwei/code/starwhale/example/LLM/belle-bloom/.starwhale/conda', '--channel', 'conda-forge', '--channel', 'nvidia/label/cuda-11.7.1', '--channel', 'pyt
orch', '--yes', '--override-channels', "'cuda-toolkit=11.7.1' 'torch=2.0.1' 'pytorch-cuda=11.7'"]                                                                                                                                                                                 
[2023-05-19 14:21:24.981330] 🔈 |DEBUG|                                                                                                                                                                                                                                           
[2023-05-19 14:21:24.982171] 🔈 |DEBUG| CondaValueError: invalid package specification: cuda-toolkit=11.7.1' 'torch=2.0.1' 'pytorch-cuda=11.7
```

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
