### PR TITLE
bugfix(client): model copy compression and fileExisted issue

### DIFF
--- a/client/tests/base/test_copy.py
+++ b/client/tests/base/test_copy.py
@@ -514,6 +514,13 @@ class TestBundleCopy(BaseTestCase):
                 self.assertEqual(
                     b"0" * 65536 + b"1" * 65536 + b"2" * 65536 + b"3" * 65536, data
                 )
+        BundleCopy(
+            src_uri=cloud_uri,
+            dest_uri=cases[0]["dest_uri"],
+            typ=ResourceType.model,
+            dest_local_project_uri=cases[0]["dest_local_project_uri"],
+            force=True,
+        ).do()
 
     @Mocker()
     @respx.mock


### PR DESCRIPTION
  1. improve compression judgement logics
  2. fix a boundary error when dealing with compressed chunks
  3. fix FileExistsError when copy model with force

## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
