### PR TITLE
bugfix(controller): override contentLength in InputStreamResource returned by ModelService.getFileData so that the underlying InputStream won't be read twice

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ModelController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ModelController.java
@@ -254,7 +254,12 @@ public class ModelController implements ModelApi {
     @Override
     public ResponseEntity<InputStreamResource> getFileData(String project, String model, String version, String path) {
         var result = this.modelService.getFileData(project, model, version, path);
-        return ResponseEntity.ok(new InputStreamResource(result));
+        return ResponseEntity.ok(new InputStreamResource(result) {
+            @Override
+            public long contentLength() {
+                return result.getSize();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
