### PR TITLE
fix(console): load widget init missing

### DIFF
--- a/console/packages/starwhale-core/src/widget/WidgetFactory.tsx
+++ b/console/packages/starwhale-core/src/widget/WidgetFactory.tsx
@@ -1,6 +1,7 @@
 import { WidgetGroupType, WidgetType } from '../types'
 import WidgetPlugin from './WidgetPlugin'
 import { generateId } from '../utils/generators'
+import modules from './WidgetModules'
 
 export type DerivedPropertiesMap = Record<string, string>
 
@@ -16,6 +17,10 @@ class WidgetFactory {
         }
     }
 
+    static hasWidget(widgetType: WidgetType) {
+        return this.widgetMap.has(widgetType)
+    }
+
     static getWidgetTypes(): WidgetType[] {
         return Array.from(this.widgetMap.keys())
     }
@@ -27,12 +32,12 @@ class WidgetFactory {
     }
 
     static getWidget(widgetType: WidgetType) {
-        if (!this.widgetTypes[widgetType]) return null
+        if (!this.widgetTypes[widgetType]) return undefined
         return this.widgetMap.get(widgetType)
     }
 
     static newWidget(widgetType: WidgetType) {
-        if (!this.widgetMap.has(widgetType)) return null
+        if (!this.widgetMap.has(widgetType)) return undefined
         const widget = this.widgetMap.get(widgetType) as WidgetPlugin
         const id = generateId(widget.defaults?.group ?? '')
 
@@ -46,5 +51,11 @@ class WidgetFactory {
         }
     }
 }
+
+modules.forEach((w: WidgetPlugin<any>) => {
+    if (!w.getType()) return
+    if (WidgetFactory.hasWidget(w.getType())) return
+    WidgetFactory.register(w.getType(), w)
+})
 
 export default WidgetFactory

--- a/console/packages/starwhale-core/src/widget/WidgetModules.tsx
+++ b/console/packages/starwhale-core/src/widget/WidgetModules.tsx
@@ -1,0 +1,7 @@
+import DNDListWidget from '@starwhale/widgets/DNDListWidget'
+import SectionWidget from '@starwhale/widgets/SectionWidget'
+import PanelTableWidget from '@starwhale/widgets/PanelTableWidget'
+import PanelRocAucWidget from '@starwhale/widgets/PanelRocAucWidget'
+import PanelHeatmapWidget from '@starwhale/widgets/PanelConfusionMatrixWidget'
+
+export default [DNDListWidget, SectionWidget, PanelTableWidget, PanelRocAucWidget, PanelHeatmapWidget]

--- a/console/packages/starwhale-core/src/widget/hooks/useWidget.tsx
+++ b/console/packages/starwhale-core/src/widget/hooks/useWidget.tsx
@@ -1,25 +1,12 @@
 import { useEffect, useState } from 'react'
-import DNDListWidget from '@starwhale/widgets/DNDListWidget'
-import SectionWidget from '@starwhale/widgets/SectionWidget'
-import PanelTableWidget from '@starwhale/widgets/PanelTableWidget'
-import PanelRocAucWidget from '@starwhale/widgets/PanelRocAucWidget'
-import PanelHeatmapWidget from '@starwhale/widgets/PanelConfusionMatrixWidget'
 import WidgetFactory from '../WidgetFactory'
 import WidgetPlugin from '../WidgetPlugin'
 
-const modules = [DNDListWidget, SectionWidget, PanelTableWidget, PanelRocAucWidget, PanelHeatmapWidget]
-
 export function useWidget(widgetType: string) {
-    const [widget, setWidget] = useState<WidgetPlugin | undefined>(WidgetFactory.widgetMap.get(widgetType))
+    const [widget, setWidget] = useState<WidgetPlugin | undefined>(WidgetFactory.getWidget(widgetType))
 
     useEffect(() => {
-        if (!WidgetFactory.widgetMap.has(widgetType)) {
-            modules.forEach((w: WidgetPlugin<any>) => {
-                if (w.getType() === widgetType) WidgetFactory.register(w.getType(), w)
-            })
-        }
-
-        const temp = WidgetFactory.widgetMap.get(widgetType)
+        const temp = WidgetFactory.getWidget(widgetType)
 
         if (temp && temp !== widget) {
             setWidget(temp)

--- a/console/src/domain/model/services/modelVersion.ts
+++ b/console/src/domain/model/services/modelVersion.ts
@@ -121,7 +121,7 @@ export async function fetchModelVersionPanelSetting(
     token: string
 ) {
     return fetchModelVersionFile(projectName, modelName, modelVersionId, token, 'eval_panel_layout.json').then((raw) =>
-        JSON.parse(raw)
+        raw ? JSON.parse(raw) : undefined
     )
 }
 


### PR DESCRIPTION
## Description

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
