### PR TITLE
chore(controller): use the start and stop time in workload

### DIFF
--- a/console/src/domain/job/schemas/task.tsx
+++ b/console/src/domain/job/schemas/task.tsx
@@ -22,6 +22,8 @@ export interface ITaskSchema extends IResourceSchema {
     stepName: string
     retryNum: number
     devUrl?: string
+    startedTime: number
+    finishedTime: number
 }
 
 export type ITaskDetailSchema = ITaskSchema

--- a/console/src/pages/Job/TaskListCard.tsx
+++ b/console/src/pages/Job/TaskListCard.tsx
@@ -70,10 +70,10 @@ export default function TaskListCard({ header, onAction }: ITaskListCardProps) {
                                     )
                                 }
                             </WithCurrentAuth>,
-                            task.createdTime && formatTimestampDateTime(task.createdTime),
-                            task.stopTime && formatTimestampDateTime(task.stopTime),
-                            task.stopTime && task.createdTime && task.stopTime !== -1 && task.createdTime !== -1
-                                ? moment.duration(task.stopTime - task.createdTime, 'milliseconds').humanize()
+                            task.startedTime && formatTimestampDateTime(task.startedTime),
+                            task.finishedTime && formatTimestampDateTime(task.finishedTime),
+                            task.finishedTime && task.startedTime && task.finishedTime !== -1 && task.startedTime !== -1
+                                ? moment.duration(task.finishedTime - task.startedTime, 'milliseconds').humanize()
                                 : '-',
                             <JobStatus key='status' status={task.taskStatus as any} />,
                             <StyledLink

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/task/TaskVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/task/TaskVo.java
@@ -17,7 +17,6 @@
 package ai.starwhale.mlops.api.protocol.task;
 
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
 import lombok.Builder;
@@ -36,10 +35,9 @@ public class TaskVo implements Serializable {
 
     private String uuid;
 
-    private Long createdTime;
+    private Long startedTime;
 
-    @JsonProperty("stopTime")
-    private Long endTime;
+    private Long finishedTime;
 
     private TaskStatus taskStatus;
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dag/DagQuerier.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dag/DagQuerier.java
@@ -35,9 +35,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -112,7 +112,7 @@ public class DagQuerier {
     }
 
     @Data
-    @Builder
+    @SuperBuilder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class TaskNodeContent extends TimeConcern {
@@ -133,7 +133,7 @@ public class DagQuerier {
     }
 
     @Data
-    @Builder
+    @SuperBuilder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class JobNodeContent extends TimeConcern {
@@ -152,7 +152,7 @@ public class DagQuerier {
     }
 
     @Data
-    @Builder
+    @SuperBuilder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class StepNodeContent extends TimeConcern {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/bo/Job.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/bo/Job.java
@@ -30,15 +30,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 /**
  *
  */
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Job extends TimeConcern {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/step/bo/Step.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/step/bo/Step.java
@@ -23,11 +23,11 @@ import ai.starwhale.mlops.domain.system.resourcepool.bo.ResourcePool;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import java.util.List;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-@Builder
+@SuperBuilder
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/bo/Task.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/bo/Task.java
@@ -22,16 +22,16 @@ import ai.starwhale.mlops.domain.job.step.bo.Step;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 /**
  * Tasks are derived from a Job. Tasks are the executing units of a Job.
  */
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Getter
 public class Task extends TimeConcern {
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/converter/TaskConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/converter/TaskConverter.java
@@ -68,11 +68,11 @@ public class TaskConverter {
                 .uuid(entity.getTaskUuid())
                 .taskStatus(entity.getTaskStatus())
                 .retryNum(entity.getRetryNum())
-                .endTime(entity.getFinishedTime().getTime())
+                .finishedTime(entity.getFinishedTime().getTime())
                 .stepName(step.getName())
                 .devUrl(entity.getDevWay() != null && StringUtils.hasText(entity.getIp())
                         ? entity.getDevWay().toDevUrl(entity.getIp(), devPort) : null)
-                .createdTime(entity.getStartedTime().getTime())
+                .startedTime(entity.getStartedTime().getTime())
                 .resourcePool(pool)
                 .build();
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/mapper/TaskMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/mapper/TaskMapper.java
@@ -91,8 +91,14 @@ public interface TaskMapper {
     @Update("update task_info set finished_time = #{finishedTime} where id = #{taskId}")
     void updateTaskFinishedTime(@Param("taskId") Long taskId, @Param("finishedTime") Date finishedTime);
 
+    @Update("update task_info set finished_time = #{finishedTime} where id = #{taskId} and finished_time is null")
+    void updateTaskFinishedTimeIfNotSet(@Param("taskId") Long taskId, @Param("finishedTime") Date finishedTime);
+
     @Update("update task_info set started_time = #{startedTime} where id = #{taskId}")
     void updateTaskStartedTime(@Param("taskId") Long taskId, @Param("startedTime") Date startedTime);
+
+    @Update("update task_info set started_time = #{startedTime} where id = #{taskId} and started_time is null")
+    void updateTaskStartedTimeIfNotSet(@Param("taskId") Long taskId, @Param("startedTime") Date startedTime);
 
     @Select("select " + COLUMNS + " from task_info where step_id = #{stepId}")
     List<TaskEntity> findByStepId(@Param("stepId") Long stepId);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/WatchableTask.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/WatchableTask.java
@@ -120,6 +120,16 @@ public class WatchableTask extends Task implements TaskWrapper {
         originalTask.setRetryNum(retryNum);
     }
 
+    @Override
+    public void setStartTime(Long startTime) {
+        originalTask.setStartTime(startTime);
+    }
+
+    @Override
+    public void setFinishTime(Long finishTime) {
+        originalTask.setFinishTime(finishTime);
+    }
+
     public void setResultRootPath(ResultPath resultRootPath) {
         originalTask.setResultRootPath(resultRootPath);
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForPersist.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForPersist.java
@@ -50,14 +50,21 @@ public class TaskWatcherForPersist implements TaskStatusChangeWatcher {
     public void onTaskStatusChange(Task task, TaskStatus oldStatus) {
         log.debug("persisting task for {} ", task.getId());
         TaskStatus status = task.getStatus();
-        var now = new Date();
         if (taskStatusMachine.isFinal(status)) {
-            task.setFinishTime(now.getTime());
-            taskMapper.updateTaskFinishedTime(task.getId(), now);
+            var tm = task.getFinishTime();
+            if (tm == null) {
+                taskMapper.updateTaskFinishedTimeIfNotSet(task.getId(), new Date());
+            } else {
+                taskMapper.updateTaskFinishedTime(task.getId(), new Date(tm));
+            }
         }
         if (status == TaskStatus.RUNNING) {
-            task.setStartTime(now.getTime());
-            taskMapper.updateTaskStartedTime(task.getId(), now);
+            var tm = task.getStartTime();
+            if (tm == null) {
+                taskMapper.updateTaskStartedTimeIfNotSet(task.getId(), new Date());
+            } else {
+                taskMapper.updateTaskStartedTime(task.getId(), new Date(tm));
+            }
         }
         taskMapper.updateTaskStatus(List.of(task.getId()), status);
         log.debug("task {} status persisted to {} ", task.getId(), status);

--- a/server/controller/src/main/java/ai/starwhale/mlops/reporting/ReportedTask.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/reporting/ReportedTask.java
@@ -18,6 +18,7 @@ package ai.starwhale.mlops.reporting;
 
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -27,10 +28,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @EqualsAndHashCode
+@Builder
 public class ReportedTask {
 
     final Long id;
     final TaskStatus status;
     final Integer retryCount;
     final String ip;
+    final Long startTimeMillis;
+    final Long stopTimeMillis;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/JobEventHandler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/JobEventHandler.java
@@ -107,6 +107,7 @@ public class JobEventHandler implements ResourceEventHandler<V1Job> {
         if (status == null) {
             return;
         }
+        Long stopTime = null;
         TaskStatus taskStatus = TaskStatus.UNKNOWN;
         // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#jobstatus-v1-batch
         //  The latest available observations of an object's current state.
@@ -126,12 +127,15 @@ public class JobEventHandler implements ResourceEventHandler<V1Job> {
                     log.warn("multiple True status conditions for job received {} random one is chosen",
                             conditionsLogString(conditions));
                 }
-                String type = collect.get(0).getType();
+                var condition = collect.get(0);
+                String type = condition.getType();
                 if ("Failed".equalsIgnoreCase(type)) {
                     taskStatus = TaskStatus.FAIL;
+                    stopTime = Util.k8sTimeToMs(condition.getLastTransitionTime());
                     log.debug("job status changed for {} is failed {}", jobName(job), status);
                 } else if ("Complete".equalsIgnoreCase(type)) {
                     taskStatus = TaskStatus.SUCCESS;
+                    stopTime = Util.k8sTimeToMs(condition.getLastTransitionTime());
                 } else if ("Suspended".equalsIgnoreCase(type)) {
                     log.warn("unexpected task status detected {}", type);
                 } else {
@@ -139,10 +143,28 @@ public class JobEventHandler implements ResourceEventHandler<V1Job> {
                 }
             }
         }
+        // warning: Represents time when the job controller started processing a job.
+        // When a Job is created in the suspended state, this field is not set until the first time it is resumed.
+        // This field is reset every time a Job is resumed from suspension.
+        // It is represented in RFC3339 form and is in UTC.
+        // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jobstatus-v1-batch
+        // get the start time of the job to fill in the task status, beware that the start time is not reliable
+        // we only use it to fill in the task start time when the start time filed is not set
+        Long startTime = null;
+        if (null != status.getStartTime()) {
+            startTime = status.getStartTime().toInstant().toEpochMilli();
+        }
+
         // retry number here is not reliable, it only counts failed pods that is not deleted
         Integer retryNum = null != status.getFailed() ? status.getFailed() : 0;
-        taskModifyReceiver.receive(List.of(
-                new ReportedTask(Long.parseLong(jobName(job)), taskStatus, retryNum, null)));
+        var report = ReportedTask.builder()
+                .id(Long.parseLong(jobName(job)))
+                .status(taskStatus)
+                .startTimeMillis(startTime)
+                .stopTimeMillis(stopTime)
+                .retryCount(retryNum)
+                .build();
+        taskModifyReceiver.receive(List.of(report));
     }
 
     private String conditionsLogString(List<V1JobCondition> conditions) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/JobEventHandler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/JobEventHandler.java
@@ -150,10 +150,7 @@ public class JobEventHandler implements ResourceEventHandler<V1Job> {
         // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jobstatus-v1-batch
         // get the start time of the job to fill in the task status, beware that the start time is not reliable
         // we only use it to fill in the task start time when the start time filed is not set
-        Long startTime = null;
-        if (null != status.getStartTime()) {
-            startTime = status.getStartTime().toInstant().toEpochMilli();
-        }
+        Long startTime = Util.k8sTimeToMs(status.getStartTime());
 
         // retry number here is not reliable, it only counts failed pods that is not deleted
         Integer retryNum = null != status.getFailed() ? status.getFailed() : 0;

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/Util.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/Util.java
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.common;
+package ai.starwhale.mlops.schedule.k8s;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import java.time.OffsetDateTime;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-@SuperBuilder
-public class TimeConcern {
-
-    Long startTime = System.currentTimeMillis();
-    Long finishTime;
-
+public class Util {
+    public static Long k8sTimeToMs(OffsetDateTime time) {
+        if (time == null) {
+            return null;
+        }
+        return time.toInstant().toEpochMilli();
+    }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskConverterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskConverterTest.java
@@ -90,8 +90,8 @@ public class TaskConverterTest {
         TaskVo taskVo = taskConvertor.convert(taskEntity);
         Assertions.assertEquals(taskVo.getTaskStatus(), taskEntity.getTaskStatus());
         Assertions.assertEquals(taskVo.getUuid(), taskEntity.getTaskUuid());
-        Assertions.assertEquals(taskVo.getEndTime(), taskEntity.getFinishedTime().getTime());
-        Assertions.assertEquals(taskVo.getCreatedTime(), taskEntity.getStartedTime().getTime());
+        Assertions.assertEquals(taskVo.getFinishedTime(), taskEntity.getFinishedTime().getTime());
+        Assertions.assertEquals(taskVo.getStartedTime(), taskEntity.getStartedTime().getTime());
         Assertions.assertEquals(taskVo.getStepName(), "ppl");
         Assertions.assertEquals(taskVo.getRetryNum(), taskEntity.getRetryNum());
         Assertions.assertEquals(taskVo.getDevUrl(), "http://127.0.0.1:8000");

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskServiceTest.java
@@ -48,13 +48,9 @@ public class TaskServiceTest {
 
     TaskService taskService;
     TaskConverter taskConvertor;
-
     TaskMapper taskMapper;
-
     StorageAccessService storageAccessService;
-
     JobDao jobDao;
-
     StepMapper stepMapper;
 
     @BeforeEach
@@ -93,14 +89,12 @@ public class TaskServiceTest {
         Assertions.assertEquals(2, taskVoPageInfo.getSize());
         Assertions.assertEquals(2, taskVoPageInfo.getList().size());
         assertThat(taskVoPageInfo.getList(), containsInAnyOrder(
-                TaskVo.builder().id("1").createdTime(startedTime.getTime()).endTime(finishedTime.getTime())
+                TaskVo.builder().id("1").startedTime(startedTime.getTime()).finishedTime(finishedTime.getTime())
                         .uuid("uuid1")
                         .taskStatus(TaskStatus.RUNNING).resourcePool("a").stepName("ppl").build(),
-                TaskVo.builder().id("2").createdTime(startedTime.getTime()).endTime(finishedTime.getTime())
+                TaskVo.builder().id("2").startedTime(startedTime.getTime()).finishedTime(finishedTime.getTime())
                         .uuid("uuid2")
                         .taskStatus(TaskStatus.SUCCESS).resourcePool("a").stepName("ppl").build()));
-
-
     }
 
     @Test
@@ -132,14 +126,12 @@ public class TaskServiceTest {
         Assertions.assertEquals(2, taskVoPageInfo.getSize());
         Assertions.assertEquals(2, taskVoPageInfo.getList().size());
         assertThat(taskVoPageInfo.getList(), containsInAnyOrder(
-                TaskVo.builder().id("1").createdTime(startedTime.getTime()).endTime(finishedTime.getTime())
+                TaskVo.builder().id("1").startedTime(startedTime.getTime()).finishedTime(finishedTime.getTime())
                         .uuid("uuid1")
                         .taskStatus(TaskStatus.RUNNING).resourcePool("job from step").stepName("ppl").build(),
-                TaskVo.builder().id("2").createdTime(startedTime.getTime()).endTime(finishedTime.getTime())
+                TaskVo.builder().id("2").startedTime(startedTime.getTime()).finishedTime(finishedTime.getTime())
                         .uuid("uuid2")
                         .taskStatus(TaskStatus.SUCCESS).resourcePool("job from step").stepName("ppl").build()));
-
-
     }
 
     @Test
@@ -158,8 +150,8 @@ public class TaskServiceTest {
 
         var taskVo = TaskVo.builder()
                 .id("1")
-                .createdTime(startedTime.getTime())
-                .endTime(finishedTime.getTime())
+                .startedTime(startedTime.getTime())
+                .finishedTime(finishedTime.getTime())
                 .taskStatus(TaskStatus.RUNNING)
                 .uuid("uuid1")
                 .stepName("ppl")

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskWatcherForPersistTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskWatcherForPersistTest.java
@@ -50,9 +50,10 @@ public class TaskWatcherForPersistTest {
                 .uuid(UUID.randomUUID().toString())
                 .status(TaskStatus.RUNNING)
                 .step(Step.builder().job(Job.builder().jobRuntime(JobRuntime.builder().build()).build()).build())
+                .startTime(7L)
                 .build();
         taskWatcherForPersist.onTaskStatusChange(task, TaskStatus.READY);
-        verify(taskMapper).updateTaskStartedTime(eq(task.getId()), argThat(d -> d.getTime() > 0));
+        verify(taskMapper).updateTaskStartedTime(eq(task.getId()), argThat(d -> d.getTime() == 7));
         verify(taskMapper).updateTaskStatus(List.of(task.getId()), task.getStatus());
     }
 
@@ -66,10 +67,11 @@ public class TaskWatcherForPersistTest {
                 .status(TaskStatus.SUCCESS)
                 .step(Step.builder().job(Job.builder().jobRuntime(JobRuntime.builder()
                         .build()).build()).build())
+                .finishTime(8L)
                 .build();
         taskWatcherForPersist.onTaskStatusChange(task, TaskStatus.RUNNING);
         verify(taskMapper).updateTaskFinishedTime(eq(task.getId()),
-                argThat(d -> d.getTime() > 0));
+                argThat(d -> d.getTime() == 8L));
         verify(taskMapper).updateTaskStatus(List.of(task.getId()), task.getStatus());
 
     }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskWatcherForScheduleTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/TaskWatcherForScheduleTest.java
@@ -88,13 +88,14 @@ public class TaskWatcherForScheduleTest {
                 .status(TaskStatus.FAIL)
                 .step(Step.builder().job(Job.builder().jobRuntime(JobRuntime.builder()
                         .build()).build()).build())
+                .startTime(System.currentTimeMillis() - 1000 * 60L + 1000) // +1s prevent immediately deletion
                 .build();
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.RUNNING);
         task.updateStatus(TaskStatus.SUCCESS);
         taskWatcherForSchedule.onTaskStatusChange(task, TaskStatus.RUNNING);
         taskWatcherForSchedule.processTaskDeletion();
         verify(taskScheduler, times(0)).stop(List.of(task));
-        Thread.sleep(1000 * 60L);
+        Thread.sleep(2000);
         taskWatcherForSchedule.processTaskDeletion();
         verify(taskScheduler, times(1)).stop(List.of(task, task));
     }

--- a/server/controller/src/test/java/ai/starwhale/mlops/reporting/TaskModifyReceiverImpTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/reporting/TaskModifyReceiverImpTest.java
@@ -52,7 +52,12 @@ public class TaskModifyReceiverImpTest {
     @Test
     public void testFreezeTask() {
         when(jobHolder.tasksOfIds(List.of(1L))).thenReturn(Collections.emptySet());
-        taskStatusReceiver.receive(List.of(new ReportedTask(1L, TaskStatus.READY, null, "127.0.0.1")));
+        var expected = ReportedTask.builder()
+                .id(1L)
+                .status(TaskStatus.READY)
+                .ip("127.0.0.1")
+                .build();
+        taskStatusReceiver.receive(List.of(expected));
         verify(taskMapper).updateTaskStatus(List.of(1L), TaskStatus.READY);
     }
 
@@ -60,7 +65,12 @@ public class TaskModifyReceiverImpTest {
     public void testHotTask() {
         Task task = new Task();
         when(jobHolder.tasksOfIds(List.of(1L))).thenReturn(Set.of(task));
-        taskStatusReceiver.receive(List.of(new ReportedTask(1L, TaskStatus.READY, null, "127.0.0.1")));
+        var expected = ReportedTask.builder()
+                .id(1L)
+                .status(TaskStatus.READY)
+                .ip("127.0.0.1")
+                .build();
+        taskStatusReceiver.receive(List.of(expected));
         verify(taskMapper, times(0)).updateTaskStatus(List.of(1L), TaskStatus.READY);
         Assertions.assertEquals(TaskStatus.READY, task.getStatus());
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/PodEventHandlerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/PodEventHandlerTest.java
@@ -60,12 +60,12 @@ public class PodEventHandlerTest {
         taskModifyReceiver = mock(TaskModifyReceiver.class);
         podEventHandler = new PodEventHandler(taskLogK8sCollector, taskModifyReceiver, hotJobHolder);
         v1Pod = new V1Pod()
-            .metadata(new V1ObjectMeta().labels(Map.of("job-name", "3")))
-            .status(new V1PodStatus()
-                .containerStatuses(List.of(
-                    new V1ContainerStatus().state(
-                        new V1ContainerState().terminated(new V1ContainerStateTerminated()))
-                )));
+                .metadata(new V1ObjectMeta().labels(Map.of("job-name", "3")))
+                .status(new V1PodStatus()
+                        .containerStatuses(List.of(
+                                new V1ContainerStatus().state(
+                                        new V1ContainerState().terminated(new V1ContainerStateTerminated()))
+                        )));
     }
 
     @Test
@@ -86,9 +86,9 @@ public class PodEventHandlerTest {
         verify(taskModifyReceiver, times(1)).receive(any());
         verify(taskModifyReceiver).receive(argThat(tasks ->
                 tasks.size() == 1
-                    && tasks.get(0).getId() == 3L
-                    && tasks.get(0).getStatus() == TaskStatus.PREPARING
-                    && Objects.equals(tasks.get(0).getIp(), "127.0.0.1")));
+                        && tasks.get(0).getId() == 3L
+                        && tasks.get(0).getStatus() == TaskStatus.PREPARING
+                        && Objects.equals(tasks.get(0).getIp(), "127.0.0.1")));
     }
 
     @Test
@@ -105,7 +105,10 @@ public class PodEventHandlerTest {
         v1Pod.getStatus().conditions(List.of(new V1PodCondition().status("True").type("PodScheduled")));
         podEventHandler.onUpdate(null, v1Pod);
         verify(taskLogK8sCollector, times(0)).collect(any());
-        var expect = List.of(new ReportedTask(3L, TaskStatus.RUNNING, null, null));
-        verify(taskModifyReceiver, times(1)).receive(expect);
+        var expect = ReportedTask.builder()
+                .id(3L)
+                .status(TaskStatus.PREPARING)
+                .build();
+        verify(taskModifyReceiver, times(1)).receive(List.of(expect));
     }
 }


### PR DESCRIPTION
## Description

- Use the pod start time as the task start time
- User the K8s Job last success time or failed time as the task stop time
- Rename `createdTime` to `startedTime` and `stopTime` to `finishedTime` in TaskVo
- Make task status running when pod running (revert the schedule as running logic)

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
