### PR TITLE
fix(controller): collect pod log before delete when cancel job

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/log/CancellableTaskLogK8sCollector.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/log/CancellableTaskLogK8sCollector.java
@@ -35,7 +35,7 @@ public class CancellableTaskLogK8sCollector implements CancellableTaskLogCollect
     public CancellableTaskLogK8sCollector(K8sClient k8sClient, Long taskId)
             throws IOException, ApiException {
         this.k8sClient = k8sClient;
-        call = k8sClient.readLog(getPodName(taskId), WORKER_CONTAINER);
+        call = k8sClient.readLog(getPodName(taskId), WORKER_CONTAINER, true);
         resp = call.execute();
         bufferedReader = new BufferedReader(new InputStreamReader(resp.body().byteStream(), StandardCharsets.UTF_8));
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/log/TaskLogK8sCollector.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/log/TaskLogK8sCollector.java
@@ -63,7 +63,7 @@ public class TaskLogK8sCollector implements TaskLogCollector {
                 log.warn("pod not exists for task {}", task.getId());
                 return;
             }
-            String logName = v1Pod.getMetadata().getName() + System.currentTimeMillis() / 1000;
+            String logName = v1Pod.getMetadata().getName();
             String taskLog = k8sClient.logOfPod(v1Pod, containers);
             log.debug("logs for task {} collected {} ...", task.getId(),
                     StringUtils.hasText(taskLog) ? taskLog.substring(0, Math.min(taskLog.length() - 1, 100)) : "");

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/SwTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/SwTaskScheduler.java
@@ -33,8 +33,8 @@ public interface SwTaskScheduler {
     void schedule(Collection<Task> tasks);
 
     /**
-     * @param taskIds tasks to be stop scheduled
+     * @param tasks tasks to be stop scheduled
      */
-    void stop(Collection<Long> taskIds);
+    void stop(Collection<Task> tasks);
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
@@ -278,7 +278,7 @@ public class K8sClient {
         InputStream is = null;
         Response response = null;
         try {
-            Call call = readLog(pod.getMetadata().getName(), containerName);
+            Call call = readLog(pod.getMetadata().getName(), containerName, false);
             response = call.execute();
             if (!response.isSuccessful()) {
                 throw new ApiException(response.code(), "Logs request failed: " + response.code());
@@ -304,12 +304,12 @@ public class K8sClient {
         log.debug("log for container {} collected", containerName);
     }
 
-    public Call readLog(String pod, String container) throws IOException, ApiException {
+    public Call readLog(String pod, String container, boolean follow) throws IOException, ApiException {
         return coreV1Api.readNamespacedPodLogCall(
                 pod,
                 ns,
                 container,
-                true,
+                follow,
                 null,
                 null,
                 "false",

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/PodEventHandler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/PodEventHandler.java
@@ -59,7 +59,6 @@ public class PodEventHandler implements ResourceEventHandler<V1Pod> {
 
     @Override
     public void onDelete(V1Pod obj, boolean deletedFinalStateUnknown) {
-        collectLog(obj);
     }
 
     private Long getTaskId(V1Pod pod) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/PodEventHandler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/PodEventHandler.java
@@ -59,6 +59,7 @@ public class PodEventHandler implements ResourceEventHandler<V1Pod> {
 
     @Override
     public void onDelete(V1Pod obj, boolean deletedFinalStateUnknown) {
+        collectLog(obj);
     }
 
     private Long getTaskId(V1Pod pod) {
@@ -131,6 +132,7 @@ public class PodEventHandler implements ResourceEventHandler<V1Pod> {
     }
 
     private void collectLog(V1Pod pod) {
+        log.debug("collect log for pod {} status {}", pod.getMetadata().getName(), pod.getStatus());
         if (null == pod.getStatus()
                 || null == pod.getStatus().getContainerStatuses()
                 || null == pod.getStatus().getContainerStatuses().get(0)

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskWatcherForScheduleTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskWatcherForScheduleTest.java
@@ -53,7 +53,7 @@ public class TaskWatcherForScheduleTest {
                 .build();
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.CREATED);
         verify(taskScheduler).schedule(List.of(task));
-        verify(taskScheduler, times(0)).stop(List.of(task.getId()));
+        verify(taskScheduler, times(0)).stop(List.of(task));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class TaskWatcherForScheduleTest {
         task.updateStatus(TaskStatus.CANCELED);
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.READY);
         verify(taskScheduler, times(0)).schedule(List.of(task));
-        verify(taskScheduler, times(2)).stop(List.of(task.getId()));
+        verify(taskScheduler, times(2)).stop(List.of(task));
     }
 
     @Test
@@ -93,10 +93,10 @@ public class TaskWatcherForScheduleTest {
         task.updateStatus(TaskStatus.SUCCESS);
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.RUNNING);
         taskWatcherForSchedule.processTaskDeletion();
-        verify(taskScheduler, times(0)).stop(List.of(task.getId()));
+        verify(taskScheduler, times(0)).stop(List.of(task));
         Thread.sleep(1000 * 60L);
         taskWatcherForSchedule.processTaskDeletion();
-        verify(taskScheduler, times(1)).stop(List.of(task.getId(), task.getId()));
+        verify(taskScheduler, times(1)).stop(List.of(task, task));
     }
 
     @Test
@@ -116,6 +116,6 @@ public class TaskWatcherForScheduleTest {
 
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.FAIL);
         verify(taskScheduler, times(0)).schedule(List.of(task));
-        verify(taskScheduler, times(0)).stop(List.of(task.getId()));
+        verify(taskScheduler, times(0)).stop(List.of(task));
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/log/CancellableTaskLogK8sCollectorFactoryTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/log/CancellableTaskLogK8sCollectorFactoryTest.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.domain.task.log;
 
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,7 +48,7 @@ public class CancellableTaskLogK8sCollectorFactoryTest {
         when(respBody.byteStream()).thenReturn(new ByteArrayInputStream("".getBytes()));
         when(resp.body()).thenReturn(respBody);
         when(call.execute()).thenReturn(resp);
-        when(k8sClient.readLog(anyString(), anyString())).thenReturn(call);
+        when(k8sClient.readLog(anyString(), anyString(), anyBoolean())).thenReturn(call);
         var factory = new CancellableTaskLogK8sCollectorFactory(k8sClient);
         var collector = factory.make(1L);
         Assertions.assertNotNull(collector);

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/log/CancellableTaskLogK8sCollectorTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/log/CancellableTaskLogK8sCollectorTest.java
@@ -18,6 +18,7 @@ package ai.starwhale.mlops.domain.task.log;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -60,7 +61,7 @@ public class CancellableTaskLogK8sCollectorTest {
         when(resp.body()).thenReturn(respBody);
         when(call.execute()).thenReturn(resp);
 
-        when(k8sClient.readLog(anyString(), anyString())).thenReturn(call);
+        when(k8sClient.readLog(anyString(), anyString(), anyBoolean())).thenReturn(call);
         var ins = new CancellableTaskLogK8sCollector(k8sClient, 1L);
 
         assertThat(ins.readLine(), is(line));

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
@@ -113,7 +113,7 @@ public class K8sClientTest {
                 eq("pdn"),
                 eq(nameSpace),
                 anyString(),
-                eq(true),
+                eq(false),
                 eq(null),
                 eq(null),
                 eq("false"),

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sTaskSchedulerTest.java
@@ -43,6 +43,7 @@ import ai.starwhale.mlops.domain.task.bo.ResultPath;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.bo.TaskRequest;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
+import ai.starwhale.mlops.domain.task.status.watchers.log.TaskLogK8sCollector;
 import ai.starwhale.mlops.storage.StorageAccessService;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiException;
@@ -85,11 +86,10 @@ public class K8sTaskSchedulerTest {
                 taskTokenValidator,
                 runTimeProperties,
                 new K8sJobTemplateMock(""),
-                null,
-                null,
-                null, "http://instanceUri", 50,
+                "http://instanceUri", 50,
                 "OnFailure", 10,
-                storageAccessService);
+                storageAccessService,
+                mock(TaskLogK8sCollector.class));
         return scheduler;
     }
 
@@ -114,13 +114,12 @@ public class K8sTaskSchedulerTest {
                 mock(TaskTokenValidator.class),
                 runTimeProperties,
                 k8sJobTemplate,
-                null,
-                null,
-                null, "",
+                "",
                 50,
                 "OnFailure",
                 10,
-                mock(StorageAccessService.class)
+                mock(StorageAccessService.class),
+                mock(TaskLogK8sCollector.class)
         );
         var task = mockTask(false);
         scheduler.schedule(Set.of(task));
@@ -149,13 +148,12 @@ public class K8sTaskSchedulerTest {
                 mock(TaskTokenValidator.class),
                 runTimeProperties,
                 k8sJobTemplate,
-                null,
-                null,
-                null, "",
+                "",
                 50,
                 "OnFailure",
                 10,
-                mock(StorageAccessService.class)
+                mock(StorageAccessService.class),
+                mock(TaskLogK8sCollector.class)
         );
         var task = mockTask(false);
         var pool = task.getStep().getResourcePool();
@@ -188,13 +186,12 @@ public class K8sTaskSchedulerTest {
                 mock(TaskTokenValidator.class),
                 runTimeProperties,
                 k8sJobTemplate,
-                null,
-                null,
-                null, "",
+                "",
                 50,
                 "OnFailure",
                 10,
-                mock(StorageAccessService.class)
+                mock(StorageAccessService.class),
+                mock(TaskLogK8sCollector.class)
         );
         var task = mockTask(true);
         scheduler.schedule(Set.of(task));


### PR DESCRIPTION
## Description

- Collect the pod log before deleting the job
- Use pod name as log file name (remove the timestamp)

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
