### PR TITLE
fix(client): wrong file path linked when model file exists in cache

### DIFF
--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -299,8 +299,9 @@ class BundleCopy(CloudRequestMixed):
             if fd.signature:
                 f = self._object_store.get(fd.signature)
                 if f is not None and f.exists():
-                    f.link(_workdir / fd.path / fd.name)
-                    progress.update(_tid, completed=fd.size)
+                    console.trace(f"link {fd.signature} to {fd.path}")
+                    f.link(_workdir / fd.path)
+                    progress.update(_tid, total=fd.size, advance=fd.size)
                     return
 
             self.do_download_file(

--- a/client/starwhale/core/model/copy.py
+++ b/client/starwhale/core/model/copy.py
@@ -77,11 +77,12 @@ class ModelCopy(BundleCopy):
                 continue
             _sign = _m["signature"]
             _dest = workdir / _m["path"]
+            _size = _m.get("size", 0)
 
             yield FileNode(
                 path=_dest,
                 signature=_sign,
-                size=0,
+                size=_size,
                 name=_m["name"],
                 file_desc=FileDesc.MODEL,
             )


### PR DESCRIPTION
## Description

![2023-06-01_13-50](https://github.com/star-whale/starwhale/assets/3217223/d37193c2-2472-4ce2-85d2-ef8d0fee7e67)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
