### PR TITLE
chore(client): force to limit pydantic version < 2.0.0

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -42,6 +42,7 @@ install_requires = [
     "trio>=0.22.0",
     "httpx>=0.22.0",
     "urllib3<1.27",
+    "pydantic<2.0.0",  # current broker and fastapi lib code only work with pydantic < 2.0.0
 ]
 
 extras_require = {


### PR DESCRIPTION
## Description
- error:
  - https://github.com/star-whale/starwhale/actions/runs/5503317419/jobs/10028401030
  - https://github.com/star-whale/starwhale/actions/runs/5503317419/jobs/10028401966
- reason:pydantic recently was upgraded to 2.0.0, but broker and fastapi lib code only work with pydantic < 2.0.0

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
