### PR TITLE
enhance(controller): support exporting prometheus metrics

### DIFF
--- a/docker/charts/templates/controller-deployment.yaml
+++ b/docker/charts/templates/controller-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health
-              port: {{ .Values.controller.containerPort }}
+              port: {{ .Values.controller.managementPort }}
             initialDelaySeconds: 50
             periodSeconds: 10
             timeoutSeconds: 90
@@ -85,6 +85,8 @@ spec:
               value: controller
             - name: SW_CONTROLLER_PORT
               value: "{{ .Values.controller.containerPort }}"
+            - name: SW_MANAGEMENT_PORT
+              value: "{{ .Values.controller.managementPort }}"
             - name: SW_JWT_TOKEN_EXPIRE_MINUTES
               value: "{{ .Values.controller.jwt.tokenExpireMinutes }}"
             - name: SW_UPLOAD_MAX_FILE_SIZE

--- a/docker/charts/values.yaml
+++ b/docker/charts/values.yaml
@@ -82,6 +82,7 @@ controller:
     username: starwhale
     password: abcd1234
   containerPort: 8082
+  managementPort: 9082
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/server/controller/pom.xml
+++ b/server/controller/pom.xml
@@ -223,6 +223,11 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/spec/JobSpecParser.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/spec/JobSpecParser.java
@@ -38,7 +38,6 @@ public class JobSpecParser {
             return Constants.yamlMapper.readValue(yamlContent, new TypeReference<>() {
             });
         } catch (JsonProcessingException e) {
-            log.info("yaml in map format, {}", yamlContent);
             return parseAllStepFromYaml(yamlContent);
         }
     }

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -150,3 +150,8 @@ management:
     web:
       exposure:
         include: ${SW_BIZ_MANAGMENT_EXPOSURE_ENDPOINTS:httptrace,loggers,health,info,metrics}
+  server:
+    port: ${SW_MANAGEMENT_PORT:9082}
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/server/controller/src/test/java/ai/starwhale/mlops/ObjectMockHolder.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/ObjectMockHolder.java
@@ -16,46 +16,17 @@
 
 package ai.starwhale.mlops;
 
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import ai.starwhale.mlops.domain.job.JobDao;
-import ai.starwhale.mlops.domain.job.cache.HotJobHolderImpl;
-import ai.starwhale.mlops.domain.job.status.JobStatusCalculator;
-import ai.starwhale.mlops.domain.job.status.JobStatusMachine;
-import ai.starwhale.mlops.domain.job.step.mapper.StepMapper;
-import ai.starwhale.mlops.domain.job.step.status.StepStatusMachine;
-import ai.starwhale.mlops.domain.job.step.trigger.SimpleStepTrigger;
 import ai.starwhale.mlops.domain.storage.StoragePathCoordinator;
 import ai.starwhale.mlops.domain.system.agent.AgentConverter;
 import ai.starwhale.mlops.domain.task.converter.TaskBoConverter;
-import ai.starwhale.mlops.domain.task.mapper.TaskMapper;
-import ai.starwhale.mlops.domain.task.status.TaskStatusMachine;
 import ai.starwhale.mlops.storage.StorageAccessService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.util.List;
 
 public class ObjectMockHolder {
-
-    public static TaskMapper taskMapper = mock(TaskMapper.class);
-
     public static JobDao jobDao = mock(JobDao.class);
-
-    public static StepMapper stepMapper = mock(StepMapper.class);
-
-    public static TaskStatusMachine taskStatusMachine() {
-        return new TaskStatusMachine();
-    }
-
-    public static JobStatusMachine jobStatusMachine() {
-        return new JobStatusMachine();
-    }
-
-    public static StepStatusMachine stepStatusMachine() {
-        return new StepStatusMachine();
-    }
 
     public static StoragePathCoordinator storagePathCoordinator() {
         return new StoragePathCoordinator("/test/sys/starwhale");
@@ -76,24 +47,4 @@ public class ObjectMockHolder {
     public static StorageAccessService storageAccessService() {
         return mock(StorageAccessService.class);
     }
-
-    public static SimpleStepTrigger evalPplStepTrigger() {
-        StorageAccessService storageAccessService = storageAccessService();
-        try {
-            when(storageAccessService.list(anyString())).thenReturn(List.of("a", "b", "c").stream());
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return new SimpleStepTrigger(storageAccessService);
-    }
-
-    public static HotJobHolderImpl hotJobHolder() {
-        return new HotJobHolderImpl();
-    }
-
-    public static JobStatusCalculator jobStatusCalculator() {
-        return new JobStatusCalculator();
-    }
-
-
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetUploaderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetUploaderTest.java
@@ -51,6 +51,7 @@ import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.storage.LengthAbleInputStream;
 import ai.starwhale.mlops.storage.StorageAccessService;
 import ai.starwhale.mlops.storage.StorageObjectInfo;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -91,7 +92,7 @@ public class DatasetUploaderTest {
                 Project.builder().id(1L).build());
         when(projectService.findProject(anyString())).thenReturn(Project.builder().id(1L).build());
 
-        HotJobHolder hotJobHolder = new HotJobHolderImpl();
+        HotJobHolder hotJobHolder = new HotJobHolderImpl(mock(MeterRegistry.class));
 
         DatasetDao datasetDao = mock(DatasetDao.class);
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/HotJobHolderImplTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/HotJobHolderImplTest.java
@@ -16,12 +16,15 @@
 
 package ai.starwhale.mlops.domain.job;
 
+import static org.mockito.Mockito.mock;
+
 import ai.starwhale.mlops.JobMockHolder;
 import ai.starwhale.mlops.domain.job.bo.Job;
 import ai.starwhale.mlops.domain.job.cache.HotJobHolderImpl;
 import ai.starwhale.mlops.domain.job.status.JobStatus;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -35,7 +38,7 @@ public class HotJobHolderImplTest {
 
     @Test
     public void testHotJobHolderImpl() {
-        final HotJobHolderImpl hotJobHolder = new HotJobHolderImpl();
+        final HotJobHolderImpl hotJobHolder = new HotJobHolderImpl(mock(MeterRegistry.class));
         JobMockHolder jobMockHolder = new JobMockHolder();
         Job job1 = jobMockHolder.mockJob();
         Job job2 = jobMockHolder.mockJob();

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/model/ModelServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/model/ModelServiceTest.java
@@ -87,6 +87,7 @@ import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedOutputStream;
 import de.codecentric.boot.admin.server.config.AdminServerProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -137,7 +138,7 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
         "ai.starwhale.mlops.resulting",
         "ai.starwhale.mlops.configuration.security"},
         excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = ModelServingService.class)})
-@Import({K8sJobTemplate.class, ResourceEventHolder.class})
+@Import({K8sJobTemplate.class, ResourceEventHolder.class, SimpleMeterRegistry.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ModelServiceTest extends MySqlContainerHolder {
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -46,6 +46,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <spring-boot.version>2.7.7</spring-boot.version>
         <spring-boot-admin.version>2.7.7</spring-boot-admin.version>
+        <micrometer.version>1.11.2</micrometer.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Description

- Support Prometheus metrics
- Add `job.cache.size` and `task.cache.size` metrics

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
