### PR TITLE
bugfix(model): model copy retries and add read limit for LengthAbleInputStream

### DIFF
--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -84,7 +84,7 @@ sw:
       page-row-count-limit: ${SW_DATASTORE_PARQUET_PAGE_ROW_COUNT_LIMIT:20000}
   blob-service:
     data-root-path: ${SW_BLOB_SERVICE_DATA_ROOT_PATH:blob/}
-    url-expiration-time: ${SW_BLOB_SERVICE_URL_EXPIRATION_TIME:5m}
+    url-expiration-time: ${SW_BLOB_SERVICE_URL_EXPIRATION_TIME:4h}
 ---
 #Development
 spring:

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/LengthAbleInputStream.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/LengthAbleInputStream.java
@@ -19,80 +19,120 @@ package ai.starwhale.mlops.storage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Objects;
 
 public class LengthAbleInputStream extends InputStream {
+
     private final InputStream inputStream;
 
     private final long size;
 
+    private long remaining;
+
     public LengthAbleInputStream(InputStream inputStream, long size) {
         this.inputStream = inputStream;
         this.size = size;
+        this.remaining = size;
     }
 
     @Override
     public int read() throws IOException {
-        return this.inputStream.read();
+        if (this.remaining == 0) {
+            return -1;
+        }
+        var ret = this.inputStream.read();
+        if (ret < 0) {
+            this.remaining = 0;
+        } else {
+            --this.remaining;
+        }
+        return ret;
     }
 
     @Override
     public int read(byte[] b) throws IOException {
-        return inputStream.read(b);
+        return this.read(b, 0, b.length);
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-        return inputStream.read(b, off, len);
+        if (this.remaining == 0) {
+            return -1;
+        }
+        len = (int) Math.min(this.remaining, len);
+        var ret = this.inputStream.read(b, off, len);
+        if (ret < 0) {
+            this.remaining = 0;
+        } else {
+            this.remaining -= ret;
+        }
+        return ret;
     }
 
     @Override
     public byte[] readAllBytes() throws IOException {
-        return inputStream.readAllBytes();
+        return this.readNBytes(Integer.MAX_VALUE);
     }
 
     @Override
     public byte[] readNBytes(int len) throws IOException {
-        return inputStream.readNBytes(len);
+        if (this.remaining == 0 || len == 0) {
+            return new byte[0];
+        }
+        len = (int) Math.min(this.remaining, len);
+        var ret = this.inputStream.readNBytes(len);
+        this.remaining -= ret.length;
+        return ret;
     }
 
     @Override
     public int readNBytes(byte[] b, int off, int len) throws IOException {
-        return inputStream.readNBytes(b, off, len);
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (this.remaining == 0 || len == 0) {
+            return 0;
+        }
+        len = (int) Math.min(this.remaining, len);
+        var ret = this.inputStream.readNBytes(b, off, len);
+        this.remaining -= ret;
+        return ret;
     }
 
     @Override
     public long skip(long n) throws IOException {
-        return inputStream.skip(n);
+        n = Math.min(this.remaining, n);
+        var ret = this.inputStream.skip(n);
+        this.remaining -= ret;
+        return ret;
     }
 
     @Override
     public int available() throws IOException {
-        return inputStream.available();
+        return this.inputStream.available();
     }
 
     @Override
     public void close() throws IOException {
-        inputStream.close();
+        this.inputStream.close();
     }
 
     @Override
     public void mark(int readlimit) {
-        inputStream.mark(readlimit);
+        this.inputStream.mark(readlimit);
     }
 
     @Override
     public void reset() throws IOException {
-        inputStream.reset();
+        this.inputStream.reset();
     }
 
     @Override
     public boolean markSupported() {
-        return inputStream.markSupported();
+        return this.inputStream.markSupported();
     }
 
     @Override
     public long transferTo(OutputStream out) throws IOException {
-        return inputStream.transferTo(out);
+        return this.inputStream.transferTo(out);
     }
 
     public long getSize() {

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/util/LengthAbleInputStreamTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/util/LengthAbleInputStreamTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import ai.starwhale.mlops.storage.LengthAbleInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LengthAbleInputStreamTest {
+
+    private LengthAbleInputStream inputStream;
+
+    @BeforeEach
+    public void setUp() {
+        this.inputStream =
+                new LengthAbleInputStream(
+                        new ByteArrayInputStream("test test".getBytes(StandardCharsets.UTF_8)),
+                        4);
+    }
+
+    @Test
+    public void testRead() throws IOException {
+        assertThat(this.inputStream.read(), is((int) 't'));
+        assertThat(this.inputStream.read(), is((int) 'e'));
+        assertThat(this.inputStream.read(), is((int) 's'));
+        assertThat(this.inputStream.read(), is((int) 't'));
+        assertThat(this.inputStream.read(), is(-1));
+        assertThat(this.inputStream.read(), is(-1));
+    }
+
+    @Test
+    public void testRead2() throws IOException {
+        byte[] b;
+        b = new byte[0];
+        assertThat(this.inputStream.read(b), is(0));
+        assertThat(new String(b), is(""));
+        b = new byte[1];
+        assertThat(this.inputStream.read(b), is(1));
+        assertThat(new String(b), is("t"));
+        b = new byte[2];
+        assertThat(this.inputStream.read(b), is(2));
+        assertThat(new String(b), is("es"));
+        b = new byte[3];
+        assertThat(this.inputStream.read(b), is(1));
+        assertThat(new String(b), is("t\0\0"));
+        b = new byte[4];
+        assertThat(this.inputStream.read(b), is(-1));
+        assertThat(new String(b), is("\0\0\0\0"));
+        b = new byte[5];
+        assertThat(this.inputStream.read(b), is(-1));
+        assertThat(new String(b), is("\0\0\0\0\0"));
+    }
+
+    @Test
+    public void testRead3() throws IOException {
+        var b = new byte[10];
+        assertThat(this.inputStream.read(b, 0, 1), is(1));
+        assertThat(new String(b), is("t\0\0\0\0\0\0\0\0\0"));
+        assertThat(this.inputStream.read(b, 1, 2), is(2));
+        assertThat(new String(b), is("tes\0\0\0\0\0\0\0"));
+        assertThat(this.inputStream.read(b, 3, 3), is(1));
+        assertThat(new String(b), is("test\0\0\0\0\0\0"));
+        assertThat(this.inputStream.read(b, 4, 4), is(-1));
+        assertThat(new String(b), is("test\0\0\0\0\0\0"));
+        assertThat(this.inputStream.read(b, 4, 5), is(-1));
+        assertThat(new String(b), is("test\0\0\0\0\0\0"));
+    }
+
+    @Test
+    public void testReadNbytes() throws IOException {
+        assertThat(new String(inputStream.readNBytes(1)), is("t"));
+        assertThat(new String(inputStream.readNBytes(2)), is("es"));
+        assertThat(new String(inputStream.readNBytes(3)), is("t"));
+        assertThat(new String(inputStream.readNBytes(4)), is(""));
+        assertThat(new String(inputStream.readNBytes(5)), is(""));
+    }
+
+    @Test
+    public void testReadNbytes2() throws IOException {
+        var b = new byte[10];
+        assertThat(inputStream.readNBytes(b, 0, 1), is(1));
+        assertThat(new String(b), is("t\0\0\0\0\0\0\0\0\0"));
+        assertThat(inputStream.readNBytes(b, 1, 2), is(2));
+        assertThat(new String(b), is("tes\0\0\0\0\0\0\0"));
+        assertThat(inputStream.readNBytes(b, 3, 3), is(1));
+        assertThat(new String(b), is("test\0\0\0\0\0\0"));
+        assertThat(inputStream.readNBytes(b, 4, 4), is(0));
+        assertThat(new String(b), is("test\0\0\0\0\0\0"));
+        assertThat(inputStream.readNBytes(b, 4, 5), is(0));
+        assertThat(new String(b), is("test\0\0\0\0\0\0"));
+    }
+
+    @Test
+    public void testReadAllBytes() throws IOException {
+        assertThat(new String(inputStream.readAllBytes()), is("test"));
+        assertThat(new String(inputStream.readAllBytes()), is(""));
+        assertThat(new String(inputStream.readAllBytes()), is(""));
+    }
+
+    @Test
+    public void testSkip() throws IOException {
+        assertThat(inputStream.skip(0), is(0L));
+        assertThat(inputStream.skip(1), is(1L));
+        assertThat(inputStream.skip(2), is(2L));
+        assertThat(inputStream.skip(3), is(1L));
+        assertThat(inputStream.skip(4), is(0L));
+        assertThat(inputStream.skip(5), is(0L));
+    }
+}
+


### PR DESCRIPTION
  1. add read limit for LengthAbleInputStream
  2. add http request retries for model copy

## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
