### PR TITLE
fix(image): use the same logic with client when resolve image's repo

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
@@ -29,8 +29,8 @@ public class DockerImage {
     String image;
 
     /**
-     * @param registry such as ghcr.io
-     * @param image such as starwhale-ai/starwhale:0.3.5-rc123.dev12432344
+     * @param registry such as ghcr.io/starwhale-ai
+     * @param image such as starwhale:0.3.5-rc123.dev12432344
      */
     public DockerImage(String registry, String image) {
         this.registry = registry;
@@ -40,7 +40,7 @@ public class DockerImage {
     /**
      * please refer to https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go
      */
-    private static final Pattern PATTERN_IMAGE_FULL = Pattern.compile("^(.+?)\\/(.+)$");
+    private static final Pattern PATTERN_IMAGE_FULL = Pattern.compile("^(.*)/(.*)$");
 
     /**
      * @param imageNameFull such as ghcr.io/starwhale-ai/starwhale:0.3.5-rc123.dev12432344
@@ -51,22 +51,9 @@ public class DockerImage {
             this.registry = "";
             this.image = imageNameFull;
         } else {
-            String candidateRegistry = matcher.group(1);
-            if (isDomain(candidateRegistry)) {
-                this.registry = candidateRegistry;
-                image = matcher.group(2);
-            } else {
-                this.registry = "";
-                this.image = imageNameFull;
-            }
-
+            this.registry = matcher.group(1);
+            this.image = matcher.group(2);
         }
-    }
-
-    private static final Pattern PATTERN_DOMAIN_LOCAL_HOST = Pattern.compile("localhost(:\\d+)?");
-
-    private static boolean isDomain(String candidate) {
-        return candidate.contains(".") || PATTERN_DOMAIN_LOCAL_HOST.matcher(candidate).matches();
     }
 
     private static final String SLASH = "/";

--- a/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/DockerImage.java
@@ -25,15 +25,15 @@ import org.springframework.util.StringUtils;
 @Getter
 @EqualsAndHashCode
 public class DockerImage {
-    String registry;
+    String repo;
     String image;
 
     /**
-     * @param registry such as ghcr.io/starwhale-ai
+     * @param repo such as ghcr.io/starwhale-ai
      * @param image such as starwhale:0.3.5-rc123.dev12432344
      */
-    public DockerImage(String registry, String image) {
-        this.registry = registry;
+    public DockerImage(String repo, String image) {
+        this.repo = repo;
         this.image = image;
     }
 
@@ -48,25 +48,25 @@ public class DockerImage {
     public DockerImage(String imageNameFull) {
         Matcher matcher = PATTERN_IMAGE_FULL.matcher(imageNameFull);
         if (!matcher.matches()) {
-            this.registry = "";
+            this.repo = "";
             this.image = imageNameFull;
         } else {
-            this.registry = matcher.group(1);
+            this.repo = matcher.group(1);
             this.image = matcher.group(2);
         }
     }
 
     private static final String SLASH = "/";
 
-    public String resolve(String newRegistry) {
-        if (!StringUtils.hasText(newRegistry)) {
-            newRegistry = this.registry;
+    public String resolve(String newRepo) {
+        if (!StringUtils.hasText(newRepo)) {
+            newRepo = this.repo;
         }
-        return StringUtils.trimTrailingCharacter(newRegistry, '/') + SLASH + image;
+        return StringUtils.trimTrailingCharacter(newRepo, '/') + SLASH + image;
     }
 
     public String toString() {
-        return StringUtils.trimTrailingCharacter(registry, '/') + SLASH + image;
+        return StringUtils.trimTrailingCharacter(repo, '/') + SLASH + image;
     }
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -641,8 +641,7 @@ public class RuntimeService {
             var baseImage = runtimeVersion.getImage(dockerSetting.getRegistryForPull());
             Map<String, ContainerOverwriteSpec> ret = new HashMap<>();
             List<V1EnvVar> envVars = new ArrayList<>(List.of(
-                    new V1EnvVar().name("SW_IMAGE_REPO").value(
-                            new DockerImage(baseImage).getRegistry()),
+                    new V1EnvVar().name("SW_IMAGE_REPO").value(new DockerImage(baseImage).getRepo()),
                     new V1EnvVar().name("SW_INSTANCE_URI").value(instanceUri),
                     new V1EnvVar().name("SW_PROJECT").value(project.getName()),
                     new V1EnvVar().name("SW_RUNTIME_VERSION").value(

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/DockerImageTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/DockerImageTest.java
@@ -25,19 +25,19 @@ public class DockerImageTest {
     @Test
     public void testGhcrConstructor() {
         Assertions.assertEquals(
-                new DockerImage("ghcr.io//", "star-whale/starwhale:latest").toString(),
+                new DockerImage("ghcr.io/star-whale//", "starwhale:latest").toString(),
                 "ghcr.io/star-whale/starwhale:latest");
 
         DockerImage dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-                new DockerImage("ghcr.io", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                new DockerImage("ghcr.io/star-whale", "starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
                 dockerImage);
 
         dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:latest");
-        Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale:latest"), dockerImage);
+        Assertions.assertEquals(new DockerImage("ghcr.io/star-whale", "starwhale:latest"), dockerImage);
 
         dockerImage = new DockerImage("ghcr.io/star-whale/starwhale");
-        Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale"), dockerImage);
+        Assertions.assertEquals(new DockerImage("ghcr.io/star-whale", "starwhale"), dockerImage);
     }
 
     @Test
@@ -45,14 +45,14 @@ public class DockerImageTest {
         DockerImage dockerImage = new DockerImage(
                 "localhost:8083/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-                new DockerImage("localhost:8083", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                new DockerImage("localhost:8083/star-whale", "starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
                 dockerImage);
 
         dockerImage = new DockerImage("localhost:8083/star-whale/starwhale:latest");
-        Assertions.assertEquals(new DockerImage("localhost:8083", "star-whale/starwhale:latest"), dockerImage);
+        Assertions.assertEquals(new DockerImage("localhost:8083/star-whale", "starwhale:latest"), dockerImage);
 
         dockerImage = new DockerImage("localhost:8083/star-whale/starwhale");
-        Assertions.assertEquals(new DockerImage("localhost:8083", "star-whale/starwhale"), dockerImage);
+        Assertions.assertEquals(new DockerImage("localhost:8083/star-whale", "starwhale"), dockerImage);
     }
 
     @Test
@@ -60,14 +60,14 @@ public class DockerImageTest {
         DockerImage dockerImage = new DockerImage(
                 "localhost/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-                new DockerImage("localhost", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                new DockerImage("localhost/star-whale", "starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
                 dockerImage);
 
         dockerImage = new DockerImage("localhost/star-whale/starwhale:latest");
-        Assertions.assertEquals(new DockerImage("localhost", "star-whale/starwhale:latest"), dockerImage);
+        Assertions.assertEquals(new DockerImage("localhost/star-whale", "starwhale:latest"), dockerImage);
 
         dockerImage = new DockerImage("localhost/star-whale/starwhale");
-        Assertions.assertEquals(new DockerImage("localhost", "star-whale/starwhale"), dockerImage);
+        Assertions.assertEquals(new DockerImage("localhost/star-whale", "starwhale"), dockerImage);
     }
 
     @Test
@@ -75,14 +75,14 @@ public class DockerImageTest {
         DockerImage dockerImage = new DockerImage(
                 "docker.io/starwhaleai/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-                new DockerImage("docker.io", "starwhaleai/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                new DockerImage("docker.io/starwhaleai", "starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
                 dockerImage);
 
         dockerImage = new DockerImage("ghcr.io/star-whale/starwhale:latest");
-        Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale:latest"), dockerImage);
+        Assertions.assertEquals(new DockerImage("ghcr.io/star-whale", "starwhale:latest"), dockerImage);
 
         dockerImage = new DockerImage("ghcr.io/star-whale/starwhale");
-        Assertions.assertEquals(new DockerImage("ghcr.io", "star-whale/starwhale"), dockerImage);
+        Assertions.assertEquals(new DockerImage("ghcr.io/star-whale", "starwhale"), dockerImage);
 
     }
 
@@ -90,21 +90,21 @@ public class DockerImageTest {
     public void testHostPortConstructor() {
         DockerImage dockerImage = new DockerImage(
                 "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
-        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000",
-                "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
+        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale",
+                    "starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
 
         dockerImage = new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:latest");
         Assertions.assertEquals(
-                new DockerImage("homepage-ca.intra.starwhale.ai:5000", "star-whale/starwhale:latest"), dockerImage);
+                new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale", "starwhale:latest"), dockerImage);
 
         dockerImage = new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale");
         Assertions.assertEquals(
-                new DockerImage("homepage-ca.intra.starwhale.ai:5000", "star-whale/starwhale"), dockerImage);
+                new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale", "starwhale"), dockerImage);
 
         dockerImage = new DockerImage(
                 "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
-        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000",
-                "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
+        Assertions.assertEquals(new DockerImage("homepage-ca.intra.starwhale.ai:5000/star-whale",
+                "starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
     }
 
     @Test
@@ -112,44 +112,45 @@ public class DockerImageTest {
         DockerImage dockerImage = new DockerImage(
                 "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-                new DockerImage("131.0.1.8:5000", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
+                new DockerImage("131.0.1.8:5000/star-whale", "starwhale:0.3.0-rc.6-nightly-20220920-016d5507"),
                 dockerImage);
 
         dockerImage = new DockerImage("131.0.1.8:5000/star-whale/starwhale:latest");
-        Assertions.assertEquals(new DockerImage("131.0.1.8:5000", "star-whale/starwhale:latest"), dockerImage);
+        Assertions.assertEquals(new DockerImage("131.0.1.8:5000/star-whale", "starwhale:latest"), dockerImage);
 
         dockerImage = new DockerImage("131.0.1.8:5000/star-whale/starwhale");
-        Assertions.assertEquals(new DockerImage("131.0.1.8:5000", "star-whale/starwhale"), dockerImage);
+        Assertions.assertEquals(new DockerImage("131.0.1.8:5000/star-whale", "starwhale"), dockerImage);
     }
 
     @Test
     public void testOnlyNameConstructor() {
         var dockerImage = new DockerImage("star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507");
         Assertions.assertEquals(
-                new DockerImage("", "star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
+                new DockerImage("star-whale", "starwhale:0.3.0-rc.6-nightly-20220920-016d5507"), dockerImage);
 
         dockerImage = new DockerImage("star-whale/starwhale:latest");
-        Assertions.assertEquals(new DockerImage("", "star-whale/starwhale:latest"), dockerImage);
+        Assertions.assertEquals(new DockerImage("star-whale", "starwhale:latest"), dockerImage);
 
         dockerImage = new DockerImage("star-whale/starwhale");
-        Assertions.assertEquals(new DockerImage("", "star-whale/starwhale"), dockerImage);
+        Assertions.assertEquals(new DockerImage("star-whale", "starwhale"), dockerImage);
 
     }
 
     @Test
     public void testResolve() {
         Map<String, String> images = Map.of(
-                "docker.io", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-                "docker.io/", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-                "ghcr.io", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-                "ghcr.io/", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-                "131.0.1.8:5000", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-                "131.0.1.8:5000/", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-                "homepage-ca.intra.starwhale.ai:5000",
+                "docker.io/star-whale", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "docker.io/star-whale/", "docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "ghcr.io/star-whale", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "ghcr.io/star-whale/", "ghcr.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "131.0.1.8:5000/star-whale", "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "131.0.1.8:5000/star-whale/",
+                "131.0.1.8:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
+                "homepage-ca.intra.starwhale.ai:5000/star-whale",
                 "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-                "homepage-ca.intra.starwhale.ai:5000/",
+                "homepage-ca.intra.starwhale.ai:5000/star-whale/",
                 "homepage-ca.intra.starwhale.ai:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507",
-                "localhost:5000", "localhost:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"
+                "localhost:5000/star-whale", "localhost:5000/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507"
         );
         images.forEach((k, v) -> Assertions.assertEquals(v,
             new DockerImage("docker.io/star-whale/starwhale:0.3.0-rc.6-nightly-20220920-016d5507").resolve(k)));

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConverterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeVersionConverterTest.java
@@ -75,14 +75,14 @@ public class RuntimeVersionConverterTest {
                 .build();
         // case 1: use builtin
         var dockerImage = new DockerImage(runtime.getImage("self.registry:5000"));
-        assertThat("registry", dockerImage.getRegistry(), is("self.registry:5000"));
+        assertThat("registry", dockerImage.getRepo(), is("self.registry:5000"));
         assertThat("image", dockerImage.toString(), is("self.registry:5000/starwhale:0.4.7.builtin"));
 
         // case 2: use custom
         runtime.setVersionMeta(RuntimeTestConstants.MANIFEST_WITHOUT_BUILTIN_IMAGE);
 
         dockerImage = new DockerImage(runtime.getImage("self.registry:5000"));
-        assertThat("registry", dockerImage.getRegistry(), is(RuntimeTestConstants.CUSTOM_REPO));
+        assertThat("registry", dockerImage.getRepo(), is(RuntimeTestConstants.CUSTOM_REPO));
         assertThat("image", dockerImage.toString(), is(RuntimeTestConstants.CUSTOM_IMAGE));
     }
 


### PR DESCRIPTION
## Description

Replace the built-in image with the repoName(registry/org)

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
