### PR TITLE
bug(example): fix quickstart notebook path bug

### DIFF
--- a/example/notebooks/quickstart-standalone.ipynb
+++ b/example/notebooks/quickstart-standalone.ipynb
@@ -99,6 +99,7 @@
    "source": [
     "%%bash\n",
     "\n",
+    "cd starwhale\n",
     "swcli runtime build --yaml example/runtime/pytorch/runtime.yaml"
    ]
   },
@@ -162,7 +163,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "\n",
+    "cd starwhale\n",
     "swcli -vvv model build example/mnist --runtime pytorch"
    ]
   },
@@ -227,6 +228,7 @@
    "source": [
     "%%bash\n",
     "\n",
+    "cd starwhale\n",
     "swcli dataset build --yaml example/mnist/dataset.yaml"
    ]
   },


### PR DESCRIPTION
## Description
https://colab.research.google.com/github/tianweidut/starwhale/blob/hotfix/notebook/example/notebooks/quickstart-standalone.ipynb

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
