### PR TITLE
bug(client): fix trio typing plugin not found error

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -25,7 +25,7 @@ install-sw:
 
 install-dev-req:
 	python3 -m pip install -r requirements-dev.txt
-	((grep -E "ubuntu|debian" /etc/os-release > /dev/null) && sudo apt-get install libsndfile1) || echo "skip install libsndfile1"
+	((grep -E "ubuntu|debian" /etc/os-release > /dev/null) && sudo apt-get install libsndfile1 -y) || echo "skip install libsndfile1"
 
 black-format:
 	black --config pyproject.toml $(PY_CHANGED_FILES)

--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -19,7 +19,6 @@ pyfakefs >= 4.5.6
 pytest-mock >= 3.7.0
 requests-mock >= 1.9.3
 isort >= 5.10.1
-trio-typing[mypy] >= 0.7.0
 respx >= 0.19.0
 # for integration test
 torch>=2.0.1; python_version >= '3.11'
@@ -33,3 +32,8 @@ soundfile
 openapi-spec-validator
 # for jupyternotebook
 jupyter
+# for trio typing
+trio-typing[mypy] >= 0.7.0
+# trio>=0.22 has already removed async_generator dependency, but the trio_typing lib still hooks it.
+# So we need to install async_generator>=1.9 to workaround the warning.
+async_generator >= 1.9

--- a/client/setup.py
+++ b/client/setup.py
@@ -40,7 +40,6 @@ install_requires = [
     "types-protobuf>=3.19.0",
     "lz4>=3.1.10",
     "trio>=0.22.0",
-    "trio_typing>=0.7.0",
     "httpx>=0.22.0",
 ]
 


### PR DESCRIPTION
## Description
- error: https://github.com/star-whale/starwhale/actions/runs/5440233912/jobs/9892964282
- reason:
  - trio_typing:  https://github.com/python-trio/trio-typing/blob/master/trio_typing/plugin.py#L41
  - trio: 
    - https://github.com/python-trio/trio/pull/2478
    - 0.22 was released at 2023.7.2 

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
