### PR TITLE
fix(datastore): list item may be null

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/ListValue.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/ListValue.java
@@ -40,7 +40,16 @@ public class ListValue extends ArrayList<BaseValue> implements BaseValue {
             var iter2 = ((ListValue) other).iterator();
             for (; ; ) {
                 if (iter1.hasNext() && iter2.hasNext()) {
-                    var result = iter1.next().compareTo(iter2.next());
+                    var l = iter1.next();
+                    var r = iter2.next();
+                    if (l == null && r == null) {
+                        continue;
+                    } else if (l == null) {
+                        return -1;
+                    } else if (r == null) {
+                        return 1;
+                    }
+                    var result = l.compareTo(r);
                     if (result != 0) {
                         return result;
                     }

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/BaseValueTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/BaseValueTest.java
@@ -236,6 +236,23 @@ public class BaseValueTest {
                 greaterThan(0));
         assertThat(BaseValue.compare(BaseValue.valueOf(List.of(1, 2, 3)), BaseValue.valueOf(List.of())),
                 greaterThan(0));
+        // compare list with null item
+        var left = new ArrayList<Integer>() {
+            {
+                add(1);
+                add(2);
+                add(null);
+            }
+        };
+        assertThat(BaseValue.compare(BaseValue.valueOf(left), BaseValue.valueOf(List.of(1, 2, 3))), lessThan(0));
+        var right = new ArrayList<Integer>() {
+            {
+                add(1);
+                add(2);
+                add(null);
+            }
+        };
+        assertThat(BaseValue.compare(BaseValue.valueOf(List.of(1, 2, 3)), BaseValue.valueOf(right)), greaterThan(0));
     }
 
     @Test


### PR DESCRIPTION
## Description

cc @tianweidut 

```
java.lang.NullPointerException: null
        at ai.starwhale.mlops.datastore.type.ListValue.compareTo(ListValue.java:43) ~[classes!/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.type.ObjectValue.compareTo(ObjectValue.java:72) ~[classes!/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.type.BaseValue.compare(BaseValue.java:149) ~[classes!/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.impl.MemoryTableImpl.insertRecords(MemoryTableImpl.java:347) ~[classes!/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.impl.MemoryTableImpl.update(MemoryTableImpl.java:321) ~[classes!/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.DataStore.update(DataStore.java:160) ~[classes!/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.api.DataStoreController.updateTable(DataStoreController.java:111) ~[classes!/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.api.DataStoreController$$FastClassBySpringCGLIB$$f68dbec7.invoke(<generated>) ~[classes!/:0.1.0-SNAPSHOT]
```

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
