### PR TITLE
chore(ci): enable client-e2e for mac osx

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -155,7 +155,6 @@ jobs:
           directory: ./client
 
   e2e:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
@@ -164,6 +163,15 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+        os:
+          - macos-latest
+          - ubuntu-latest
+        exclude:
+          # https://github.com/pytorch/pytorch/issues/86566
+          # pytorch does not release python 3.11 wheel package for macosx os yet.
+          - os: macos-latest
+            python-version: "3.11"
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash

--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 import typing as t
 import logging
 import subprocess
@@ -457,12 +458,15 @@ class TestCli:
 
     def smoke_commands(self) -> None:
         commands = [
-            "timeout 10 swcli --help",
+            "swcli --help",
             "swcli --version",
         ]
 
         for cmd in commands:
+            start = time.time()
             check_invoke(cmd.split())
+            if time.time() - start > 10:
+                raise RuntimeError(f"{cmd} timeout")
 
     def test_sdk(self) -> None:
         script_path = (


### PR DESCRIPTION
## Description

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
