### PR TITLE
fix(controller): read model file without compression fail

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
@@ -669,7 +669,8 @@ public class ModelService {
         if (compressionAlgorithm == CompressionAlgorithm.COMPRESSION_ALGORITHM_NO_COMPRESSION) {
             return in;
         }
-        return new SequenceInputStream(new Enumeration<>() {
+
+        var enumInputs = new Enumeration<InputStream>() {
             final byte[] decompressBuf = new byte[65536];
             final byte[] readBuf = new byte[65536];
             InputStream current = null;
@@ -714,8 +715,14 @@ public class ModelService {
                 this.current = null;
                 return ret;
             }
-        });
+        };
 
+        return new SequenceInputStream(enumInputs) {
+            @Override
+            public void close() throws IOException {
+                in.close();
+            }
+        };
     }
 
     private ModelPackageStorage.MetaBlob addSignedUrls(ModelPackageStorage.MetaBlob metaBlob) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
@@ -107,7 +107,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4SafeDecompressor;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.IOUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
@@ -107,6 +107,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4SafeDecompressor;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -651,7 +652,8 @@ public class ModelService {
                     }
                     return readFileData(in, compressionAlgorithm);
                 }
-                try (var data = blobService.readBlob(blobId, file.getBlobOffset(), file.getBlobSize())) {
+                try {
+                    var data = blobService.readBlob(blobId, file.getBlobOffset(), file.getBlobSize());
                     return readFileData(data, compressionAlgorithm);
                 } catch (IOException e) {
                     throw new SwProcessException(ErrorType.STORAGE, "can not read data", e);
@@ -741,7 +743,8 @@ public class ModelService {
         }
     }
 
-    private List<ModelPackageStorage.File> getFile(ModelPackageStorage.MetaBlob firstMetaBlob, String path) {
+    // this method is public for testing purpose
+    public List<ModelPackageStorage.File> getFile(ModelPackageStorage.MetaBlob firstMetaBlob, String path) {
         var metaBlob = new AtomicReference<>(firstMetaBlob);
         var indexes = new LinkedList<>(metaBlob.get().getMetaBlobIndexesList());
         indexes.addFirst(MetaBlobIndex.newBuilder().setLastFileIndex(firstMetaBlob.getFilesCount() - 1).build());

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/LengthAbleInputStream.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/LengthAbleInputStream.java
@@ -29,6 +29,8 @@ public class LengthAbleInputStream extends InputStream {
 
     private long remaining;
 
+    private boolean closed = false;
+
     public LengthAbleInputStream(InputStream inputStream, long size) {
         this.inputStream = inputStream;
         this.size = size;
@@ -37,6 +39,7 @@ public class LengthAbleInputStream extends InputStream {
 
     @Override
     public int read() throws IOException {
+        checkClosed();
         if (this.remaining == 0) {
             return -1;
         }
@@ -56,6 +59,7 @@ public class LengthAbleInputStream extends InputStream {
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
+        checkClosed();
         if (this.remaining == 0) {
             return -1;
         }
@@ -71,11 +75,13 @@ public class LengthAbleInputStream extends InputStream {
 
     @Override
     public byte[] readAllBytes() throws IOException {
+        checkClosed();
         return this.readNBytes(Integer.MAX_VALUE);
     }
 
     @Override
     public byte[] readNBytes(int len) throws IOException {
+        checkClosed();
         if (this.remaining == 0 || len == 0) {
             return new byte[0];
         }
@@ -87,6 +93,7 @@ public class LengthAbleInputStream extends InputStream {
 
     @Override
     public int readNBytes(byte[] b, int off, int len) throws IOException {
+        checkClosed();
         Objects.checkFromIndexSize(off, len, b.length);
         if (this.remaining == 0 || len == 0) {
             return 0;
@@ -112,6 +119,7 @@ public class LengthAbleInputStream extends InputStream {
 
     @Override
     public void close() throws IOException {
+        this.closed = true;
         this.inputStream.close();
     }
 
@@ -137,5 +145,11 @@ public class LengthAbleInputStream extends InputStream {
 
     public long getSize() {
         return this.size;
+    }
+
+    protected void checkClosed() throws IOException {
+        if (this.closed) {
+            throw new IOException("Stream closed");
+        }
     }
 }


### PR DESCRIPTION
## Description

```
handleInternalServerError /api/v1/project/starwhale/model/mnist/getFileData
                                                                                                                                                                
                                                                                                                                                                
java.io.IOException: closed                                                                                                                                     
        at okio.RealBufferedSource$inputStream$1.read(RealBufferedSource.kt:154) ~[okio-2.8.0.jar!/:na]                                               
        at java.base/java.io.FilterInputStream.read(FilterInputStream.java:133) ~[na:na]                                                                    
        at ai.starwhale.mlops.storage.LengthAbleInputStream.read(LengthAbleInputStream.java:63) ~[storage-access-layer-0.1.0-SNAPSHOT.jar!/:0.1.0-SNAPSHOT]   
        at java.base/java.io.SequenceInputStream.read(SequenceInputStream.java:199) ~[na:na]                                                     
        at ai.starwhale.mlops.storage.LengthAbleInputStream.read(LengthAbleInputStream.java:63) ~[storage-access-layer-0.1.0-SNAPSHOT.jar!/:0.1.0-SNAPSHOT] 
        at ai.starwhale.mlops.storage.LengthAbleInputStream.read(LengthAbleInputStream.java:54) ~[storage-access-layer-0.1.0-SNAPSHOT.jar!/:0.1.0-SNAPSHOT]
        at org.springframework.util.StreamUtils.copy(StreamUtils.java:166) ~[spring-core-5.3.24.jar!/:5.3.24]                                              
        at org.springframework.http.converter.ResourceHttpMessageConverter.writeContent(ResourceHttpMessageConverter.java:139) ~[spring-web-5.3.24.jar!/:5.3.24] 
        at org.springframework.http.converter.ResourceHttpMessageConverter.writeInternal(ResourceHttpMessageConverter.java:129) ~[spring-web-5.3.24.jar!/:5.3.24]
        at org.springframework.http.converter.ResourceHttpMessageConverter.writeInternal(ResourceHttpMessageConverter.java:45) ~[spring-web-5.3.24.jar!/:5.3.24]
```

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
