### PR TITLE
chore(e2e): remove useless sudo in e2e script

### DIFF
--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -30,7 +30,7 @@ ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, os.pardir))
 WORK_DIR = os.environ.get("WORK_DIR")
 if not WORK_DIR:
     raise RuntimeError("WORK_DIR NOT FOUND")
-STATUS_SUCCESS = {"SUCCESS", "success"}
+STATUS_SUCCESS = {"success", "SUCCESS"}
 STATUS_FAIL = {"FAIL", "fail", "CANCELED"}
 
 logging.basicConfig(level=logging.DEBUG)

--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -64,8 +64,8 @@ show_minikube_logs() {
 
 start_nexus() {
   docker run -d --publish=$PORT_NEXUS:$PORT_NEXUS --publish=$PORT_NEXUS_DOCKER:$PORT_NEXUS_DOCKER --name nexus  -e NEXUS_SECURITY_RANDOMPASSWORD=false $NEXUS_IMAGE
-  sudo cp /etc/hosts /etc/hosts.bak_e2e
-  sudo echo "127.0.0.1 $NEXUS_HOSTNAME" | sudo tee -a /etc/hosts
+  cp /etc/hosts /etc/hosts.bak_e2e
+  echo "127.0.0.1 $NEXUS_HOSTNAME" | tee -a /etc/hosts
 }
 
 build_swcli() {
@@ -225,7 +225,7 @@ check_controller_service() {
     nohup kubectl port-forward --namespace $SWNS svc/minio $PORT_MINIO:$PORT_MINIO > /dev/null 2>&1 &
     DNS_RECORD='127.0.0.1 minio'
     if ! fgrep "$DNS_RECORD" /etc/hosts; then
-      echo "$DNS_RECORD" | sudo tee -a /etc/hosts
+      echo "$DNS_RECORD" | tee -a /etc/hosts
     fi
 }
 


### PR DESCRIPTION
## Description

in self-hosted e2e container:
```
root@3500d42c713c:/# echo "127.0.0.1 minio" | sudo tee -a /etc/hosts
bash: sudo: command not found
root@3500d42c713c:/# sudo cat /etc/hosts
bash: sudo: command not found
root@3500d42c713c:/# exot
bash: exot: command not found
```

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
