### PR TITLE
chore(client): show trackback locals in the trace mode

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -10,7 +10,7 @@ ulimit -n 65535 || true
 
 CONDA_BIN="/opt/miniconda3/bin"
 PIP_CACHE_DIR=${SW_PIP_CACHE_DIR:=/"${SW_USER:-root}"/.cache/pip}
-VERBOSE="-vvvv"
+VERBOSE="-vvv"
 HANDLER=${SW_RUN_HANDLER:-""}
 STEP=${SW_TASK_STEP:-""}
 TASK_INDEX=${SW_TASK_INDEX:-0}

--- a/client/starwhale/utils/debug.py
+++ b/client/starwhale/utils/debug.py
@@ -23,6 +23,11 @@ def init_logger(verbose: int = 0) -> None:
 
     Returns: None
     """
+    verbose_env = os.environ.get(ENV_LOG_VERBOSE_COUNT)
+    if verbose_env is not None:
+        verbose = int(verbose_env)
+
+    show_locals = False
     if verbose == 0:
         lvl = console.ERROR
         max_frames = 1
@@ -38,13 +43,13 @@ def init_logger(verbose: int = 0) -> None:
     elif verbose >= 4:
         lvl = console.TRACE
         max_frames = 1000
+        show_locals = True
     else:
         raise ValueError(f"Invalid verbose level: {verbose}")
 
     console.set_level(lvl)
     lvl_name = console.get_level_name(lvl)
     os.environ[ENV_LOG_LEVEL] = lvl_name
-    os.environ[ENV_LOG_VERBOSE_COUNT] = str(verbose)
 
     if verbose > 0:
         os.environ[ENV_DISABLE_PROGRESS_BAR] = "1"
@@ -52,5 +57,8 @@ def init_logger(verbose: int = 0) -> None:
 
     # TODO: custom debug for tb install
     traceback.install(
-        console=console.rich_console, show_locals=True, max_frames=max_frames, width=200
+        console=console.rich_console,
+        show_locals=show_locals,
+        max_frames=max_frames,
+        width=200,
     )

--- a/scripts/client_test/cmds/artifacts_cmd.py
+++ b/scripts/client_test/cmds/artifacts_cmd.py
@@ -71,7 +71,7 @@ class Model(BaseArtifact):
         version = gen_uniq_version()
         cmd = [
             CLI,
-            "-vvvv",
+            "-vvv",
             "model",
             "run",
             "--uri",
@@ -112,7 +112,7 @@ class Model(BaseArtifact):
     @classmethod
     def build(cls, workdir: str, name: str, runtime: str = "") -> Resource:
         version = gen_uniq_version()
-        cmd = [CLI, "-vvvv", "model", "build", workdir, "--name", name]
+        cmd = [CLI, "-vvv", "model", "build", workdir, "--name", name]
         if runtime:
             cmd.extend(["--runtime", runtime])
         _ret_code, _res = invoke(cmd, external_env={_ENV_FIXED_VERSION: version})
@@ -120,7 +120,7 @@ class Model(BaseArtifact):
         return Resource(f"{name}/version/{version}", typ=ResourceType.model)
 
     def copy(self, src_uri: str, target_project: str, force: bool) -> None:
-        _args = [CLI, "-vvvv", self.name, "copy", src_uri, target_project]
+        _args = [CLI, "-vvv", self.name, "copy", src_uri, target_project]
         if force:
             _args.append("--force")
         _ret_code, _res = invoke(_args, log=True)
@@ -142,7 +142,7 @@ class Dataset(BaseArtifact):
 
         cmd = [
             CLI,
-            "-vvvv",
+            "-vvv",
             "dataset",
             "build",
             "--name",
@@ -162,7 +162,7 @@ class Dataset(BaseArtifact):
         force: bool = False,
         mode: DatasetChangeMode = DatasetChangeMode.PATCH,
     ) -> None:
-        _args = [CLI, "-vvvv", self.name, "copy", src_uri, target_project]
+        _args = [CLI, "-vvv", self.name, "copy", src_uri, target_project]
         if force:
             _args.append("--force")
         if mode == DatasetChangeMode.PATCH:
@@ -184,7 +184,7 @@ class Runtime(BaseArtifact):
         config = RuntimeConfig.create_by_yaml(Path(yaml_path))
         cmd = [
             CLI,
-            "-vvvv",
+            "-vvv",
             "runtime",
             "build",
             "--yaml",
@@ -206,7 +206,7 @@ class Runtime(BaseArtifact):
         force: bool,
         mode: DatasetChangeMode = DatasetChangeMode.PATCH,
     ) -> None:
-        _args = [CLI, "-vvvv", self.name, "copy", src_uri, target_project]
+        _args = [CLI, "-vvv", self.name, "copy", src_uri, target_project]
         if force:
             _args.append("--force")
         _ret_code, _res = invoke(_args)


### PR DESCRIPTION
## Description
- only show trackback locals in the trace mode
- provide `ENV_LOG_VERBOSE_COUNT` env to config log verbosity
- update the default level for tests: `trace` -> `debug`

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
