### PR TITLE
chore(ci): add http proxy for e2e docker build

### DIFF
--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -31,7 +31,7 @@ WORK_DIR = os.environ.get("WORK_DIR")
 if not WORK_DIR:
     raise RuntimeError("WORK_DIR NOT FOUND")
 STATUS_SUCCESS = {"SUCCESS", "success"}
-STATUS_FAIL = {"FAIL", "fail", "CANCELED"}
+STATUS_FAIL = {"fail", "CANCELED", "FAIL"}
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/scripts/publish/pub.sh
+++ b/scripts/publish/pub.sh
@@ -189,7 +189,15 @@ cli() {
     if ! twine upload --repository nexus dist/* ; then echo "[ERROR] Something wrong while uploading pypi version , press CTL+C to interrupt execution if needed"; fi
     popd
     pushd ../../docker
-    docker build --network=host -t starwhale -f Dockerfile.starwhale --build-arg ENABLE_E2E_TEST_PYPI_REPO=1 --build-arg PORT_NEXUS=$PORT_NEXUS --build-arg LOCAL_PYPI_HOSTNAME=$NEXUS_HOSTNAME --build-arg SW_VERSION=$PYPI_RELEASE_VERSION  --build-arg SW_PYPI_EXTRA_INDEX_URL="$SW_PYPI_EXTRA_INDEX_URL" .
+    docker build --network=host -t starwhale -f Dockerfile.starwhale  \
+        --build-arg ENABLE_E2E_TEST_PYPI_REPO=1 \
+        --build-arg PORT_NEXUS=$PORT_NEXUS \
+        --build-arg LOCAL_PYPI_HOSTNAME=$NEXUS_HOSTNAME \
+        --build-arg SW_VERSION=$PYPI_RELEASE_VERSION \
+        --build-arg HTTP_PROXY=$HTTP_PROXY \
+        --build-arg HTTPS_PROXY=$HTTPS_PROXY \
+        --build-arg NO_PROXY=$NO_PROXY \
+        --build-arg SW_PYPI_EXTRA_INDEX_URL="$SW_PYPI_EXTRA_INDEX_URL" .
     docker tag starwhale $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/starwhale:$PYPI_RELEASE_VERSION
     docker tag starwhale $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/starwhale:$PYPI_RELEASE_VERSION
     if ! docker push $NEXUS_HOSTNAME:$PORT_NEXUS_DOCKER/star-whale/starwhale:$PYPI_RELEASE_VERSION ; then echo "[ERROR] Something wrong while pushing , press CTL+C to interrupt execution if needed"; fi


### PR DESCRIPTION
## Description
The e2e always failed at code-server download of the docker build phase.
- before error:
![image](https://github.com/star-whale/starwhale/assets/590748/38a15dbf-516d-49e6-8273-de5b90cdbe77)

- after fixed:
![image](https://github.com/star-whale/starwhale/assets/590748/38cb1325-0f49-4b06-96de-aecb2dcb41aa)


## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
