### PR TITLE
chore(controller): add failed reason in task response

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/task/TaskVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/task/TaskVo.java
@@ -49,4 +49,5 @@ public class TaskVo implements Serializable {
 
     private String devUrl;
 
+    private String failedReason;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/converter/TaskConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/converter/TaskConverter.java
@@ -84,6 +84,7 @@ public class TaskConverter {
                 .devUrl(devUrl)
                 .startedTime(entity.getStartedTime() == null ? null : entity.getStartedTime().getTime())
                 .resourcePool(pool)
+                .failedReason(entity.getFailedReason())
                 .build();
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/mapper/TaskMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/mapper/TaskMapper.java
@@ -32,7 +32,7 @@ public interface TaskMapper {
 
     String COLUMNS = "task_info.id, task_uuid, step_id, agent_id, task_status, task_request, "
             + " task_info.finished_time, task_info.started_time, task_info.created_time, task_info.modified_time,"
-            + " retry_num, output_path, ip, dev_way, dev_password";
+            + " retry_num, output_path, ip, dev_way, dev_password, failed_reason";
 
     @Select("select " + COLUMNS + " from task_info"
             + " left join step s on s.id = task_info.step_id where s.job_id = #{jobId} order by id desc")
@@ -105,5 +105,8 @@ public interface TaskMapper {
 
     @Update("update task_info set task_request = #{request} where id = #{taskId}")
     void updateTaskRequest(@Param("taskId") Long taskId, @Param("request") String request);
+
+    @Update("update task_info set failed_reason = #{reason} where id = #{id}")
+    void updateFailedReason(@Param("id") Long taskId, @Param("reason") String reason);
 }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/po/TaskEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/po/TaskEntity.java
@@ -57,4 +57,5 @@ public class TaskEntity extends BaseEntity {
 
     private Date finishedTime;
 
+    private String failedReason;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/reporting/SimpleTaskModifyReceiver.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/reporting/SimpleTaskModifyReceiver.java
@@ -47,6 +47,10 @@ public class SimpleTaskModifyReceiver implements TaskModifyReceiver {
     public void receive(List<ReportedTask> reportedTasks) {
 
         reportedTasks.forEach(reportedTask -> {
+            if (reportedTask.getFailedReason() != null) {
+                taskMapper.updateFailedReason(reportedTask.getId(), reportedTask.getFailedReason());
+            }
+
             Collection<Task> optionalTasks = jobHolder.tasksOfIds(List.of(reportedTask.getId()));
 
             if (null == optionalTasks || optionalTasks.isEmpty()) {

--- a/server/controller/src/main/resources/db/migration/v0_4_0/V0_4_0_008__add_task_fail_reason.sql
+++ b/server/controller/src/main/resources/db/migration/v0_4_0/V0_4_0_008__add_task_fail_reason.sql
@@ -14,28 +14,6 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.reporting;
 
-import ai.starwhale.mlops.domain.task.status.TaskStatus;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-
-/**
- * convert taskReport to
- */
-@Getter
-@AllArgsConstructor
-@EqualsAndHashCode
-@Builder
-public class ReportedTask {
-
-    final Long id;
-    final TaskStatus status;
-    final Integer retryCount;
-    final String ip;
-    final Long startTimeMillis;
-    final Long stopTimeMillis;
-    final String failedReason;
-}
+ALTER TABLE task_info
+    ADD failed_reason VARCHAR(255) NULL;

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/task/mapper/TaskMapperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/task/mapper/TaskMapperTest.java
@@ -217,4 +217,17 @@ public class TaskMapperTest extends MySqlContainerHolder {
         Assertions.assertEquals(request, taskMapper.findTaskById(task1.getId()).getTaskRequest());
     }
 
+    @Test
+    public void testFailedReason() {
+        TaskEntity task = TaskEntity.builder()
+                .taskStatus(TaskStatus.CREATED)
+                .retryNum(0)
+                .taskUuid(UUID.randomUUID().toString())
+                .stepId(1L)
+                .build();
+        taskMapper.addTask(task);
+        String reason = "reason";
+        taskMapper.updateFailedReason(task.getId(), reason);
+        Assertions.assertEquals(reason, taskMapper.findTaskById(task.getId()).getFailedReason());
+    }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/JobEventHandlerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/JobEventHandlerTest.java
@@ -104,6 +104,21 @@ public class JobEventHandlerTest {
                 .retryCount(1)
                 .build();
         verify(taskModifyReceiver).receive(List.of(expected));
+
+        // test with reason and message
+        var con = new V1JobCondition()
+                .status("True").type("Failed").lastTransitionTime(endTime).reason("reason").message("message");
+        v1JobStatus.setConditions(List.of(con));
+        jobEventHandler.onAdd(v1Job);
+        var expected2 = ReportedTask.builder()
+                .id(1L)
+                .status(TaskStatus.FAIL)
+                .startTimeMillis(startTime.toInstant().toEpochMilli())
+                .stopTimeMillis(endTime.toInstant().toEpochMilli())
+                .failedReason("reason, message")
+                .retryCount(1)
+                .build();
+        verify(taskModifyReceiver).receive(List.of(expected2));
     }
 
     @Test


### PR DESCRIPTION
## Description

Add `failedReason` fied in task list resp (may be null), demo:

```json

{
    "code": "success",
    "message": "Success",
    "data": {
        "total": 2,
        "list": [
            {
                "id": "78",
                "uuid": "f2644658-cb81-46bc-ba22-f29e2ec87029",
                "failedReason":  "ProviderFailed, failed to get instance configs"
            },
...
```

cc @waynelwz 

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
