### PR TITLE
fix(client): fix race condition in unit test

### DIFF
--- a/client/starwhale/utils/fs.py
+++ b/client/starwhale/utils/fs.py
@@ -5,6 +5,7 @@ import typing as t
 import difflib
 import hashlib
 import tarfile
+import tempfile
 from enum import IntEnum
 from pathlib import Path
 
@@ -42,8 +43,7 @@ def ensure_file(
             raise
 
     if _saved != content or not p.exists():
-        # TODO: add timestamp for tmp file
-        _tmp_f = p.parent / f".{p.name}.tmp"
+        _tmp_f = Path(tempfile.mktemp(dir=p.parent, suffix=f".{p.name}.tmp"))
         if isinstance(content, bytes):
             _tmp_f.write_bytes(content)
         elif isinstance(content, str):


### PR DESCRIPTION
## Description

https://github.com/star-whale/starwhale/actions/runs/5140825504/jobs/9252653401?pr=2302#step:8:452

```
_______________________ TestPytorch.test_image_transform _______________________

self = <tests.sdk.test_dataset_sdk.TestPytorch testMethod=test_image_transform>

    def setUp(self) -> None:
>       super().setUp()

tests/sdk/test_dataset_sdk.py:47: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/__init__.py:26: in setUp
    self.datastore_root = str(sw_config.SWCliConfigMixed().datastore_dir)
starwhale/utils/config.py:111: in __init__
    self._config = swcli_config or load_swcli_config()
starwhale/utils/config.py:46: in load_swcli_config
    _config = render_default_swcli_config(fpath)
starwhale/utils/config.py:86: in render_default_swcli_config
    render_swcli_config(c, fpath)
starwhale/utils/config.py:105: in render_swcli_config
    ensure_file(fpath, yaml.safe_dump(c, default_flow_style=False), mode=0o600)
starwhale/utils/fs.py:56: in ensure_file
    _tmp_f.rename(path)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/tmp/sw-test-mock-yjlm3t2e/.config.yaml.tmp')
target = '/tmp/sw-test-mock-yjlm3t2e/config.yaml'

    def rename(self, target):
        """
        Rename this path to the given path.
        """
        if self._closed:
            self._raise_closed()
>       self._accessor.rename(self, target)
E       FileNotFoundError: [Errno 2] No such file or directory: '/tmp/sw-test-mock-yjlm3t2e/.config.yaml.tmp' -> '/tmp/sw-test-mock-yjlm3t2e/config.yaml'

```

![2023-06-06_15-11](https://github.com/star-whale/starwhale/assets/3217223/24794271-10fe-4a26-87a7-0e240a0c5959)



## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
