### PR TITLE
chore(ci): remove torch/tensorflow python3.11 unittest skip

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -96,11 +96,6 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-        exclude:
-          # https://github.com/pytorch/pytorch/issues/86566
-          # pytorch does not release python 3.11 wheel package for macosx os yet.
-          - os: macos-latest
-            python-version: "3.11"
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -22,10 +22,10 @@ isort >= 5.10.1
 trio-typing[mypy] >= 0.7.0
 respx >= 0.19.0
 # for integration test
-torch
-# TODO: wait for tensorflow release for python3.11
-# https://github.com/tensorflow/tensorflow/issues/58032
-tensorflow; python_version <= '3.10'
+torch>=2.0.1; python_version >= '3.11'
+torch; python_version < '3.11'
+tensorflow>=2.12.0; python_version >= '3.11'
+tensorflow; python_version < '3.11'
 # for starwhale[image] test
 pillow
 # for starwhale[audio] test

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import os
 import re
-import sys
 import typing as t
 from http import HTTPStatus
 from pathlib import Path
@@ -1682,15 +1681,6 @@ class TestPytorch(_DatasetSDKTestBase):
         assert item["audio"].dtype == torch.float64
 
 
-# TODO: wait for tensorflow release for python3.11
-# https://github.com/tensorflow/tensorflow/issues/58032
-skip_py311 = pytest.mark.skipif(
-    sys.version_info >= (3, 11),
-    reason="skip python3.11, because tensorflow does not release the related wheel package.",
-)
-
-
-@skip_py311
 class TestTensorflow(_DatasetSDKTestBase):
     def test_simple_data(self) -> None:
         import tensorflow as tf


### PR DESCRIPTION
## Description
pytorch/tensorflow has already supported 3.11:
- https://github.com/tensorflow/tensorflow/issues/58032
- https://github.com/pytorch/pytorch/issues/86566

## Modules
- [x] Python-SDK

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
