### PR TITLE
bug(client): fix dataset create for cloud instance error

### DIFF
--- a/client/starwhale/base/uri/resource.py
+++ b/client/starwhale/base/uri/resource.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import re
 from enum import Enum
 from glob import glob
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 from pathlib import Path
 from dataclasses import dataclass
 
 import requests
+from requests import HTTPError
 
 from starwhale.utils import console, load_yaml
 from starwhale.consts import SW_API_VERSION
@@ -142,6 +144,11 @@ class Resource:
                 self.refine()
             except (NoMatchException, VerifyException) as e:
                 console.warning(f"refine resource[{typ}] {uri} failed: {e}")
+            except HTTPError as e:
+                if e.response.status_code == HTTPStatus.NOT_FOUND:
+                    console.warning(f"refine remote resource[{typ}] {uri} failed: {e}")
+                else:
+                    raise
 
     def refine(self) -> "Resource":
         if not self.project.instance.is_local:

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -815,16 +815,15 @@ class TestDatasetSDK(_DatasetSDKTestBase):
             },
         )
 
-        ds_version = "123456a"
         version_req = rm.request(
             HTTPMethod.HEAD,
-            f"http://1.1.1.1/api/v1/project/self/dataset/mnist/version/{ds_version}",
+            "http://1.1.1.1/api/v1/project/self/dataset/mnist/version/latest",
             status_code=HTTPStatus.NOT_FOUND,
         )
         rm.request(
             HTTPMethod.GET,
-            "http://1.1.1.1/api/v1/project/self/dataset/mnist",
-            json={"data": {"id": 1, "versionName": ds_version, "versionId": 100}},
+            "http://1.1.1.1/api/v1/project/self/dataset/mnist?versionUrl=latest",
+            status_code=HTTPStatus.NOT_FOUND,
         )
         ds = dataset("http://1.1.1.1/projects/self/datasets/mnist/versions/latest")
         assert version_req.call_count == 1


### PR DESCRIPTION
## Description
- related error:  create a non-existed dataset by dataset sdk.
  ![image](https://github.com/star-whale/starwhale/assets/590748/dd786dd2-85a2-4eb2-a2db-337e6f01d5e5)

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
