### PR TITLE
chore(client): tune runtime restore command output

### DIFF
--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -336,19 +336,28 @@ class RuntimeTermView(BaseTermView):
     @classmethod
     @BaseTermView._only_standalone
     def restore(cls, target: str) -> None:
+        console.print(
+            f":golfer: try to restore python runtime environment: {target} ..."
+        )
         if in_production() or (os.path.exists(target) and os.path.isdir(target)):
             workdir = Path(target)
+            Runtime.restore(workdir)
+            activate_script_path = workdir / "activate.host"
+            console.print(
+                f":ramen: runtime(from workdir:{target}) has been restored, activate it in the current shell: \n"
+                f"\t :stars: run command: [bold green]$(sh {str(activate_script_path)})[/]"
+            )
         else:
             _uri = Resource(target, ResourceType.runtime)
             _runtime = StandaloneRuntime(_uri)
             workdir = _runtime.store.snapshot_workdir
             if not workdir.exists():
                 _runtime.extract(force=True, target=workdir)
-
-        console.print(
-            f":golfer: try to restore python runtime environment: {workdir} ..."
-        )
-        Runtime.restore(workdir)
+            Runtime.restore(workdir)
+            console.print(
+                f":ramen: runtime(from uri:{_uri}) has been restored, activate it in the current shell: \n"
+                f"\t :stars: run command: [bold green]swcli runtime activate {target}[/]"
+            )
 
     @classmethod
     def copy(

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -551,11 +551,8 @@ def _render_sw_activate(
 
     if verbose:
         console.print(
-            f" :clap: {_sw_path.name} and {_host_path.name} is generated at {workdir}"
+            f":clap: {_sw_path.name} and {_host_path.name} is generated at {workdir}"
         )
-        console.print(" :compass: run cmd:  ")
-        console.print(f" \t Docker Container: [bold red] $(sh {_sw_path}) [/]")
-        console.print(f" \t Host: [bold red] $(sh {_host_path}) [/]")
 
 
 def get_conda_prefix_path(name: str = "") -> str:


### PR DESCRIPTION
## Description
- restore by Runtime URI:
```
❯ swcli runtime restore pytorch
🏌 try to restore python runtime environment: pytorch ...
🧮 setup python(3.9) env with venv...
👏 create venv@/home/tianwei/.starwhale/self/workdir/runtime/pytorch/z7/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d/export/venv, python:3.9.13 (main, Oct 13 2022, 21:15:33) 
[GCC 11.2.0]
🍡 installing dependencies for pip_req_file:.starwhale/lock/requirements-sw-lock.txt in the venv environment
👏 activate.sw and activate.host is generated at /home/tianwei/.starwhale/self/workdir/runtime/pytorch/z7/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d
  6 out of 6 steps finished ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:01
🍜 runtime(from uri:local/project/self/runtime/pytorch/version/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d) has been restored, activate it in the current shell: 
         🌠 run command: swcli runtime activate pytorch
```

- restore by Runtime workdir:
```
❯ swcli runtime restore /home/tianwei/.starwhale/self/workdir/runtime/pytorch/z7/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d
🏌 try to restore python runtime environment: /home/tianwei/.starwhale/self/workdir/runtime/pytorch/z7/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d ...
🧮 setup python(3.9) env with venv...
👏 create venv@/home/tianwei/.starwhale/self/workdir/runtime/pytorch/z7/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d/export/venv, python:3.9.13 (main, Oct 13 2022, 21:15:33) 
[GCC 11.2.0]
🍡 installing dependencies for pip_req_file:.starwhale/lock/requirements-sw-lock.txt in the venv environment
👏 activate.sw and activate.host is generated at /home/tianwei/.starwhale/self/workdir/runtime/pytorch/z7/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d
  6 out of 6 steps finished ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:01
🍜 runtime(from workdir:/home/tianwei/.starwhale/self/workdir/runtime/pytorch/z7/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d) has been restored, activate it in the current shell: 
         🌠 run command: $(sh /home/tianwei/.starwhale/self/workdir/runtime/pytorch/z7/z7xiow2mwcb4afk2qpg2yvfc3gfm5wktbuy4ry4d/activate.host)
```

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
