### PR TITLE
chore(ci): add sudo command for e2e base image

### DIFF
--- a/docker/Dockerfile.base_e2e
+++ b/docker/Dockerfile.base_e2e
@@ -21,10 +21,8 @@ RUN mkdir -p /etc/apt/keyrings \
     && apt-get install -y docker-ce-cli
 
 # Install kubectl/helm
-RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list \
-    && apt-get update \
-    && apt-get install -y kubectl \
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
     && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 # Install nodejs/yarn

--- a/docker/Dockerfile.base_e2e
+++ b/docker/Dockerfile.base_e2e
@@ -7,8 +7,7 @@ ENV TZ=Etc/UTC
 
 # Install common tools/git/software-properties-common
 RUN apt-get update \
-    && apt-get install -y ca-certificates curl gnupg lsb-release wget jq vim rsync zip unzip\
-    && apt-get install -y git git-lfs\
+    && apt-get install -y ca-certificates curl gnupg lsb-release wget jq vim rsync zip unzip git git-lfs sudo \
     && git lfs install \
     && apt-get install -y software-properties-common
 
@@ -16,8 +15,8 @@ RUN apt-get update \
 RUN mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
     &&  echo \
-         "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-         $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt-get update \
     && apt-get install -y docker-ce-cli
 


### PR DESCRIPTION
## Description
-  in self-hosted e2e container:
```
root@3500d42c713c:/# echo "127.0.0.1 minio" | sudo tee -a /etc/hosts
bash: sudo: command not found
root@3500d42c713c:/# sudo cat /etc/hosts
bash: sudo: command not found
root@3500d42c713c:/# exot
bash: exot: command not found
```
- build error:
![image](https://github.com/star-whale/starwhale/assets/590748/1837c67f-2ac8-4ca0-925e-7dad70985229)

- success build: 
![image](https://github.com/star-whale/starwhale/assets/590748/711c0d37-705e-4866-ad38-5460820fd44c)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
