### PR TITLE
feat(controller): online eval can be disabled

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/StarwhaleControllerApplication.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/StarwhaleControllerApplication.java
@@ -19,6 +19,7 @@ package ai.starwhale.mlops;
 import ai.starwhale.mlops.configuration.ControllerProperties;
 import ai.starwhale.mlops.configuration.DataSourceProperties;
 import ai.starwhale.mlops.configuration.DockerSetting;
+import ai.starwhale.mlops.configuration.FeaturesProperties;
 import ai.starwhale.mlops.configuration.RunTimeProperties;
 import de.codecentric.boot.admin.server.config.EnableAdminServer;
 import org.mybatis.spring.annotation.MapperScan;
@@ -32,7 +33,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableAdminServer
 @MapperScan({"ai.starwhale.mlops.domain.**.mapper"})
 @EnableConfigurationProperties({ControllerProperties.class, RunTimeProperties.class, DockerSetting.class,
-        DataSourceProperties.class})
+        DataSourceProperties.class, FeaturesProperties.class})
 public class StarwhaleControllerApplication {
 
     public static void main(String[] args) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/SystemApi.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/SystemApi.java
@@ -17,6 +17,7 @@
 package ai.starwhale.mlops.api;
 
 import ai.starwhale.mlops.api.protocol.ResponseMessage;
+import ai.starwhale.mlops.api.protocol.system.FeaturesVo;
 import ai.starwhale.mlops.api.protocol.system.LatestVersionVo;
 import ai.starwhale.mlops.api.protocol.system.SystemVersionVo;
 import ai.starwhale.mlops.api.protocol.system.UpgradeRequest;
@@ -121,4 +122,9 @@ public interface SystemApi {
             produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasAnyRole('OWNER')")
     ResponseEntity<ResponseMessage<String>> querySetting();
+
+    @Operation(summary = "Get system features", description = "Get system features list")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "ok")})
+    @GetMapping(value = "/system/features", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ResponseMessage<FeaturesVo>> queryFeatures();
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/SystemController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/SystemController.java
@@ -18,6 +18,7 @@ package ai.starwhale.mlops.api;
 
 import ai.starwhale.mlops.api.protocol.Code;
 import ai.starwhale.mlops.api.protocol.ResponseMessage;
+import ai.starwhale.mlops.api.protocol.system.FeaturesVo;
 import ai.starwhale.mlops.api.protocol.system.LatestVersionVo;
 import ai.starwhale.mlops.api.protocol.system.SystemVersionVo;
 import ai.starwhale.mlops.api.protocol.system.UpgradeRequest;
@@ -39,7 +40,7 @@ public class SystemController implements SystemApi {
     private final SystemSettingService systemSettingService;
 
     public SystemController(SystemService systemService,
-            SystemSettingService systemSettingService) {
+                            SystemSettingService systemSettingService) {
         this.systemService = systemService;
         this.systemSettingService = systemSettingService;
     }
@@ -96,5 +97,10 @@ public class SystemController implements SystemApi {
     @Override
     public ResponseEntity<ResponseMessage<String>> querySetting() {
         return ResponseEntity.ok(Code.success.asResponse(systemSettingService.querySetting()));
+    }
+
+    @Override
+    public ResponseEntity<ResponseMessage<FeaturesVo>> queryFeatures() {
+        return ResponseEntity.ok(Code.success.asResponse(systemService.queryFeatures()));
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/system/FeaturesVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/system/FeaturesVo.java
@@ -17,18 +17,15 @@
 package ai.starwhale.mlops.api.protocol.system;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.io.Serializable;
+import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.validation.annotation.Validated;
 
 @Data
 @Builder
-@Schema(description = "System version", title = "Version")
+@Schema(description = "System features", title = "Features")
 @Validated
-public class SystemVersionVo implements Serializable {
-
-    private String id;
-
-    private String version;
+public class FeaturesVo {
+    List<String> disabled;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/system/LatestVersionVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/system/LatestVersionVo.java
@@ -23,7 +23,7 @@ import org.springframework.validation.annotation.Validated;
 
 @Data
 @Builder
-@Schema(description = "Latest verion", title = "Version")
+@Schema(description = "Latest version", title = "Version")
 @Validated
 public class LatestVersionVo {
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/configuration/FeaturesProperties.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/configuration/FeaturesProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.configuration;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@ConfigurationProperties(prefix = "sw.features")
+public class FeaturesProperties {
+    public static final String FEATURE_ONLINE_EVAL = "online-eval";
+    public static final String FEATURE_JOB_PAUSE = "job-pause";
+    public static final String FEATURE_JOB_RESUME = "job-resume";
+
+    List<String> disabled;
+
+    public boolean featureEnabled(String feat) {
+        return disabled == null || !disabled.contains(feat);
+    }
+
+    public boolean isOnlineEvalEnabled() {
+        return featureEnabled(FEATURE_ONLINE_EVAL);
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/SystemService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/SystemService.java
@@ -16,7 +16,9 @@
 
 package ai.starwhale.mlops.domain.system;
 
+import ai.starwhale.mlops.api.protocol.system.FeaturesVo;
 import ai.starwhale.mlops.api.protocol.system.LatestVersionVo;
+import ai.starwhale.mlops.configuration.FeaturesProperties;
 import ai.starwhale.mlops.domain.system.resourcepool.bo.ResourcePool;
 import ai.starwhale.mlops.domain.upgrade.UpgradeService;
 import ai.starwhale.mlops.domain.upgrade.bo.UpgradeLog;
@@ -32,13 +34,16 @@ public class SystemService {
 
     private final UpgradeService upgradeService;
     private final String controllerVersion;
+    private final FeaturesProperties featuresProperties;
 
     public SystemService(SystemSettingService systemSettingService,
-            UpgradeService upgradeService,
-            @Value("${sw.version}") String controllerVersion) {
+                         UpgradeService upgradeService,
+                         @Value("${sw.version}") String controllerVersion,
+                         FeaturesProperties featuresProperties) {
         this.systemSettingService = systemSettingService;
         this.upgradeService = upgradeService;
         this.controllerVersion = controllerVersion;
+        this.featuresProperties = featuresProperties;
     }
 
     public String upgrade(String version, String image) {
@@ -71,5 +76,11 @@ public class SystemService {
 
     public void updateResourcePools(List<ResourcePool> resourcePools) {
         systemSettingService.updateResourcePools(resourcePools);
+    }
+
+    public FeaturesVo queryFeatures() {
+        return FeaturesVo.builder()
+                .disabled(featuresProperties.getDisabled())
+                .build();
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/system/SystemSettingService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/system/SystemSettingService.java
@@ -129,7 +129,7 @@ public class SystemSettingService implements CommandLineRunner {
                 }
                 listeners.forEach(l -> l.onUpdate(systemSetting));
             } catch (JsonProcessingException e) {
-                log.error("corrupted system setting yaml");
+                log.error("corrupted system setting yaml {}", setting.getContent());
                 throw new SwValidationException(ValidSubject.SETTING);
             }
         } else {

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -12,6 +12,8 @@ spring:
       static-locations: file:/opt/starwhale.java/static/, classpath:/static/
 sw:
   version: ${SW_VERSION_CONTROLLER:0.1.0:8c82767b60686f3e2bfea9dafe8c8cce5dd34f52}
+  features:
+    disabled: ${SW_DISABLED_FEATURES:}
   public-api:
     base-url: ${SW_PUBLIC_API_BASE_URL:}
     latest-version: ${SW_LATEST_VERSION_URL:${sw.public-api.base-url}/version/latest}


### PR DESCRIPTION
## Description

- Online eval can be disabled with the starting up env
- Add API (/system/features) for querying disabled features for the console, the demo response:

```json
{
  "code": "success",
  "message": "Success",
  "data": {
    "disabled": [
      "online-eval",
      "foo"
    ]
  }
}
```

cc @waynelwz 

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
