### PR TITLE
feat(runtime): support runtime replace image registry

### DIFF
--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -117,7 +117,7 @@ from starwhale.base.bundle_copy import BundleCopy
 from starwhale.base.uri.project import Project as ProjectURI
 from starwhale.base.uri.resource import Resource, ResourceType
 
-from .store import RuntimeStorage
+from .store import RuntimeStorage, get_docker_run_image_by_manifest
 
 RUNTIME_API_VERSION = "1.1"
 _TEMPLATE_DIR = Path(__file__).parent / "template"
@@ -1751,8 +1751,6 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                 self.extract(force=True)
 
         def _render_dockerfile(_manifest: t.Dict[str, t.Any]) -> None:
-            from starwhale.core.runtime.store import get_docker_run_image_by_manifest
-
             console.print(f":wolf_face: render Dockerfile @{dockerfile_path}")
             _env = jinja2.Environment(
                 loader=jinja2.FileSystemLoader(searchpath=_TEMPLATE_DIR)

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -1751,6 +1751,8 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                 self.extract(force=True)
 
         def _render_dockerfile(_manifest: t.Dict[str, t.Any]) -> None:
+            from starwhale.core.runtime.store import get_docker_run_image_by_manifest
+
             console.print(f":wolf_face: render Dockerfile @{dockerfile_path}")
             _env = jinja2.Environment(
                 loader=jinja2.FileSystemLoader(searchpath=_TEMPLATE_DIR)
@@ -1758,7 +1760,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
             _template = _env.get_template("Dockerfile.tmpl")
             _pip = _manifest["configs"].get("pip", {})
             _out = _template.render(
-                base_image=_manifest["base_image"],
+                base_image=get_docker_run_image_by_manifest(manifest=_manifest),
                 runtime_name=self.uri.name,
                 runtime_version=_manifest["version"],
                 pypi_index_url=_pip.get("index_url", ""),

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -2622,6 +2622,17 @@ class StandaloneRuntimeTestCase(TestCase):
         manifest["version"] = version
         manifest["configs"]["docker"]["image"] = image
 
+        custom_image = "docker.io/sw/base:v1"
+        manifest["docker"] = {
+            "custom_run_image": custom_image,
+            "builtin_run_image": {
+                "repo": "self-registry/sw",
+                "name": "starwhale",
+                "tag": "v2-cuda11.7",
+                "fullname": "self-registry/sw/starwhale:v2",
+            },
+        }
+
         sr = StandaloneRuntime(uri)
 
         ensure_dir(sr.store.snapshot_workdir)
@@ -2640,7 +2651,7 @@ class StandaloneRuntimeTestCase(TestCase):
         assert dockerfile_path.exists()
         assert dockerignore_path.exists()
         dockerfile_content = dockerfile_path.read_text()
-        assert f"BASE_IMAGE={manifest['base_image']}" in dockerfile_content
+        assert f"BASE_IMAGE={custom_image}" in dockerfile_content
         assert f"starwhale_runtime_version={version}" in dockerfile_content
 
         assert m_check.call_count == 3

--- a/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
@@ -16,12 +16,11 @@
 
 package ai.starwhale.mlops.common;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Getter
 @EqualsAndHashCode

--- a/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
@@ -20,6 +20,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 @Getter
 @EqualsAndHashCode
 public class DockerImage {
@@ -35,7 +38,46 @@ public class DockerImage {
         this.image = image;
     }
 
+    /**
+     * please refer to https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go
+     */
+    private static final Pattern PATTERN_IMAGE_FULL = Pattern.compile("^(.+?)\\/(.+)$");
+
+    /**
+     * @param imageNameFull such as ghcr.io/starwhale-ai/starwhale:0.3.5-rc123.dev12432344
+     */
+    public DockerImage(String imageNameFull) {
+        Matcher matcher = PATTERN_IMAGE_FULL.matcher(imageNameFull);
+        if (!matcher.matches()) {
+            this.registry = "";
+            this.image = imageNameFull;
+        } else {
+            String candidateRegistry = matcher.group(1);
+            if (isDomain(candidateRegistry)) {
+                this.registry = candidateRegistry;
+                image = matcher.group(2);
+            } else {
+                this.registry = "";
+                this.image = imageNameFull;
+            }
+
+        }
+    }
+
+    private static final Pattern PATTERN_DOMAIN_LOCAL_HOST = Pattern.compile("localhost(:\\d+)?");
+
+    private static boolean isDomain(String candidate) {
+        return candidate.contains(".") || PATTERN_DOMAIN_LOCAL_HOST.matcher(candidate).matches();
+    }
+
     private static final String SLASH = "/";
+
+    public String resolve(String newRegistry) {
+        if (!StringUtils.hasText(newRegistry)) {
+            newRegistry = this.registry;
+        }
+        return StringUtils.trimTrailingCharacter(newRegistry, '/') + SLASH + image;
+    }
 
     public String toString() {
         return StringUtils.trimTrailingCharacter(registry, '/') + SLASH + image;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/ModelServingService.java
@@ -278,7 +278,8 @@ public class ModelServingService {
         var name = getServiceName(id);
 
         String builtImage = runtime.getBuiltImage();
-        String image = StringUtils.isNotEmpty(builtImage) ? builtImage : runtime.getImage();
+        String image = StringUtils.isNotEmpty(builtImage) ? builtImage :
+                runtime.getImage(systemSettingService.getSystemSetting().getDockerSetting().getRegistryForPull());
 
         var rt = runtimeMapper.find(runtime.getRuntimeId());
         var md = modelMapper.find(model.getModelId());

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/JobBoConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/JobBoConverter.java
@@ -119,7 +119,8 @@ public class JobBoConverter {
         RuntimeEntity runtimeEntity = runtimeMapper.find(
                 runtimeVersionEntity.getRuntimeId());
         String builtImage = runtimeVersionEntity.getBuiltImage();
-        String image = StringUtils.hasText(builtImage) ? builtImage : runtimeVersionEntity.getImage();
+        String image = StringUtils.hasText(builtImage) ? builtImage : runtimeVersionEntity.getImage(
+                    systemSettingService.getSystemSetting().getDockerSetting().getRegistryForPull());
 
         Job job;
         try {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -634,10 +634,11 @@ public class RuntimeService {
             // record image to annotations
             k8sJobTemplate.updateAnnotations(job.getMetadata(), Map.of("image", image.toString()));
 
+            var baseImage = runtimeVersion.getImage(dockerSetting.getRegistryForPull());
             Map<String, ContainerOverwriteSpec> ret = new HashMap<>();
             List<V1EnvVar> envVars = new ArrayList<>(List.of(
                     new V1EnvVar().name("SW_IMAGE_REPO").value(
-                            new DockerImage(runtimeVersion.getImage(dockerSetting.getRegistryForPull())).getRegistry()),
+                            new DockerImage(baseImage).getRegistry()),
                     new V1EnvVar().name("SW_INSTANCE_URI").value(instanceUri),
                     new V1EnvVar().name("SW_PROJECT").value(project.getName()),
                     new V1EnvVar().name("SW_RUNTIME_VERSION").value(
@@ -659,7 +660,7 @@ public class RuntimeService {
             k8sJobTemplate.getInitContainerTemplates(job).forEach(templateContainer -> {
                 ContainerOverwriteSpec containerOverwriteSpec = new ContainerOverwriteSpec(templateContainer.getName());
                 containerOverwriteSpec.setEnvs(envVars);
-                containerOverwriteSpec.setImage(runtimeVersion.getImage());
+                containerOverwriteSpec.setImage(baseImage);
                 ret.put(templateContainer.getName(), containerOverwriteSpec);
             });
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -91,6 +91,7 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -108,6 +109,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -120,6 +122,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class RuntimeService {
 
+    static final String RUNTIME_MANIFEST = "_manifest.yaml";
     private final RuntimeMapper runtimeMapper;
     private final RuntimeVersionMapper runtimeVersionMapper;
     private final StorageService storageService;
@@ -495,15 +498,12 @@ public class RuntimeService {
         }
         /* create new entity */
         if (!entityExists) {
-            RuntimeManifest runtimeManifestObj;
             String runtimeManifest;
             try (final InputStream inputStream = dsFile.getInputStream()) {
-                // only extract the eval job file content
+                // extract the manifest file content
                 runtimeManifest = new String(
                         Objects.requireNonNull(
-                                TarFileUtil.getContentFromTarFile(inputStream, "", "_manifest.yaml")));
-                runtimeManifestObj = Constants.yamlMapper.readValue(runtimeManifest,
-                        RuntimeManifest.class);
+                                TarFileUtil.getContentFromTarFile(inputStream, "", RUNTIME_MANIFEST)));
             } catch (IOException e) {
                 log.error("upload runtime failed {}", uploadRequest.getRuntime(), e);
                 throw new StarwhaleApiException(new SwProcessException(ErrorType.SYSTEM),
@@ -515,7 +515,8 @@ public class RuntimeService {
                     .runtimeId(entity.getId())
                     .versionName(uploadRequest.version())
                     .versionMeta(runtimeManifest)
-                    .image(null == runtimeManifestObj ? null : runtimeManifestObj.getBaseImage())
+                    // TODO: deprecated this set operation
+                    .image(RuntimeVersionEntity.extractImage(runtimeManifest, null))
                     .build();
             runtimeVersionMapper.insert(version);
             RevertManager.create(bundleManager, runtimeDao)
@@ -536,7 +537,8 @@ public class RuntimeService {
         @Data
         @NoArgsConstructor
         @AllArgsConstructor
-        static
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static
         class Docker {
             @JsonProperty("builtin_run_image")
             BuiltinImage builtinImage;
@@ -548,7 +550,8 @@ public class RuntimeService {
         @Data
         @NoArgsConstructor
         @AllArgsConstructor
-        static
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static
         class BuiltinImage {
             @JsonProperty("fullname")
             String fullName;
@@ -639,7 +642,10 @@ public class RuntimeService {
             k8sJobTemplate.updateAnnotations(job.getMetadata(), Map.of("image", image.toString()));
 
             Map<String, ContainerOverwriteSpec> ret = new HashMap<>();
+            // TODO add SW_IMAGE_REPO env for build
             List<V1EnvVar> envVars = new ArrayList<>(List.of(
+                    new V1EnvVar().name("SW_IMAGE_REPO").value(
+                            new DockerImage(runtimeVersion.getImage(dockerSetting.getRegistryForPull())).getRegistry()),
                     new V1EnvVar().name("SW_INSTANCE_URI").value(instanceUri),
                     new V1EnvVar().name("SW_PROJECT").value(project.getName()),
                     new V1EnvVar().name("SW_RUNTIME_VERSION").value(

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -91,7 +91,6 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -103,13 +102,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -515,8 +512,6 @@ public class RuntimeService {
                     .runtimeId(entity.getId())
                     .versionName(uploadRequest.version())
                     .versionMeta(runtimeManifest)
-                    // TODO: deprecated this set operation
-                    .image(RuntimeVersionEntity.extractImage(runtimeManifest, null))
                     .build();
             runtimeVersionMapper.insert(version);
             RevertManager.create(bundleManager, runtimeDao)
@@ -538,8 +533,7 @@ public class RuntimeService {
         @NoArgsConstructor
         @AllArgsConstructor
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public static
-        class Docker {
+        public static class Docker {
             @JsonProperty("builtin_run_image")
             BuiltinImage builtinImage;
 
@@ -551,8 +545,7 @@ public class RuntimeService {
         @NoArgsConstructor
         @AllArgsConstructor
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public static
-        class BuiltinImage {
+        public static class BuiltinImage {
             @JsonProperty("fullname")
             String fullName;
             String name;
@@ -642,7 +635,6 @@ public class RuntimeService {
             k8sJobTemplate.updateAnnotations(job.getMetadata(), Map.of("image", image.toString()));
 
             Map<String, ContainerOverwriteSpec> ret = new HashMap<>();
-            // TODO add SW_IMAGE_REPO env for build
             List<V1EnvVar> envVars = new ArrayList<>(List.of(
                     new V1EnvVar().name("SW_IMAGE_REPO").value(
                             new DockerImage(runtimeVersion.getImage(dockerSetting.getRegistryForPull())).getRegistry()),

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -102,7 +102,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
+
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -526,6 +529,33 @@ public class RuntimeService {
 
         @JsonProperty("base_image")
         String baseImage;
+
+        @JsonProperty("docker")
+        Docker docker;
+
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        static
+        class Docker {
+            @JsonProperty("builtin_run_image")
+            BuiltinImage builtinImage;
+
+            @JsonProperty("custom_run_image")
+            String customImage;
+        }
+
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        static
+        class BuiltinImage {
+            @JsonProperty("fullname")
+            String fullName;
+            String name;
+            String repo;
+            String tag;
+        }
     }
 
     public void pull(String projectUrl, String runtimeUrl, String versionUrl, HttpServletResponse httpResponse) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/converter/RuntimeVersionConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/converter/RuntimeVersionConverter.java
@@ -21,6 +21,7 @@ import static cn.hutool.core.util.BooleanUtil.toInt;
 import ai.starwhale.mlops.api.protocol.runtime.RuntimeVersionVo;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.VersionAliasConverter;
+import ai.starwhale.mlops.configuration.DockerSetting;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
 import ai.starwhale.mlops.exception.ConvertException;
 import org.springframework.stereotype.Component;
@@ -31,10 +32,14 @@ public class RuntimeVersionConverter {
     private final IdConverter idConvertor;
     private final VersionAliasConverter versionAliasConvertor;
 
+    private final DockerSetting dockerSetting;
+
     public RuntimeVersionConverter(IdConverter idConvertor,
-            VersionAliasConverter versionAliasConvertor) {
+                                   VersionAliasConverter versionAliasConvertor,
+                                   DockerSetting dockerSetting) {
         this.idConvertor = idConvertor;
         this.versionAliasConvertor = versionAliasConvertor;
+        this.dockerSetting = dockerSetting;
     }
 
     public RuntimeVersionVo convert(RuntimeVersionEntity entity)
@@ -50,7 +55,7 @@ public class RuntimeVersionConverter {
                 .alias(versionAliasConvertor.convert(entity.getVersionOrder(), latest, entity))
                 .tag(entity.getVersionTag())
                 .meta(entity.getVersionMeta())
-                .image(entity.getImage())
+                .image(entity.getImage(dockerSetting.getRegistryForPull()))
                 .builtImage(entity.getBuiltImage())
                 .shared(toInt(entity.getShared()))
                 .createdTime(entity.getCreatedTime().getTime())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/po/RuntimeVersionEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/po/RuntimeVersionEntity.java
@@ -80,8 +80,8 @@ public class RuntimeVersionEntity extends BaseEntity implements BundleVersionEnt
                     return docker.getCustomImage();
                 } else {
                     var dockerImage = new DockerImage(docker.getBuiltinImage().getFullName());
-                    return StringUtils.hasText(replaceableBuiltinRegistry) ?
-                            dockerImage.resolve(replaceableBuiltinRegistry) : dockerImage.toString();
+                    return StringUtils.hasText(replaceableBuiltinRegistry)
+                            ? dockerImage.resolve(replaceableBuiltinRegistry) : dockerImage.toString();
                 }
             } else {
                 return manifestObj.getBaseImage();

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/DockerImageTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/DockerImageTest.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.common;
 
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -23,8 +24,151 @@ public class DockerImageTest {
 
     @Test
     public void testGhcrConstructor() {
-        String dockerImage = "ghcr.io/star-whale/starwhale:latest";
-        Assertions.assertEquals(new DockerImage("ghcr.io//", "star-whale/starwhale:latest").toString(), dockerImage);
+        Assertions.assertEquals(
+            new DockerImage("ghcr.io//", "star-whale/starwhale:latest").toString(),
+            "ghcr.io/star-whale/starwhale:latest");
+
+        DockerImage dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(
+            new DockerImage("ghcr.io", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+            dockerImage);
+
+        dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:latest");
+        Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale:latest"), dockerImage);
+
+        dockerImage = new DockerImage("ghcr.io/star-whale/starwhale");
+        Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale"), dockerImage);
     }
+
+    @Test
+    public void testLocalhostPortConstructor() {
+        DockerImage dockerImage = new DockerImage(
+            "localhost:8083/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(
+            new DockerImage("localhost:8083", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+            dockerImage);
+
+        dockerImage = new DockerImage("localhost:8083/star-whale/starwhale:latest");
+        Assertions.assertEquals(new DockerImage("localhost:8083", "star-whale/starwhale:latest"), dockerImage);
+
+        dockerImage = new DockerImage("localhost:8083/star-whale/starwhale");
+        Assertions.assertEquals(new DockerImage("localhost:8083", "star-whale/starwhale"), dockerImage);
+    }
+
+    @Test
+    public void testLocalhostConstructor() {
+        DockerImage dockerImage = new DockerImage(
+            "localhost/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(
+            new DockerImage("localhost", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+            dockerImage);
+
+        dockerImage = new DockerImage("localhost/star-whale/starwhale:latest");
+        Assertions.assertEquals(new DockerImage("localhost", "star-whale/starwhale:latest"), dockerImage);
+
+        dockerImage = new DockerImage("localhost/star-whale/starwhale");
+        Assertions.assertEquals(new DockerImage("localhost", "star-whale/starwhale"), dockerImage);
+    }
+
+    @Test
+    public void testDockerConstructor() {
+        DockerImage dockerImage = new DockerImage(
+            "docker.io/starwhaleai/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(
+            new DockerImage("docker.io", "starwhaleai/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+            dockerImage);
+
+        dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:latest");
+        Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale:latest"), dockerImage);
+
+        dockerImage = new DockerImage("ghcr.io/star-whale/starwhale");
+        Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale"), dockerImage);
+
+    }
+
+    @Test
+    public void testHostPortConstructor() {
+        DockerImage dockerImage = new DockerImage(
+            "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000",
+            "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
+
+        dockerImage = new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:latest");
+        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000", "star-whale/starwhale:latest"),
+            dockerImage);
+
+        dockerImage = new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale");
+        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000", "star-whale/starwhale"),
+            dockerImage);
+
+        dockerImage = new DockerImage(
+            "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000",
+            "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
+    }
+
+    @Test
+    public void testIpPortConstructor() {
+        DockerImage dockerImage = new DockerImage(
+            "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(
+            new DockerImage("131.0.1.8:5000", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+            dockerImage);
+
+        dockerImage = new DockerImage("131.0.1.8:5000/star-whale/starwhale:latest");
+        Assertions.assertEquals(new DockerImage("131.0.1.8:5000", "star-whale/starwhale:latest"), dockerImage);
+
+        dockerImage = new DockerImage("131.0.1.8:5000/star-whale/starwhale");
+        Assertions.assertEquals(new DockerImage("131.0.1.8:5000", "star-whale/starwhale"), dockerImage);
+    }
+
+    @Test
+    public void testOnlyNameConstructor() {
+        DockerImage dockerImage = new DockerImage("star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(new DockerImage("", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+            dockerImage);
+
+        dockerImage = new DockerImage("star-whale/starwhale:latest");
+        Assertions.assertEquals(new DockerImage("", "star-whale/starwhale:latest"), dockerImage);
+
+        dockerImage = new DockerImage("star-whale/starwhale");
+        Assertions.assertEquals(new DockerImage("", "star-whale/starwhale"), dockerImage);
+
+    }
+
+    @Test
+    public void testResolve() {
+        Map<String, String> images = Map.of(
+            "docker.io", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+            "docker.io/", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+            "ghcr.io", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+            "ghcr.io/", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+            "131.0.1.8:5000", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+            "131.0.1.8:5000/", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+            "homepage-ca.intra.starwhale.ai:5000",
+            "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+            "homepage-ca.intra.starwhale.ai:5000/",
+            "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+            "localhost:5000", "localhost:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"
+        );
+        images.forEach((k, v) -> Assertions.assertEquals(v,
+            new DockerImage("docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507").resolve(k)));
+
+        images.forEach((k, v) -> Assertions.assertEquals(v,
+            new DockerImage("ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507").resolve(k)));
+
+        images.forEach((k, v) -> Assertions.assertEquals(v,
+            new DockerImage("star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507").resolve(k)));
+
+        images.forEach((k, v) -> Assertions.assertEquals(v,
+            new DockerImage(
+                "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507")
+                .resolve(k)
+        ));
+
+        images.forEach((k, v) -> Assertions.assertEquals(v, new DockerImage(v).resolve("")));
+
+    }
+
 
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/DockerImageTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/DockerImageTest.java
@@ -25,13 +25,13 @@ public class DockerImageTest {
     @Test
     public void testGhcrConstructor() {
         Assertions.assertEquals(
-            new DockerImage("ghcr.io//", "star-whale/starwhale:latest").toString(),
-            "ghcr.io/star-whale/starwhale:latest");
+                new DockerImage("ghcr.io//", "star-whale/starwhale:latest").toString(),
+                "ghcr.io/star-whale/starwhale:latest");
 
         DockerImage dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-            new DockerImage("ghcr.io", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
-            dockerImage);
+                new DockerImage("ghcr.io", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                dockerImage);
 
         dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:latest");
         Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale:latest"), dockerImage);
@@ -43,10 +43,10 @@ public class DockerImageTest {
     @Test
     public void testLocalhostPortConstructor() {
         DockerImage dockerImage = new DockerImage(
-            "localhost:8083/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+                "localhost:8083/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-            new DockerImage("localhost:8083", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
-            dockerImage);
+                new DockerImage("localhost:8083", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                dockerImage);
 
         dockerImage = new DockerImage("localhost:8083/star-whale/starwhale:latest");
         Assertions.assertEquals(new DockerImage("localhost:8083", "star-whale/starwhale:latest"), dockerImage);
@@ -58,10 +58,10 @@ public class DockerImageTest {
     @Test
     public void testLocalhostConstructor() {
         DockerImage dockerImage = new DockerImage(
-            "localhost/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+                "localhost/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-            new DockerImage("localhost", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
-            dockerImage);
+                new DockerImage("localhost", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                dockerImage);
 
         dockerImage = new DockerImage("localhost/star-whale/starwhale:latest");
         Assertions.assertEquals(new DockerImage("localhost", "star-whale/starwhale:latest"), dockerImage);
@@ -73,10 +73,10 @@ public class DockerImageTest {
     @Test
     public void testDockerConstructor() {
         DockerImage dockerImage = new DockerImage(
-            "docker.io/starwhaleai/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+                "docker.io/starwhaleai/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-            new DockerImage("docker.io", "starwhaleai/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
-            dockerImage);
+                new DockerImage("docker.io", "starwhaleai/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                dockerImage);
 
         dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:latest");
         Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale:latest"), dockerImage);
@@ -89,31 +89,31 @@ public class DockerImageTest {
     @Test
     public void testHostPortConstructor() {
         DockerImage dockerImage = new DockerImage(
-            "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+                "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000",
-            "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
+                "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
 
         dockerImage = new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:latest");
-        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000", "star-whale/starwhale:latest"),
-            dockerImage);
+        Assertions.assertEquals(
+                new DockerImage("homepage-ca.intra.starwhale.ai:5000", "star-whale/starwhale:latest"), dockerImage);
 
         dockerImage = new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale");
-        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000", "star-whale/starwhale"),
-            dockerImage);
+        Assertions.assertEquals(
+                new DockerImage("homepage-ca.intra.starwhale.ai:5000", "star-whale/starwhale"), dockerImage);
 
         dockerImage = new DockerImage(
-            "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+                "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000",
-            "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
+                "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
     }
 
     @Test
     public void testIpPortConstructor() {
         DockerImage dockerImage = new DockerImage(
-            "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+                "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-            new DockerImage("131.0.1.8:5000", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
-            dockerImage);
+                new DockerImage("131.0.1.8:5000", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                dockerImage);
 
         dockerImage = new DockerImage("131.0.1.8:5000/star-whale/starwhale:latest");
         Assertions.assertEquals(new DockerImage("131.0.1.8:5000", "star-whale/starwhale:latest"), dockerImage);
@@ -124,9 +124,9 @@ public class DockerImageTest {
 
     @Test
     public void testOnlyNameConstructor() {
-        DockerImage dockerImage = new DockerImage("star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
-        Assertions.assertEquals(new DockerImage("", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
-            dockerImage);
+        var dockerImage = new DockerImage("star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
+        Assertions.assertEquals(
+                new DockerImage("", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
 
         dockerImage = new DockerImage("star-whale/starwhale:latest");
         Assertions.assertEquals(new DockerImage("", "star-whale/starwhale:latest"), dockerImage);
@@ -139,17 +139,17 @@ public class DockerImageTest {
     @Test
     public void testResolve() {
         Map<String, String> images = Map.of(
-            "docker.io", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-            "docker.io/", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-            "ghcr.io", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-            "ghcr.io/", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-            "131.0.1.8:5000", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-            "131.0.1.8:5000/", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-            "homepage-ca.intra.starwhale.ai:5000",
-            "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-            "homepage-ca.intra.starwhale.ai:5000/",
-            "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-            "localhost:5000", "localhost:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"
+                "docker.io", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "docker.io/", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "ghcr.io", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "ghcr.io/", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "131.0.1.8:5000", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "131.0.1.8:5000/", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "homepage-ca.intra.starwhale.ai:5000",
+                "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "homepage-ca.intra.starwhale.ai:5000/",
+                "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "localhost:5000", "localhost:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"
         );
         images.forEach((k, v) -> Assertions.assertEquals(v,
             new DockerImage("docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507").resolve(k)));

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobBoConverterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobBoConverterTest.java
@@ -159,7 +159,6 @@ public class JobBoConverterTest {
                 + "    max: null\n"
                 + "    min: null\n"
                 + "    defaults: 5.0");
-        // when(systemSettingService.queryResourcePool("rp")).thenReturn(ResourcePool.builder().name("fool").build());
         JobBoConverter jobBoConverter = new JobBoConverter(datasetDao, modelMapper, runtimeMapper,
                 runtimeVersionMapper,
                 converter,

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobBoConverterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobBoConverterTest.java
@@ -22,6 +22,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ai.starwhale.mlops.configuration.DockerSetting;
 import ai.starwhale.mlops.domain.dataset.DatasetDao;
 import ai.starwhale.mlops.domain.dataset.bo.DataSet;
 import ai.starwhale.mlops.domain.dataset.bo.DatasetVersion;
@@ -43,12 +44,13 @@ import ai.starwhale.mlops.domain.model.mapper.ModelMapper;
 import ai.starwhale.mlops.domain.model.po.ModelEntity;
 import ai.starwhale.mlops.domain.model.po.ModelVersionEntity;
 import ai.starwhale.mlops.domain.project.po.ProjectEntity;
+import ai.starwhale.mlops.domain.runtime.RuntimeTestConstants;
 import ai.starwhale.mlops.domain.runtime.mapper.RuntimeMapper;
 import ai.starwhale.mlops.domain.runtime.mapper.RuntimeVersionMapper;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeEntity;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
 import ai.starwhale.mlops.domain.system.SystemSettingService;
-import ai.starwhale.mlops.domain.system.resourcepool.bo.ResourcePool;
+import ai.starwhale.mlops.domain.system.mapper.SystemSettingMapper;
 import ai.starwhale.mlops.domain.task.converter.TaskBoConverter;
 import ai.starwhale.mlops.domain.task.mapper.TaskMapper;
 import ai.starwhale.mlops.domain.task.po.TaskEntity;
@@ -81,7 +83,7 @@ public class JobBoConverterTest {
                 .resultOutputPath("job_result")
                 .jobUuid(UUID.randomUUID().toString())
                 .runtimeVersionId(1L)
-                .resourcePool("rp")
+                .resourcePool("fool")
                 .owner(UserEntity.builder().userName("naf").id(1232L).build())
                 .build();
         DatasetDao datasetDao = mock(DatasetDao.class);
@@ -99,8 +101,12 @@ public class JobBoConverterTest {
                 jobEntity.getModelVersion().getModelId())).thenReturn(modelEntity);
 
         RuntimeVersionMapper runtimeVersionMapper = mock(RuntimeVersionMapper.class);
-        RuntimeVersionEntity runtimeVersionEntity = RuntimeVersionEntity.builder().versionName("name_swrt_version")
-                .runtimeId(1L).storagePath("swrt_path").build();
+        RuntimeVersionEntity runtimeVersionEntity = RuntimeVersionEntity.builder()
+                .versionName("name_swrt_version")
+                .runtimeId(1L)
+                .versionMeta(RuntimeTestConstants.MANIFEST_WITH_BUILTIN_IMAGE)
+                .storagePath("swrt_path")
+                .build();
         when(runtimeVersionMapper.find(
                 jobEntity.getRuntimeVersionId())).thenReturn(runtimeVersionEntity);
 
@@ -135,8 +141,25 @@ public class JobBoConverterTest {
         when(taskMapper.findByStepId(any())).thenReturn(
                 List.of(TaskEntity.builder().build(), TaskEntity.builder().build()));
 
-        SystemSettingService systemSettingService = mock(SystemSettingService.class);
-        when(systemSettingService.queryResourcePool("rp")).thenReturn(ResourcePool.builder().name("fool").build());
+        SystemSettingService systemSettingService = new SystemSettingService(
+                mock(SystemSettingMapper.class), List.of(), null, new DockerSetting(), null);
+        systemSettingService.updateSetting("---\n"
+                + "dockerSetting:\n"
+                + "  registryForPull: \"\"\n"
+                + "  registryForPush: \"\"\n"
+                + "  userName: \"\"\n"
+                + "  password: \"\"\n"
+                + "  insecure: true\n"
+                + "resourcePoolSetting:\n"
+                + "- name: \"fool\"\n"
+                + "  nodeSelector: \n"
+                + "    foo: \"bar\"\n"
+                + "  resources:\n"
+                + "  - name: \"cpu\"\n"
+                + "    max: null\n"
+                + "    min: null\n"
+                + "    defaults: 5.0");
+        // when(systemSettingService.queryResourcePool("rp")).thenReturn(ResourcePool.builder().name("fool").build());
         JobBoConverter jobBoConverter = new JobBoConverter(datasetDao, modelMapper, runtimeMapper,
                 runtimeVersionMapper,
                 converter,

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/ModelServingServiceTest.java
@@ -39,6 +39,7 @@ import ai.starwhale.mlops.domain.model.po.ModelVersionEntity;
 import ai.starwhale.mlops.domain.project.ProjectService;
 import ai.starwhale.mlops.domain.runtime.RuntimeDao;
 import ai.starwhale.mlops.domain.runtime.RuntimeResource;
+import ai.starwhale.mlops.domain.runtime.RuntimeTestConstants;
 import ai.starwhale.mlops.domain.runtime.mapper.RuntimeMapper;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeEntity;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
@@ -147,7 +148,11 @@ public class ModelServingServiceTest {
                 .resourcePool(resourcePool)
                 .build();
         when(modelServingMapper.list(2L, 9L, 8L, resourcePool)).thenReturn(List.of(entity));
-        var runtimeVer = RuntimeVersionEntity.builder().id(8L).versionName("rt-8").image("img").build();
+        var runtimeVer = RuntimeVersionEntity.builder()
+                .id(8L)
+                .versionMeta(RuntimeTestConstants.MANIFEST_WITH_BUILTIN_IMAGE)
+                .versionName("rt-8")
+                .build();
         when(runtimeDao.getRuntimeVersion("8")).thenReturn(runtimeVer);
         var modelVer = ModelVersionEntity.builder().id(9L).versionName("mp-9").build();
         when(modelDao.getModelVersion("9")).thenReturn(modelVer);
@@ -188,7 +193,7 @@ public class ModelServingServiceTest {
         expectedEnvs.put("a", "b");
         verify(k8sJobTemplate).renderModelServingOrch(
                 "model-serving-7",
-                "img",
+                RuntimeTestConstants.BUILTIN_IMAGE,
                 expectedEnvs,
                 expectedResource,
                 Map.of("foo", "bar"));

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeServiceTest.java
@@ -242,14 +242,14 @@ public class RuntimeServiceTest {
                                     .id(1L)
                                     .versionName("n1")
                                     .storagePath("path1")
-                                    .image("origin-image1")
+                                    .versionMeta(RuntimeTestConstants.MANIFEST_WITHOUT_BUILTIN_IMAGE)
                                     .build();
                         case "v2":
                             return RuntimeVersionEntity.builder()
                                     .id(2L)
                                     .versionName("n2")
                                     .storagePath("path2")
-                                    .image("origin-image2")
+                                    .versionMeta(RuntimeTestConstants.MANIFEST_WITHOUT_BUILTIN_IMAGE)
                                     .builtImage("build-image")
                                 .build();
 
@@ -257,6 +257,7 @@ public class RuntimeServiceTest {
                             return RuntimeVersionEntity.builder()
                                     .id(3L)
                                     .versionName("n3")
+                                    .versionMeta(RuntimeTestConstants.MANIFEST_WITHOUT_BUILTIN_IMAGE)
                                     .storagePath("path3")
                                     .build();
                         default:
@@ -600,8 +601,8 @@ public class RuntimeServiceTest {
                 argThat(containerOverwriteSpecMap -> {
                     var prepareBuilder = containerOverwriteSpecMap.get("prepare-runtime");
                     var imageBuilder = containerOverwriteSpecMap.get("image-builder");
-                    return prepareBuilder.getEnvs().size() == 7
-                        && imageBuilder.getEnvs().size() == 7
+                    return prepareBuilder.getEnvs().size() == 8
+                        && imageBuilder.getEnvs().size() == 8
                         && imageBuilder.getCmds().size() == 6;
                 }),
                 any(), any(), isNull());

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeTestConstants.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeTestConstants.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.runtime;
+
+public interface RuntimeTestConstants {
+    String BUILTIN_REPO = "homepage.intra.starwhale.ai:5000";
+    String BUILTIN_IMAGE = String.format("%s/starwhale:0.4.7.builtin", BUILTIN_REPO);
+    String CUSTOM_REPO = "homepage.intra.starwhale.cn";
+    String CUSTOM_IMAGE = String.format("%s/starwhale:0.4.7.custom", CUSTOM_REPO);
+
+    String MANIFEST_WITH_BUILTIN_IMAGE = "artifacts:\n"
+            + "  dependencies:\n"
+            + "  - dependencies/requirements.txt\n"
+            + "  - dependencies/.starwhale/lock/requirements-sw-lock.txt\n"
+            + "  files: []\n"
+            + "  runtime_yaml: runtime.yaml\n"
+            + "  wheels: []\n"
+            + "base_image: " + BUILTIN_IMAGE + "\n"
+            + "build:\n"
+            + "  os: Linux\n"
+            + "  sw_version: 0.4.7.dev609150619\n"
+            + "configs:\n"
+            + "  conda:\n"
+            + "    channels:\n"
+            + "    - conda-forge\n"
+            + "    condarc: {}\n"
+            + "  docker:\n"
+            + "    image: ''\n"
+            + "  pip:\n"
+            + "    extra_index_url:\n"
+            + "    - ''\n"
+            + "    index_url: ''\n"
+            + "    trusted_host:\n"
+            + "    - ''\n"
+            + "created_at: 2023-06-12 00:17:11 CST\n"
+            + "docker:\n"
+            + "  builtin_run_image:\n"
+            + "    fullname: " + BUILTIN_IMAGE + "\n"
+            + "    name: starwhale\n"
+            + "    repo: " + BUILTIN_REPO + "\n"
+            + "    tag: 0.4.7.builtin\n"
+            + "  custom_run_image: ''\n"
+            + "version: m3hxue5f6nie7r36i6pv6cdl6jzxmiz7ptzesudw\n";
+
+    String MANIFEST_WITHOUT_BUILTIN_IMAGE = "artifacts:\n"
+            + "  dependencies:\n"
+            + "  - dependencies/requirements.txt\n"
+            + "  - dependencies/.starwhale/lock/requirements-sw-lock.txt\n"
+            + "  files: []\n"
+            + "  runtime_yaml: runtime.yaml\n"
+            + "  wheels: []\n"
+            + "base_image: " + CUSTOM_IMAGE + "\n"
+            + "build:\n"
+            + "  os: Linux\n"
+            + "  sw_version: 0.4.7.dev609150619\n"
+            + "configs:\n"
+            + "  conda:\n"
+            + "    channels:\n"
+            + "    - conda-forge\n"
+            + "    condarc: {}\n"
+            + "  docker:\n"
+            + "    image: ''\n"
+            + "  pip:\n"
+            + "    extra_index_url:\n"
+            + "    - ''\n"
+            + "    index_url: ''\n"
+            + "    trusted_host:\n"
+            + "    - ''\n"
+            + "created_at: 2023-06-12 00:17:11 CST\n"
+            + "docker:\n"
+            + "  builtin_run_image:\n"
+            + "    fullname: " + BUILTIN_IMAGE + "\n"
+            + "    name: starwhale\n"
+            + "    repo: " + CUSTOM_REPO + "\n"
+            + "    tag: 0.4.7.builtin\n"
+            + "  custom_run_image: '" + CUSTOM_IMAGE + "'\n"
+            + "version: m3hxue5f6nie7r36i6pv6cdl6jzxmiz7ptzesudw\n";
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConverterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConverterTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import ai.starwhale.mlops.common.DockerImage;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.VersionAliasConverter;
 import ai.starwhale.mlops.domain.runtime.converter.RuntimeVersionConverter;
@@ -48,7 +49,7 @@ public class RuntimeVersionConverterTest {
                 .versionName("name1")
                 .versionOrder(2L)
                 .versionTag("tag1")
-                .versionMeta("meta1")
+                .versionMeta(RuntimeTestConstants.MANIFEST_WITH_BUILTIN_IMAGE)
                 .image("image1")
                 .shared(true)
                 .build());
@@ -57,10 +58,31 @@ public class RuntimeVersionConverterTest {
                 hasProperty("name", is("name1")),
                 hasProperty("alias", is("v2")),
                 hasProperty("tag", is("tag1")),
-                hasProperty("meta", is("meta1")),
+                hasProperty("meta", is(RuntimeTestConstants.MANIFEST_WITH_BUILTIN_IMAGE)),
                 hasProperty("shared", is(1)),
-                hasProperty("image", is("image1"))
+                hasProperty("image", is(RuntimeTestConstants.BUILTIN_IMAGE))
         ));
+        assertThat("image", res.getImage(), is(RuntimeTestConstants.BUILTIN_IMAGE));
+    }
+
+    @Test
+    public void testImageParse() {
+        var runtime = RuntimeVersionEntity.builder()
+                .id(1L)
+                .versionName("123456")
+                .versionMeta(RuntimeTestConstants.MANIFEST_WITH_BUILTIN_IMAGE)
+                .build();
+        // case 1: use builtin
+        var dockerImage = new DockerImage(runtime.getImage("self.registry:5000"));
+        assertThat("registry", dockerImage.getRegistry(), is("self.registry:5000"));
+        assertThat("image", dockerImage.toString(), is("self.registry:5000/starwhale:0.4.7.builtin"));
+
+        // case 2: use custom
+        runtime.setVersionMeta(RuntimeTestConstants.MANIFEST_WITHOUT_BUILTIN_IMAGE);
+
+        dockerImage = new DockerImage(runtime.getImage("self.registry:5000"));
+        assertThat("registry", dockerImage.getRegistry(), is(RuntimeTestConstants.CUSTOM_REPO));
+        assertThat("image", dockerImage.toString(), is(RuntimeTestConstants.CUSTOM_IMAGE));
     }
 
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConverterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConverterTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import ai.starwhale.mlops.common.DockerImage;
 import ai.starwhale.mlops.common.IdConverter;
 import ai.starwhale.mlops.common.VersionAliasConverter;
+import ai.starwhale.mlops.configuration.DockerSetting;
 import ai.starwhale.mlops.domain.runtime.converter.RuntimeVersionConverter;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,8 +39,8 @@ public class RuntimeVersionConverterTest {
     public void setUp() {
         runtimeVersionConvertor = new RuntimeVersionConverter(
                 new IdConverter(),
-                new VersionAliasConverter()
-        );
+                new VersionAliasConverter(),
+                new DockerSetting());
     }
 
     @Test

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/mapper/RuntimeVersionMapperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/mapper/RuntimeVersionMapperTest.java
@@ -17,6 +17,7 @@
 package ai.starwhale.mlops.domain.runtime.mapper;
 
 import ai.starwhale.mlops.domain.MySqlContainerHolder;
+import ai.starwhale.mlops.domain.runtime.RuntimeTestConstants;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeEntity;
 import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
 import java.util.List;
@@ -48,7 +49,7 @@ public class RuntimeVersionMapperTest extends MySqlContainerHolder {
                 .runtimeId(runtimeEntity.getId())
                 .ownerId(1L)
                 .versionName("version 1")
-                .versionMeta("version meta")
+                .versionMeta(RuntimeTestConstants.MANIFEST_WITH_BUILTIN_IMAGE)
                 .storagePath("storage path")
                 .image("image")
                 .build();
@@ -59,7 +60,7 @@ public class RuntimeVersionMapperTest extends MySqlContainerHolder {
                 .runtimeId(runtimeEntity.getId())
                 .ownerId(1L)
                 .versionName("version 2")
-                .versionMeta("version meta")
+                .versionMeta(RuntimeTestConstants.MANIFEST_WITHOUT_BUILTIN_IMAGE)
                 .storagePath("storage path")
                 .image("image")
                 .build();
@@ -71,11 +72,14 @@ public class RuntimeVersionMapperTest extends MySqlContainerHolder {
         var rt = runtimeVersionMapper.findLatestByProjectId(2L, null);
         Assertions.assertEquals(2, rt.size());
         Assertions.assertEquals("version 2", rt.get(0).getVersionName());
+        Assertions.assertEquals(RuntimeTestConstants.CUSTOM_IMAGE, rt.get(0).getImage());
         Assertions.assertEquals("version 1", rt.get(1).getVersionName());
+        Assertions.assertEquals(RuntimeTestConstants.BUILTIN_IMAGE, rt.get(1).getImage());
 
         rt = runtimeVersionMapper.findLatestByProjectId(2L, 1);
         Assertions.assertEquals(1, rt.size());
         Assertions.assertEquals("version 2", rt.get(0).getVersionName());
+        Assertions.assertEquals(RuntimeTestConstants.CUSTOM_IMAGE, rt.get(0).getImage());
 
         rt = runtimeVersionMapper.findLatestByProjectId(3L, null);
         Assertions.assertEquals(List.of(), rt);


### PR DESCRIPTION
## Description
related:  #2305 #2306 
1. client: runtime dockerize use new image rule
2. server: runtime version's image support replace registry

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
