### PR TITLE
feat(dataset): support dataset build from huggingface dataset

### DIFF
--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -25,6 +25,8 @@ torch>=2.0.1; python_version >= '3.11'
 torch; python_version < '3.11'
 tensorflow>=2.12.0; python_version >= '3.11'
 tensorflow; python_version < '3.11'
+datasets
+librosa  # for datasets Audio
 # for starwhale[image] test
 pillow
 # for starwhale[audio] test

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -96,6 +96,19 @@ class Dataset(BaseBundle, metaclass=ABCMeta):
     ) -> None:
         raise NotImplementedError
 
+    def build_from_huggingface(
+        self,
+        repo: str,
+        subset: str | None = None,
+        split: str | None = None,
+        revision: str = "main",
+        alignment_size: int | str = D_ALIGNMENT_SIZE,
+        volume_size: int | str = D_FILE_VOLUME_SIZE,
+        mode: DatasetChangeMode = DatasetChangeMode.PATCH,
+        cache: bool = True,
+    ) -> None:
+        raise NotImplementedError
+
     @classmethod
     def get_dataset(cls, uri: Resource) -> Dataset:
         _cls = cls._get_cls(uri)
@@ -247,6 +260,35 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
             )
 
         return rs, {}
+
+    def build_from_huggingface(
+        self,
+        repo: str,
+        subset: str | None = None,
+        split: str | None = None,
+        revision: str = "main",
+        alignment_size: int | str = D_ALIGNMENT_SIZE,
+        volume_size: int | str = D_FILE_VOLUME_SIZE,
+        mode: DatasetChangeMode = DatasetChangeMode.PATCH,
+        cache: bool = True,
+    ) -> None:
+        from starwhale.api._impl.dataset.model import Dataset as SDKDataset
+
+        ds = SDKDataset.from_huggingface(
+            name=self.name,
+            repo=repo,
+            subset=subset,
+            split=split,
+            revision=revision,
+            alignment_size=alignment_size,
+            volume_size=volume_size,
+            mode=mode,
+            cache=cache,
+        )
+        console.print(
+            f":hibiscus: congratulation! dataset build from https://huggingface.co/datasets/{repo} has been built. You can run "
+            f"[red bold blink] swcli dataset info {self.name}/version/{ds.committed_version[:SHORT_VERSION_CNT]}[/]"
+        )
 
     def build_from_json_file(
         self,

--- a/client/starwhale/core/dataset/view.py
+++ b/client/starwhale/core/dataset/view.py
@@ -160,6 +160,39 @@ class DatasetTermView(BaseTermView):
 
     @classmethod
     @BaseTermView._only_standalone
+    def build_from_huggingface(
+        cls,
+        repo: str,
+        name: str,
+        project_uri: str,
+        alignment_size: int | str,
+        volume_size: int | str,
+        subset: str | None = None,
+        split: str | None = None,
+        revision: str = "main",
+        mode: DatasetChangeMode = DatasetChangeMode.PATCH,
+        cache: bool = True,
+    ) -> None:
+        dataset_uri = cls.prepare_build_bundle(
+            project=project_uri,
+            bundle_name=name,
+            typ=ResourceType.dataset,
+            auto_gen_version=False,
+        )
+        ds = Dataset.get_dataset(dataset_uri)
+        ds.build_from_huggingface(
+            repo=repo,
+            subset=subset,
+            split=split,
+            revision=revision,
+            alignment_size=alignment_size,
+            volume_size=volume_size,
+            mode=mode,
+            cache=cache,
+        )
+
+    @classmethod
+    @BaseTermView._only_standalone
     def build_from_json_file(
         cls,
         json_file_path: str,

--- a/client/starwhale/integrations/huggingface/__init__.py
+++ b/client/starwhale/integrations/huggingface/__init__.py
@@ -1,0 +1,3 @@
+from .dataset import iter_dataset
+
+__all__ = ["iter_dataset"]

--- a/client/starwhale/integrations/huggingface/dataset.py
+++ b/client/starwhale/integrations/huggingface/dataset.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import io
+import os
+import typing as t
+
+from starwhale.utils.error import NoSupportError
+
+try:
+    import datasets as hf_datasets
+except ImportError:  # pragma: no cover
+    raise ImportError("Please install huggingface/datasets with `pip install datasets`")
+
+from starwhale.utils import console
+from starwhale.core.dataset.type import Text, Audio, Image, Binary, MIMEType
+
+
+def _transform_to_starwhale(data: t.Any, feature: t.Any) -> t.Any:
+    if isinstance(feature, hf_datasets.Value):
+        if feature.dtype == "large_string":
+            return Text(content=data)
+        elif feature.dtype == "large_binary":
+            return Binary(fp=data)
+        else:
+            return data
+    elif isinstance(feature, hf_datasets.Audio):
+        if data.get("path") is not None:
+            return Audio(fp=data["path"])
+        elif data.get("array") is not None:
+            import soundfile
+
+            img_io = io.BytesIO()
+            # TODO: support format by raw array
+            soundfile.write(img_io, data["array"], data["sampling_rate"], format="wav")
+            return Audio(fp=img_io.getvalue(), mime_type=MIMEType.WAV)
+        else:
+            raise ValueError(f"Unknown audio data fields: {data}")
+    elif isinstance(feature, hf_datasets.Image):
+        from PIL import Image as PILImage
+
+        if isinstance(data, PILImage.Image):
+            img_io = io.BytesIO()
+            data.save(img_io, format=data.format or "PNG")
+            img_fp = img_io.getvalue()
+
+            try:
+                data_mimetype = data.get_format_mimetype()
+                mime_type = MIMEType(data_mimetype)
+            except (ValueError, AttributeError):
+                mime_type = MIMEType.PNG
+            return Image(
+                fp=img_fp,
+                shape=(data.height, data.width, len(data.getbands())),
+                mime_type=mime_type,
+            )
+        else:
+            raise NoSupportError(
+                f"Unknown image type: {type(data)}, current only support PIL.Image.Image"
+            )
+    elif isinstance(feature, hf_datasets.ClassLabel):
+        # TODO: graceful handle classLabel, store it into Starwhale.ClassLabel type
+        return data
+    elif isinstance(feature, list):
+        # list supports mixed type, but Starwhale only supports same type
+        return [_transform_to_starwhale(d, feature[i]) for i, d in enumerate(data)]
+    elif isinstance(feature, hf_datasets.Sequence):
+        inner_feature = feature.feature
+        if isinstance(inner_feature, dict):
+            return {
+                k: _transform_to_starwhale(v, inner_feature[k]) for k, v in data.items()
+            }
+        else:
+            # TODO: need to handle complex Sequence type
+            return [_transform_to_starwhale(d, inner_feature) for d in data]
+    elif isinstance(feature, dict):
+        return {k: _transform_to_starwhale(v, feature[k]) for k, v in data.items()}
+    else:
+        # Other unnecessary huggingface types:
+        #   - Array2D, Array3D, Array4D and Array5D: multi-dimension array
+        #   - Translation, TranslationVariableLanguages: dict and dict[str, str|list[str]] type
+        console.debug(f"skip transform feature: {feature}")
+        return data
+
+
+def _iter_dataset(ds: hf_datasets.Dataset) -> t.Iterator[t.Tuple[int, t.Dict]]:
+    for i in range(len(ds)):
+        item = {}
+        for k, v in ds[i].items():
+            feature = ds.features[k]
+            item[k] = _transform_to_starwhale(v, feature)
+            # TODO: support inner ClassLabel
+            if isinstance(feature, hf_datasets.ClassLabel):
+                item[f"{k}__classlabel__"] = feature.names[v]
+        yield i, item
+
+
+def iter_dataset(
+    repo: str,
+    subset: str | None = None,
+    split: str | None = None,
+    revision: str = "main",
+    cache: bool = True,
+) -> t.Iterator[t.Tuple[str, t.Dict]]:
+    download_mode = (
+        hf_datasets.DownloadMode.REUSE_DATASET_IF_EXISTS
+        if cache
+        else hf_datasets.DownloadMode.FORCE_REDOWNLOAD
+    )
+
+    ds = hf_datasets.load_dataset(
+        repo,
+        subset,
+        split=split,
+        revision=revision,
+        num_proc=min(8, os.cpu_count() or 8),
+        download_mode=download_mode,
+    )
+
+    if isinstance(ds, hf_datasets.DatasetDict):
+        for _split, _ds in ds.items():
+            for _key, _data in _iter_dataset(_ds):
+                yield f"{_split}/{_key}", _data
+    elif isinstance(ds, hf_datasets.Dataset):
+        for _key, _data in _iter_dataset(ds):
+            if split:
+                _s_key = f"{split}/{_key}"
+            else:
+                _s_key = str(_key)
+            yield _s_key, _data
+    else:
+        raise RuntimeError(f"Unknown dataset type: {type(ds)}")


### PR DESCRIPTION
## Description
- build mnist from huggingface repo:
  ![image](https://github.com/star-whale/starwhale/assets/590748/ee55b4e9-5a94-4e37-83c1-01ac24bdb8f5)
- other examples
  - https://cloud.starwhale.cn/projects/23/datasets/103/versions/143/files
  - squad: 
    - https://huggingface.co/datasets/squad  
    - https://cloud.starwhale.cn/projects/23/datasets/101/versions/140/files 
  - PolyAI/minds14
    - https://huggingface.co/datasets/PolyAI/minds14
    - https://cloud.starwhale.cn/projects/23/datasets/102/versions/142/files  
  - lambdalabs/pokemon-blip-captions
    - https://huggingface.co/datasets/lambdalabs/pokemon-blip-captions
    - ![image](https://github.com/star-whale/starwhale/assets/590748/f0765346-cc14-4958-a331-e59f43545f28)
    - https://cloud.starwhale.cn/projects/tianwei:llm/datasets/104/versions/144/files

## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
