### PR TITLE
feat(console): grid table search with IN by multi status, fix view switch problems

### DIFF
--- a/console/packages/starwhale-core/src/datastore/constants.ts
+++ b/console/packages/starwhale-core/src/datastore/constants.ts
@@ -23,7 +23,7 @@ export enum OPERATOR {
     LESS = 'LESS',
     LESS_EQUAL = 'LESS_EQUAL',
     NOT = 'NOT',
-    // IN = 'IN',
+    IN = 'IN',
     // NOT_IN = 'NOT_IN',
     // CONTAINS = 'CONTAINS',
     // NOT_CONTAINS = 'NOT_CONTAINS',

--- a/console/packages/starwhale-core/src/editor/index.tsx
+++ b/console/packages/starwhale-core/src/editor/index.tsx
@@ -2,55 +2,15 @@
 import React, { useEffect, useMemo } from 'react'
 import log from 'loglevel'
 import EditorContextProvider from '../context/EditorContextProvider'
-import { registerWidgets } from '../widget/WidgetFactoryRegister'
 import WidgetFactory from '../widget/WidgetFactory'
 import { createCustomStore } from '../store/store'
 import WidgetRenderTree from '../widget/WidgetRenderTree'
 import { EventBusSrv } from '../events/events'
 import { WidgetTreeNode } from '../types'
 
-// export const registerRemoteWidgets = async () => {
-//     // @FIXME store module meta from backend
-//     // meta was defined by system not user
-//     const start = performance.now()
-
-//     // must be remote component that packaged
-//     const modules = [
-//         { type: 'ui:dndList', url: '../widgets/DNDListWidget/index.tsx' },
-//         { type: 'ui:section', url: '../widgets/SectionWidget/index.tsx' },
-//         { type: 'ui:panel:table', url: '../widgets/PanelTableWidget/index.tsx' },
-//         { type: 'ui:panel:rocauc', url: '../widgets/PanelRocAucWidget/index.tsx' },
-//         { type: 'ui:panel:heatmap', url: '../widgets/PanelHeatmapWidget/index.tsx' },
-//     ].filter((v) => !(v.type in WidgetFactory.widgetTypes))
-
-//     /* @vite-ignore */
-//     for await (const module of modules.map(async (m) => import(m.url))) {
-//         const widget = module.default as WidgetPlugin
-//         registerWidget(widget, widget.defaults)
-//     }
-
-//     console.log('Widget registration took: ', performance.now() - start, 'ms')
-// }
-// log.enableAll()
-
 export function withEditorRegister(EditorApp: React.FC) {
-    registerWidgets()
-
     return function EditorLoader(props: any) {
-        // const [registred, setRegistred] = React.useState(false)
-        useEffect(() => {
-            /*
-            import('http://127.0.0.1:8080/widget.js').then((module) => {
-                // setRegistred(true)
-                console.log(module)
-            })
-            */
-        }, [])
-        // if (!registred) {
-        //     return <BusyPlaceholder type='spinner' />
-        // }
         log.debug('WidgetFactory', WidgetFactory.widgetMap)
-
         return <EditorApp {...props} />
     }
 }

--- a/console/packages/starwhale-core/src/widget/WidgetPlugin.tsx
+++ b/console/packages/starwhale-core/src/widget/WidgetPlugin.tsx
@@ -20,6 +20,14 @@ class WidgetPlugin<
         this.renderer = renderer
         this.defaults = config
     }
+
+    getType() {
+        return this.defaults?.type
+    }
+
+    getConfig() {
+        return this.defaults
+    }
 }
 
 export default WidgetPlugin

--- a/console/packages/starwhale-core/src/widget/WidgetRenderer.tsx
+++ b/console/packages/starwhale-core/src/widget/WidgetRenderer.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import _ from 'lodash'
 import { ErrorBoundary } from '@starwhale/ui'
-import { useWidget } from './WidgetFactoryRegister'
+import { useWidget } from './hooks/useWidget'
 import { WidgetRendererProps } from '../types'
 
 const DEBUG = false

--- a/console/packages/starwhale-core/src/widget/hooks/useWidget.tsx
+++ b/console/packages/starwhale-core/src/widget/hooks/useWidget.tsx
@@ -4,14 +4,21 @@ import SectionWidget from '@starwhale/widgets/SectionWidget'
 import PanelTableWidget from '@starwhale/widgets/PanelTableWidget'
 import PanelRocAucWidget from '@starwhale/widgets/PanelRocAucWidget'
 import PanelHeatmapWidget from '@starwhale/widgets/PanelConfusionMatrixWidget'
-import { WidgetConfig } from '../types'
-import WidgetFactory from './WidgetFactory'
-import WidgetPlugin from './WidgetPlugin'
+import WidgetFactory from '../WidgetFactory'
+import WidgetPlugin from '../WidgetPlugin'
+
+const modules = [DNDListWidget, SectionWidget, PanelTableWidget, PanelRocAucWidget, PanelHeatmapWidget]
 
 export function useWidget(widgetType: string) {
     const [widget, setWidget] = useState<WidgetPlugin | undefined>(WidgetFactory.widgetMap.get(widgetType))
 
     useEffect(() => {
+        if (!WidgetFactory.widgetMap.has(widgetType)) {
+            modules.forEach((w: WidgetPlugin<any>) => {
+                if (w.getType() === widgetType) WidgetFactory.register(w.getType(), w)
+            })
+        }
+
         const temp = WidgetFactory.widgetMap.get(widgetType)
 
         if (temp && temp !== widget) {
@@ -30,25 +37,4 @@ export function useWidget(widgetType: string) {
         widget,
         setWidget,
     }
-}
-
-export const registerWidget = (Widget: any, config: WidgetConfig) => {
-    if (!config?.type) {
-        // eslint-disable-next-line no-console
-        console.log('Widget registration missing type', config)
-        return
-    }
-
-    WidgetFactory.register(config.type, Widget)
-}
-
-const modules = [DNDListWidget, SectionWidget, PanelTableWidget, PanelRocAucWidget, PanelHeatmapWidget]
-export const registerWidgets = () => {
-    const start = performance.now()
-    modules.forEach((widget) => {
-        if (widget.defaults.type in WidgetFactory.widgetTypes) return
-        registerWidget(widget, widget.defaults)
-    })
-    // eslint-disable-next-line no-console
-    console.log('Widget registration took: ', performance.now() - start, 'ms')
 }

--- a/console/packages/starwhale-core/src/widget/index.tsx
+++ b/console/packages/starwhale-core/src/widget/index.tsx
@@ -1,5 +1,5 @@
 export { default as BaseWidget } from './BaseWidget'
-export * from './WidgetFactoryRegister'
+export * from './hooks/useWidget'
 
 export { default as WidgetFactory } from './WidgetFactory'
 export * from './WidgetFactory'

--- a/console/packages/starwhale-ui/src/DynamicSelector/Selector.tsx
+++ b/console/packages/starwhale-ui/src/DynamicSelector/Selector.tsx
@@ -34,6 +34,8 @@ export function SelectorItemByTree({ value, onChange, search, inputRef, info, $m
     )
 }
 
+const empty: any = []
+
 export function DynamicSelector<T = any>({
     onChange,
     startEnhancer,
@@ -56,6 +58,9 @@ export function DynamicSelector<T = any>({
     useEffect(() => {
         if (rest.value && rest.value !== values) {
             setValues(rest.value)
+        }
+        if (!rest.value) {
+            setValues(empty)
         }
     }, [rest.value, values])
 
@@ -196,83 +201,3 @@ export function DynamicSelector<T = any>({
 }
 
 export default DynamicSelector
-
-// const treeData = [
-//     {
-//         id: '1',
-//         label: 'Fruit',
-//         isExpanded: true,
-//         info: { label: 'Fruit' },
-//         children: [
-//             {
-//                 id: '2',
-//                 label: 'Apple',
-//                 isExpanded: true,
-//                 children: [],
-//             },
-
-//             {
-//                 id: '3',
-//                 label: 'Test',
-//                 isExpanded: true,
-//                 children: [],
-//             },
-
-//             {
-//                 id: '4',
-//                 label: 'Test2',
-//                 isExpanded: true,
-//                 children: [],
-//             },
-
-//             {
-//                 id: '5',
-//                 label: 'Test2',
-//                 isExpanded: true,
-//                 children: [],
-//             },
-
-//             {
-//                 id: '6',
-//                 label: 'Test2',
-//                 isExpanded: true,
-//                 children: [],
-//             },
-//         ],
-//     },
-// ]
-
-// export default (props: DynamicSelectorPropsT<any>) => {
-//     const options = [
-//         {
-//             id: 'tree',
-//             info: {
-//                 data: treeData,
-//             },
-//             multiple: false,
-//             getData: (info: any, id: string) => findTreeNode(info.data, id),
-//             getDataToLabel: (data: any) => data?.label,
-//             getDataToValue: (data: any) => data?.id,
-//             render: SelectorItemByTree as React.FC<any>,
-//         },
-//     ]
-//     const options2 = [
-//         {
-//             id: 'tree',
-//             info: {
-//                 data: treeData,
-//             },
-//             multiple: true,
-//             getData: (info: any, id: string) => findTreeNode(info.data, id),
-//             getDataToLabel: (data: any) => data?.label,
-//             getDataToValue: (data: any) => data?.id,
-//             render: SelectorItemByTree as React.FC<any>,
-//         },
-//     ]
-//     return (
-//         <>
-//             <DynamicSelector {...props} options={options} />
-//             <DynamicSelector options={options2} />
-//         </>
-//     )
-// }

--- a/console/packages/starwhale-ui/src/GridTable/GridCombineTable.tsx
+++ b/console/packages/starwhale-ui/src/GridTable/GridCombineTable.tsx
@@ -16,6 +16,7 @@ const useStyles = createUseStyles({
         display: 'flex',
         flexDirection: 'column',
         flex: 1,
+        minWidth: 0,
     },
     header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
     headerTitle: {

--- a/console/packages/starwhale-ui/src/GridTable/components/Query/ConfigSimpleQuery.tsx
+++ b/console/packages/starwhale-ui/src/GridTable/components/Query/ConfigSimpleQuery.tsx
@@ -16,14 +16,24 @@ function ConfigSimpleQuery({ columns, onChange, value }: PropsT) {
 
     const [form] = useForm()
 
+    const columnsWithFilter = React.useMemo(() => {
+        return columns?.filter((column) => column.filterable)
+    }, [columns])
+
     useEffect(() => {
         const tmp = _.fromPairs(
             value.map((query) => {
                 return [query.property, query.value]
             })
         )
+        const prev = form.getFieldsValue()
+        Object.keys(prev).forEach((key) => {
+            if (!(key in tmp)) {
+                tmp[key] = undefined
+            }
+        })
+        form.setFieldsValue({ ...tmp })
         setValues(tmp)
-        form.setFieldsValue(tmp)
     }, [value, form])
 
     const handleValuesChange = React.useCallback(
@@ -40,10 +50,6 @@ function ConfigSimpleQuery({ columns, onChange, value }: PropsT) {
         },
         [onChange]
     )
-
-    const columnsWithFilter = React.useMemo(() => {
-        return columns?.filter((column) => column.filterable)
-    }, [columns])
 
     const Filters = React.useMemo(() => {
         return columnsWithFilter?.map((column) => {

--- a/console/packages/starwhale-ui/src/GridTable/components/Query/ConfigSimpleQuery.tsx
+++ b/console/packages/starwhale-ui/src/GridTable/components/Query/ConfigSimpleQuery.tsx
@@ -33,7 +33,7 @@ function ConfigSimpleQuery({ columns, onChange, value }: PropsT) {
                     .filter((v) => !!v)
                     .map(([key, v]) => ({
                         value: v,
-                        op: 'EQUAL',
+                        op: Array.isArray(v) ? 'IN' : 'EQUAL',
                         property: key,
                     }))
             )

--- a/console/packages/starwhale-ui/src/GridTable/components/ToolBar/index.tsx
+++ b/console/packages/starwhale-ui/src/GridTable/components/ToolBar/index.tsx
@@ -77,12 +77,8 @@ function ToolBar({ viewable, filterable, searchable, queryable, columnable }: IT
                         )}
                     </div>
                 )}
-                <div
-                    className={css({
-                        display: 'flex',
-                    })}
-                >
-                    <div className='table-config-query' style={{ flex: 1 }}>
+                <div className='flex'>
+                    <div className='table-config-query' style={{ flex: 1, minWidth: 0 }}>
                         {query}
                     </div>
 

--- a/console/packages/starwhale-ui/src/GridTable/hooks/useGridQuery.tsx
+++ b/console/packages/starwhale-ui/src/GridTable/hooks/useGridQuery.tsx
@@ -9,9 +9,10 @@ import ConfigSimpleQuery from '../components/Query/ConfigSimpleQuery'
 import Button from '@starwhale/ui/Button'
 import useTranslation from '@/hooks/useTranslation'
 
+const non: any = []
 const selector = (state: IGridState) => ({
-    queries: state.currentView?.queries ?? [],
-    onCurrentViewQueriesChange: state.onCurrentViewQueriesChange ?? [],
+    queries: state.currentView?.queries ?? non,
+    onCurrentViewQueriesChange: state.onCurrentViewQueriesChange,
 })
 
 function useGridQuery() {
@@ -40,7 +41,12 @@ function useGridQuery() {
                     gap: '20px',
                 }}
             >
-                <div className='flex'>
+                <div
+                    className='flex'
+                    style={{
+                        flex: 1,
+                    }}
+                >
                     {isSimpleQuery && hasFilter ? (
                         <ConfigSimpleQuery columns={originalColumns} value={queries} onChange={onChange} />
                     ) : (

--- a/console/packages/starwhale-ui/src/GridTable/hooks/useGridQuery.tsx
+++ b/console/packages/starwhale-ui/src/GridTable/hooks/useGridQuery.tsx
@@ -33,14 +33,14 @@ function useGridQuery() {
     const renderConfigQuery = React.useCallback(() => {
         return (
             <div
+                className='flex'
                 style={{
-                    display: 'flex',
                     justifyContent: 'space-between',
                     alignItems: 'center',
                     gap: '20px',
                 }}
             >
-                <div style={{ flex: 1 }}>
+                <div className='flex'>
                     {isSimpleQuery && hasFilter ? (
                         <ConfigSimpleQuery columns={originalColumns} value={queries} onChange={onChange} />
                     ) : (

--- a/console/packages/starwhale-ui/src/GridTable/store/StoreUpdater/index.tsx
+++ b/console/packages/starwhale-ui/src/GridTable/store/StoreUpdater/index.tsx
@@ -26,7 +26,7 @@ export function useDirectStoreUpdater(
     useEffect(() => {
         if (typeof value !== 'undefined') {
             // eslint-disable-next-line no-console
-            console.log('set state', key)
+            // console.log('set state', key)
             setState({ [key]: value }, false)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/console/packages/starwhale-ui/src/GridTable/store/store.ts
+++ b/console/packages/starwhale-ui/src/GridTable/store/store.ts
@@ -153,6 +153,7 @@ const createViewSlice: IStateCreator<IViewState> = (set, get, store) => {
 
 const rawCurrentView = {
     filters: [],
+    queries: [],
     ids: [],
     pinnedIds: [],
     selectedIds: [],
@@ -198,8 +199,11 @@ const createCurrentViewSlice: IStateCreator<ICurrentViewState> = (set, get, stor
             if (!view) {
                 view = rawCurrentView
             }
+            const prev = get()
             // view id change will not tiggered changed status, current view only saved in local,
             set({ currentView: view }, false, 'onCurrentViewIdChange')
+            // @ts-ignore
+            store.getState().onCurrentViewChange?.(get(), prev)
         },
         onCurrentViewFiltersChange: (filters) => update({ filters }, 'onCurrentViewFiltersChange'),
         onCurrentViewQueriesChange: (queries) =>
@@ -246,7 +250,7 @@ const createViewInteractiveSlice: IStateCreator<IViewInteractiveState> = (set, g
 const createTableStateInitSlice: IStateCreator<ITableStateInitState> = (set, get, store) => ({
     isInit: false,
     key: 'table',
-    initStore: (obj?: Record<string, any>) =>
+    initStore: (obj?: Record<string, any>) => {
         set(
             {
                 ...(obj ? _.pick(obj, Object.keys(rawInitialState)) : rawInitialState),
@@ -254,7 +258,8 @@ const createTableStateInitSlice: IStateCreator<ITableStateInitState> = (set, get
             },
             undefined,
             'initStore'
-        ),
+        )
+    },
     setRawConfigs: (obj: Record<string, any>) =>
         set(
             {
@@ -389,7 +394,7 @@ export type IStore = ReturnType<typeof createCustomStore>
 
 export default createCustomStore
 
-export const useEvaluationStore = createCustomStore('evaluations', {}, true)
+export const useEvaluationStore = createCustomStore('evaluations', {}, false)
 export const useEvaluationCompareStore = createCustomStore('compare', {
     compare: {
         comparePinnedKey: '',

--- a/console/packages/starwhale-ui/src/Search/FilterRenderer.tsx
+++ b/console/packages/starwhale-ui/src/Search/FilterRenderer.tsx
@@ -237,7 +237,7 @@ export default function FilterRenderer({
             )}
             {!editing && isValueExist(value) && (
                 <div className={styles.label} title={value}>
-                    {value}
+                    {Array.isArray(value) ? value.join(', ') : value}
                     <div
                         className='filter-remove'
                         role='button'

--- a/console/packages/starwhale-ui/src/Search/FilterRenderer.tsx
+++ b/console/packages/starwhale-ui/src/Search/FilterRenderer.tsx
@@ -73,7 +73,11 @@ export default function FilterRenderer({
     const $fieldOptions = React.useMemo(() => {
         return $columns
             .filter((tmp) => {
-                return tmp.label?.match(value)
+                try {
+                    return tmp.label?.match(value)
+                } catch {
+                    return false
+                }
             })
             .map((tmp) => {
                 return {

--- a/console/packages/starwhale-ui/src/Search/Search.tsx
+++ b/console/packages/starwhale-ui/src/Search/Search.tsx
@@ -21,7 +21,7 @@ export const useStyles = createUseStyles({
         '&::-webkit-scrollbar': {
             height: '4px !important',
         },
-        'flexGrow': '0',
+        'flexGrow': '1',
         '&:hover': {
             borderColor: '#799EE8 !important',
         },

--- a/console/packages/starwhale-ui/src/Search/types.ts
+++ b/console/packages/starwhale-ui/src/Search/types.ts
@@ -13,7 +13,7 @@ export type KindT = keyof typeof KIND
 
 export const FilterTypeOperators: Record<Partial<KIND>, OPERATOR[]> = {
     [KIND.CATEGORICAL]: [],
-    [KIND.STRING]: [OPERATOR.EQUAL],
+    [KIND.STRING]: [OPERATOR.EQUAL, OPERATOR.IN],
     [KIND.NUMERICAL]: [OPERATOR.EQUAL, OPERATOR.GREATER, OPERATOR.GREATER_EQUAL, OPERATOR.LESS, OPERATOR.LESS_EQUAL],
     BOOLEAN: [OPERATOR.EQUAL],
     CUSTOM: [],
@@ -143,12 +143,12 @@ export const Operators: Record<string, OperatorT> = {
     //         }
     //     },
     // },
-    // [OPERATOR.IN]: {
-    //     key: OPERATOR.IN,
-    //     label: 'in',
-    //     value: 'in',
-    //     buildFilter: () => () => true,
-    // },
+    [OPERATOR.IN]: {
+        key: OPERATOR.IN,
+        label: 'in',
+        value: 'in',
+        buildFilter: () => () => true,
+    },
     // [OPERATOR.NOT_IN]: {
     //     key: OPERATOR.NOT_IN,
     //     label: 'not in',

--- a/console/packages/starwhale-ui/src/Select/Select.tsx
+++ b/console/packages/starwhale-ui/src/Select/Select.tsx
@@ -45,6 +45,28 @@ export function Select({ size = 'compact', ...props }: ISelectProps) {
                     />
                 )
             },
+            IconsContainer: {
+                style: {
+                    color: 'rgba(2, 16, 43, 0.2)',
+                },
+            },
+            Tag: {
+                props: {
+                    overrides: {
+                        Root: {
+                            style: {
+                                cursor: 'pointer',
+                                color: 'rgba(2, 16, 43, 0.2)',
+                                backgroundColor: 'rgba(2, 16, 43, 0)',
+                                marginTop: '2px',
+                                marginBottom: '2px',
+                                marginRight: '2px',
+                                marginLeft: '2px',
+                            },
+                        },
+                    },
+                },
+            },
         },
         props.overrides
     )

--- a/console/src/components/Editor/index.tsx
+++ b/console/src/components/Editor/index.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useRef } from 'react'
 import EditorContextProvider, { StoreType } from '@starwhale/core/context/EditorContextProvider'
-import { registerWidgets } from '@starwhale/core/widget/WidgetFactoryRegister'
 import { createCustomStore } from '@starwhale/core/store'
 import WidgetRenderTree from '@starwhale/core/widget/WidgetRenderTree'
 import { EventBusSrv } from '@starwhale/core/events'
@@ -11,8 +10,6 @@ import { tranformState } from './utils'
 import { useProject } from '@project/hooks/useProject'
 
 export function withEditorRegister(EditorApp: React.FC) {
-    registerWidgets()
-
     return function EditorLoader(props: any) {
         const { project } = useProject()
         const projectId = project?.id

--- a/console/src/domain/job/components/JobForm.tsx
+++ b/console/src/domain/job/components/JobForm.tsx
@@ -99,7 +99,7 @@ export default function JobForm({ job, onSubmit }: IJobFormProps) {
         if (!modelVersion) return
         setBuiltInRuntime(modelVersion?.builtInRuntime ?? '')
         setType(modelVersion?.builtInRuntime ? RuntimeType.BUILTIN : RuntimeType.OTHER)
-    }, [modelVersion, RuntimeType])
+    }, [modelVersion, RuntimeType.BUILTIN, RuntimeType.OTHER])
 
     const fullStepSource: StepSpec[] | undefined = React.useMemo(() => {
         if (!modelVersion) return undefined
@@ -159,7 +159,7 @@ export default function JobForm({ job, onSubmit }: IJobFormProps) {
                 setLoading(false)
             }
         },
-        [onSubmit, history, stepSpecOverWrites, stepSource, checkStepSource, type]
+        [onSubmit, history, stepSpecOverWrites, stepSource, checkStepSource, type, RuntimeType.BUILTIN]
     )
 
     const handleEditorChange = React.useCallback(

--- a/console/src/i18n/locales.ts
+++ b/console/src/i18n/locales.ts
@@ -1505,6 +1505,14 @@ const locales0 = {
         en: 'Push to local',
         zh: '拉取到本地',
     },
+    'Github': {
+        en: 'Github',
+        zh: 'Github',
+    },
+    'Google': {
+        en: 'Google',
+        zh: 'Google',
+    },
     ...basic,
     ...dataset,
     ...model,

--- a/console/src/pages/Evaluation/EvaluationListCard.tsx
+++ b/console/src/pages/Evaluation/EvaluationListCard.tsx
@@ -139,7 +139,7 @@ export default function EvaluationListCard() {
                             <ModelTreeSelector
                                 placeholder={t('model.selector.version.placeholder')}
                                 projectId={projectId}
-                                multiple={false}
+                                multiple
                                 clearable
                                 getId={(v: any) => v.versionName}
                             />

--- a/console/src/pages/Evaluation/EvaluationListCard.tsx
+++ b/console/src/pages/Evaluation/EvaluationListCard.tsx
@@ -110,7 +110,7 @@ export default function EvaluationListCard() {
                     ),
                     filterable: true,
                     renderFilter: function RenderFilter() {
-                        return <JobStatusSelector clearable />
+                        return <JobStatusSelector clearable multiple />
                     },
                 })
             if (column.key?.endsWith('time')) {

--- a/console/src/styles/_global.scss
+++ b/console/src/styles/_global.scss
@@ -132,6 +132,10 @@ table {
     -webkit-line-clamp: 1;
 }
 
+.flex {
+    display: flex;
+    min-width: 0;
+}
 .flex-column-center {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Description
![image](https://github.com/star-whale/starwhale/assets/100347187/d5ebd650-78ef-4bdf-95d8-635ba145eae6)

* Resolve the issue of project grid view configuration not resetting when switching.
* Add a map cache to store the current view of multiple projects.
* Fix the bug where the query component content does not reset.
* Modify the widget component by removing the register logic to prevent hot reload failures.

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
