### PR TITLE
refactor(controller): refine job start end time

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobService.java
@@ -338,8 +338,8 @@ public class JobService {
                         && task.getStatus() != TaskStatus.FAIL
                         && task.getStatus() != TaskStatus.CREATED)
                 .collect(Collectors.toList());
-        batchPersistTaskStatus(directlyCanceledTasks, TaskStatus.CANCELED);
-        updateWithoutPersistWatcher(directlyCanceledTasks, TaskStatus.CANCELED);
+        batchPersistTaskStatus(directlyCanceledTasks, TaskStatus.CANCELLING);
+        updateWithoutPersistWatcher(directlyCanceledTasks, TaskStatus.CANCELLING);
     }
 
     public List<Job> listHotJobs() {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/status/JobStatus.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/status/JobStatus.java
@@ -43,11 +43,6 @@ public enum JobStatus {
     /**
      * CANCEL triggered by user( at least one task is TO_CANCEL)
      */
-    TO_CANCEL(),
-
-    /**
-     * CANCEL triggered by user( at least one task is TO_CANCEL)
-     */
     CANCELLING(),
 
     /**

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/status/JobStatusMachine.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/status/JobStatusMachine.java
@@ -25,7 +25,6 @@ import static ai.starwhale.mlops.domain.job.status.JobStatus.PAUSED;
 import static ai.starwhale.mlops.domain.job.status.JobStatus.READY;
 import static ai.starwhale.mlops.domain.job.status.JobStatus.RUNNING;
 import static ai.starwhale.mlops.domain.job.status.JobStatus.SUCCESS;
-import static ai.starwhale.mlops.domain.job.status.JobStatus.TO_CANCEL;
 import static ai.starwhale.mlops.domain.job.status.JobStatus.UNKNOWN;
 
 import java.util.Map;
@@ -36,18 +35,17 @@ import org.springframework.stereotype.Component;
 public class JobStatusMachine {
 
     static final Map<JobStatus, Set<JobStatus>> transferMap = Map.of(
-            CREATED, Set.of(READY, PAUSED, RUNNING, SUCCESS, TO_CANCEL, FAIL),
-            READY, Set.of(PAUSED, RUNNING, SUCCESS, TO_CANCEL, FAIL),
+            CREATED, Set.of(READY, PAUSED, RUNNING, SUCCESS, CANCELLING, FAIL),
+            READY, Set.of(PAUSED, RUNNING, SUCCESS, CANCELLING, FAIL),
             PAUSED, Set.of(READY, RUNNING, CANCELED, FAIL),
-            RUNNING, Set.of(PAUSED, SUCCESS, CANCELED, FAIL),
+            RUNNING, Set.of(PAUSED, SUCCESS, CANCELLING, FAIL),
             SUCCESS, Set.of(),
             FAIL, Set.of(READY, RUNNING, SUCCESS),
-            TO_CANCEL, Set.of(CANCELLING, CANCELED, FAIL),
             CANCELLING, Set.of(CANCELED, FAIL),
             CANCELED, Set.of(),
             UNKNOWN, Set.of(JobStatus.values()));
 
-    public static final Set<JobStatus> HOT_JOB_STATUS = Set.of(READY, RUNNING, TO_CANCEL, CANCELLING);
+    public static final Set<JobStatus> HOT_JOB_STATUS = Set.of(READY, RUNNING, CANCELLING);
     public static final Set<JobStatus> FINAL_STATUS = Set.of(FAIL, SUCCESS, CANCELED);
 
     public boolean couldTransfer(JobStatus statusNow, JobStatus statusNew) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/step/StepHelper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/step/StepHelper.java
@@ -50,26 +50,25 @@ public class StepHelper {
                         Set.of(TaskStatus.ASSIGNING, TaskStatus.PREPARING, TaskStatus.RUNNING, TaskStatus.READY),
                         RequireType.MUST),
                 new StatusRequirement<>(
-                        Set.of(TaskStatus.PAUSED, TaskStatus.TO_CANCEL, TaskStatus.CANCELLING,
+                        Set.of(TaskStatus.PAUSED, TaskStatus.CANCELLING,
                                 TaskStatus.CANCELED, TaskStatus.FAIL), RequireType.HAVE_NO)));
         map.put(StepStatus.SUCCESS,
                 Set.of(new StatusRequirement<>(Set.of(TaskStatus.SUCCESS), RequireType.ALL)));
         map.put(StepStatus.CANCELED,
                 Set.of(new StatusRequirement<>(Set.of(TaskStatus.CANCELED), RequireType.MUST),
                         new StatusRequirement<>(
-                                Set.of(TaskStatus.FAIL, TaskStatus.CANCELLING, TaskStatus.TO_CANCEL,
+                                Set.of(TaskStatus.FAIL, TaskStatus.CANCELLING,
                                         TaskStatus.CREATED, TaskStatus.ASSIGNING, TaskStatus.PAUSED,
                                         TaskStatus.PREPARING, TaskStatus.RUNNING), RequireType.HAVE_NO)));
         map.put(StepStatus.CANCELLING,
                 Set.of(new StatusRequirement<>(
-                                Set.of(TaskStatus.CANCELLING, TaskStatus.TO_CANCEL, TaskStatus.CANCELED),
+                                Set.of(TaskStatus.CANCELLING, TaskStatus.CANCELED),
                                 RequireType.MUST),
                         new StatusRequirement<>(Set.of(TaskStatus.FAIL), RequireType.HAVE_NO)));
         map.put(StepStatus.PAUSED,
                 Set.of(new StatusRequirement<>(Set.of(TaskStatus.PAUSED), RequireType.MUST),
                         new StatusRequirement<>(
-                                Set.of(TaskStatus.TO_CANCEL,
-                                        TaskStatus.CANCELLING,
+                                Set.of(TaskStatus.CANCELLING,
                                         TaskStatus.CANCELED,
                                         TaskStatus.FAIL),
                                 RequireType.HAVE_NO)));

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/TaskStatus.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/TaskStatus.java
@@ -57,11 +57,6 @@ public enum TaskStatus {
     SUCCESS,
 
     /**
-     * cancel triggered by the user
-     */
-    TO_CANCEL,
-
-    /**
      * agent cancelling task
      */
     CANCELLING,

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/TaskStatusMachine.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/TaskStatusMachine.java
@@ -26,7 +26,6 @@ import static ai.starwhale.mlops.domain.task.status.TaskStatus.PREPARING;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.READY;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.RUNNING;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.SUCCESS;
-import static ai.starwhale.mlops.domain.task.status.TaskStatus.TO_CANCEL;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.UNKNOWN;
 
 import java.util.AbstractMap.SimpleEntry;
@@ -41,10 +40,9 @@ public class TaskStatusMachine {
             new SimpleEntry<>(CREATED, Set.of(ASSIGNING, READY, PREPARING, RUNNING, SUCCESS, FAIL, CANCELED)),
             new SimpleEntry<>(READY, Set.of(ASSIGNING, PAUSED, PREPARING, RUNNING, SUCCESS, FAIL, CANCELED)),
             new SimpleEntry<>(PAUSED, Set.of(PREPARING, ASSIGNING, RUNNING, READY, CANCELED, SUCCESS)),
-            new SimpleEntry<>(ASSIGNING, Set.of(CREATED, PREPARING, RUNNING, SUCCESS, FAIL, TO_CANCEL)),
-            new SimpleEntry<>(PREPARING, Set.of(RUNNING, SUCCESS, FAIL, TO_CANCEL, CANCELED)),
-            new SimpleEntry<>(RUNNING, Set.of(SUCCESS, FAIL, TO_CANCEL, CANCELED)),
-            new SimpleEntry<>(TO_CANCEL, Set.of(CANCELLING, CANCELED, SUCCESS, FAIL)),
+            new SimpleEntry<>(ASSIGNING, Set.of(CREATED, PREPARING, RUNNING, SUCCESS, FAIL, CANCELLING)),
+            new SimpleEntry<>(PREPARING, Set.of(RUNNING, SUCCESS, FAIL, CANCELLING, CANCELED)),
+            new SimpleEntry<>(RUNNING, Set.of(SUCCESS, FAIL, CANCELLING, CANCELED)),
             new SimpleEntry<>(CANCELLING, Set.of(CANCELED, FAIL)),
             new SimpleEntry<>(CANCELED, Set.of()),
             new SimpleEntry<>(SUCCESS, Set.of()),

--- a/server/controller/src/main/java/ai/starwhale/mlops/reporting/SimpleTaskModifyReceiver.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/reporting/SimpleTaskModifyReceiver.java
@@ -63,16 +63,11 @@ public class SimpleTaskModifyReceiver implements TaskModifyReceiver {
                 // update start time
                 if (reportedTask.getStartTimeMillis() != null) {
                     var tm = new Date(reportedTask.getStartTimeMillis());
-                    // prefer using the reported start time when the status is RUNNING
-                    if (reportedTask.getStatus() == TaskStatus.RUNNING) {
-                        taskMapper.updateTaskStartedTime(reportedTask.getId(), tm);
-                    } else {
-                        taskMapper.updateTaskStartedTimeIfNotSet(reportedTask.getId(), tm);
-                    }
+                    taskMapper.updateTaskStartedTimeIfNotSet(reportedTask.getId(), tm);
                 }
                 if (reportedTask.getStopTimeMillis() != null) {
                     var tm = new Date(reportedTask.getStopTimeMillis());
-                    taskMapper.updateTaskFinishedTime(reportedTask.getId(), tm);
+                    taskMapper.updateTaskFinishedTimeIfNotSet(reportedTask.getId(), tm);
                 }
                 return;
             }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/HotJobHolderImplTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/HotJobHolderImplTest.java
@@ -40,8 +40,8 @@ public class HotJobHolderImplTest {
         Job job1 = jobMockHolder.mockJob();
         Job job2 = jobMockHolder.mockJob();
         job2.getCurrentStep().getTasks().get(0).updateStatus(TaskStatus.FAIL);
-        job1.getCurrentStep().getTasks().get(0).updateStatus(TaskStatus.TO_CANCEL);
-        job1.setStatus(JobStatus.TO_CANCEL);
+        job1.getCurrentStep().getTasks().get(0).updateStatus(TaskStatus.CANCELLING);
+        job1.setStatus(JobStatus.CANCELLING);
         hotJobHolder.adopt(job1);
         hotJobHolder.adopt(job2);
 
@@ -50,7 +50,7 @@ public class HotJobHolderImplTest {
         Assertions.assertTrue(jobs.contains(job2));
         Assertions.assertEquals(2, jobs.size());
 
-        Collection<Job> jobs1 = hotJobHolder.ofStatus(Set.of(JobStatus.TO_CANCEL));
+        Collection<Job> jobs1 = hotJobHolder.ofStatus(Set.of(JobStatus.CANCELLING));
         Assertions.assertEquals(1, jobs1.size());
         Assertions.assertTrue(jobs1.contains(job1));
 
@@ -65,7 +65,7 @@ public class HotJobHolderImplTest {
         Assertions.assertTrue(jobs.contains(job2));
         Assertions.assertEquals(1, jobs.size());
 
-        jobs1 = hotJobHolder.ofStatus(Set.of(JobStatus.TO_CANCEL));
+        jobs1 = hotJobHolder.ofStatus(Set.of(JobStatus.CANCELLING));
         Assertions.assertEquals(0, jobs1.size());
 
         tasks = hotJobHolder.tasksOfIds(

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/StatusRequirementTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/StatusRequirementTest.java
@@ -25,7 +25,6 @@ import static ai.starwhale.mlops.domain.task.status.TaskStatus.PAUSED;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.PREPARING;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.RUNNING;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.SUCCESS;
-import static ai.starwhale.mlops.domain.task.status.TaskStatus.TO_CANCEL;
 
 import ai.starwhale.mlops.domain.job.step.status.StatusRequirement;
 import ai.starwhale.mlops.domain.job.step.status.StatusRequirement.RequireType;
@@ -103,7 +102,7 @@ public class StatusRequirementTest {
         Assertions.assertTrue(tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, RUNNING)));
 
         tr = new StatusRequirement(
-                Set.of(TaskStatus.PAUSED, TO_CANCEL, TaskStatus.CANCELLING,
+                Set.of(TaskStatus.PAUSED, TaskStatus.CANCELLING,
                         TaskStatus.CANCELED, TaskStatus.FAIL), RequireType.HAVE_NO);
         Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, RUNNING)));
         Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, RUNNING)));
@@ -115,10 +114,10 @@ public class StatusRequirementTest {
         Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, RUNNING)));
 
         tr = new StatusRequirement(
-                Set.of(TaskStatus.FAIL, TO_CANCEL, TaskStatus.CANCELLING,
+                Set.of(TaskStatus.FAIL, TaskStatus.CANCELLING,
                         TaskStatus.CANCELED), RequireType.HAVE_NO);
         Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, FAIL)));
-        Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, TO_CANCEL)));
+        Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS)));
         Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, CANCELED)));
         Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, CANCELED)));
         Assertions.assertTrue(!tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, CANCELED)));
@@ -130,7 +129,7 @@ public class StatusRequirementTest {
         Assertions.assertTrue(tr.fit(List.of(RUNNING, PAUSED, CANCELLING, SUCCESS, SUCCESS)));
 
         tr = new StatusRequirement(
-                Set.of(TaskStatus.FAIL, TaskStatus.CANCELLING, TO_CANCEL,
+                Set.of(TaskStatus.FAIL, TaskStatus.CANCELLING,
                         TaskStatus.CREATED, TaskStatus.ASSIGNING, TaskStatus.PAUSED,
                         TaskStatus.PREPARING, TaskStatus.RUNNING), RequireType.HAVE_NO);
         Assertions.assertTrue(tr.fit(List.of(CANCELED, SUCCESS, SUCCESS)));
@@ -141,9 +140,9 @@ public class StatusRequirementTest {
         Assertions.assertTrue(!tr.fit(List.of(RUNNING, SUCCESS, CREATED)));
 
         tr = new StatusRequirement(
-                Set.of(TO_CANCEL, TaskStatus.CANCELLING, TaskStatus.CANCELED,
+                Set.of(TaskStatus.CANCELLING, TaskStatus.CANCELED,
                         TaskStatus.FAIL), RequireType.HAVE_NO);
-        Assertions.assertTrue(!tr.fit(List.of(RUNNING, TO_CANCEL, CREATED)));
+        Assertions.assertTrue(!tr.fit(List.of(RUNNING, CREATED, CANCELLING)));
         Assertions.assertTrue(tr.fit(List.of(RUNNING, SUCCESS, CREATED)));
 
         tr = new StatusRequirement(Set.of(TaskStatus.values()), RequireType.HAVE_NO);

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/StepHelperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/StepHelperTest.java
@@ -25,7 +25,6 @@ import static ai.starwhale.mlops.domain.task.status.TaskStatus.PREPARING;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.READY;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.RUNNING;
 import static ai.starwhale.mlops.domain.task.status.TaskStatus.SUCCESS;
-import static ai.starwhale.mlops.domain.task.status.TaskStatus.TO_CANCEL;
 
 import ai.starwhale.mlops.domain.job.step.StepHelper;
 import ai.starwhale.mlops.domain.job.step.bo.Step;
@@ -51,12 +50,10 @@ public class StepHelperTest {
         StepStatus cancelling = StepStatus.CANCELLING;
         Assertions.assertEquals(cancelling, stepHelper.desiredStepStatus(Set.of(SUCCESS, CANCELLING)));
 
-        Assertions.assertEquals(cancelling, stepHelper.desiredStepStatus(Set.of(SUCCESS, TO_CANCEL, CANCELLING)));
-
-        Assertions.assertEquals(cancelling, stepHelper.desiredStepStatus(Set.of(SUCCESS, TO_CANCEL)));
+        Assertions.assertEquals(cancelling, stepHelper.desiredStepStatus(Set.of(SUCCESS, CANCELLING)));
 
         Assertions.assertEquals(cancelling,
-                stepHelper.desiredStepStatus(Set.of(SUCCESS, TO_CANCEL, CANCELLING, CANCELED)));
+                stepHelper.desiredStepStatus(Set.of(SUCCESS, CANCELLING, CANCELED)));
 
         Assertions.assertEquals(cancelling, stepHelper.desiredStepStatus(Set.of(SUCCESS, CANCELLING, CANCELED)));
         Assertions.assertEquals(cancelling,


### PR DESCRIPTION
## Description

- Use the start time of the pod if exists when the job is in the final state
- Use now as the stop time when cancelled

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
