### PR TITLE
bug(client): fix dataset blob download api typo

### DIFF
--- a/client/starwhale/core/dataset/copy.py
+++ b/client/starwhale/core/dataset/copy.py
@@ -282,7 +282,7 @@ class DatasetCopy(BundleCopy):
         local_blob_path = DatasetStorage._get_object_store_path(hash_name)
         if not local_blob_path.exists():
             self.do_download_file(
-                url_path=f"/project/{self.src_uri.project.name}/dataset/{self.src_uri.name}/blob",
+                url_path=f"/project/{self.src_uri.project.name}/dataset/{self.src_uri.name}/hashedBlob/{hash_name}",
                 dest_path=local_blob_path,
                 instance=self.src_uri.instance,
                 progress=progress,

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -307,7 +307,7 @@ class TestDatasetCopy(BaseTestCase):
         )
         rm.request(
             HTTPMethod.GET,
-            f"{instance_uri}/api/v1/project/{cloud_project}/dataset/{dataset_name}/blob",
+            f"{instance_uri}/api/v1/project/{cloud_project}/dataset/{dataset_name}/hashedBlob/111",
         )
 
         rm.request(


### PR DESCRIPTION
## Description
depends on: https://github.com/star-whale/starwhale/pull/2420

```
❯ swcli -vvv dataset cp https://cloud.starwhale.cn/projects/12/datasets/23/versions/125/ . -dlp mnist-download --force
[2023-06-28 15:02:16.429311] 👾 verbosity: 3, log level: DEBUG
[2023-06-28 15:02:25.182327] 🚧 start to copy https://cloud.starwhale.cn/project/12/dataset/mnist/version/dwfma4n3w3pxjdnyjuvumwdtyyiq5hwmnkwtebyf -> local/project/mnist-download/dataset/mnist/version/dwfma4n3w3pxjdnyjuvumwdtyyiq5hwmnkwtebyf
[2023-06-28 15:02:25.184078] 🐦 preprocess artifacts link
[2023-06-28 15:02:40.560309] 🐱 try to download 1 blobs
[2023-06-28 15:02:48.612611] 🐴 dump dataset meta from src to dest
[2023-06-28 15:03:05.525905] 🦘 update dataset info
[2023-06-28 15:03:05.609765] 🐯 make version for dest instance
  ⬇ 10b228058ae7 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0:00:00 0 bytes 1.1 MB/s
[2023-06-28 15:03:05.683362] 🍵 console url of the remote bundle: https://cloud.starwhale.cn/projects/12/datasets/mnist/versions/dwfma4n3w3pxjdnyjuvumwdtyyiq5hwmnkwtebyf/overview
[2023-06-28 15:03:05.683747] 👏 copy done
```

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
