### PR TITLE
fix(controller): fix running tasks under failed job is not cancled

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/status/JobUpdateHelper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/status/JobUpdateHelper.java
@@ -86,7 +86,7 @@ public class JobUpdateHelper {
                     TaskStatusChangeWatcher.SKIPPED_WATCHERS.set(Set.of(TaskWatcherForJobStatus.class));
                     job.getSteps().stream().map(Step::getTasks).flatMap(Collection::stream)
                             .filter(task -> task.getStatus() == TaskStatus.RUNNING)
-                            .forEach(task -> task.updateStatus(TaskStatus.CANCELED));
+                            .forEach(task -> task.updateStatus(TaskStatus.CANCELLING));
                     TaskStatusChangeWatcher.SKIPPED_WATCHERS.remove();
                 });
             }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobUpdateHelperTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobUpdateHelperTest.java
@@ -98,7 +98,7 @@ public class JobUpdateHelperTest {
         verify(jobDao).updateJobFinishedTime(eq(mockJob.getId()),
                 argThat(d -> d.getTime() > 0), argThat(d -> d > 0));
         Thread.sleep(100); // wait for async status update
-        Assertions.assertEquals(TaskStatus.CANCELED, luckTask.getStatus());
+        Assertions.assertEquals(TaskStatus.CANCELLING, luckTask.getStatus());
 
     }
 


### PR DESCRIPTION
## Description
TaskWatcherForSchedule only listen CANCELLING status now, so it should be changed to CANCELLING

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
