### PR TITLE
chore(e2e): install the correct version in e2e when run job

### DIFF
--- a/docker/external/base-entrypoint.sh
+++ b/docker/external/base-entrypoint.sh
@@ -18,7 +18,7 @@ welcome() {
     echo "StarWhale Base Entrypoint"
     echo "Date: `date -u +%Y-%m-%dT%H:%M:%SZ`"
     echo "Starwhale Version: ${SW_VERSION}"
-    echo "Python Version: ${SW_RUNTIME_VERSION}"
+    echo "Python Version: ${PYTHON_VERSION}"
     echo "Runtime Restored: ${RUNTIME_RESTORED}"
     echo "Command type(Whether use custom command): ${USE_CUSTOM_CMD}"
     echo "Run: $1"

--- a/example/runtime/pytorch-e2e/requirements.txt
+++ b/example/runtime/pytorch-e2e/requirements.txt
@@ -1,4 +1,5 @@
-starwhale[serve]
+# use e2e version
+starwhale[serve]==${PYPI_RELEASE_VERSION}
 # for pfp
 pycocotools
 # for ucf101

--- a/scripts/client_test/update_controller_setting.sh
+++ b/scripts/client_test/update_controller_setting.sh
@@ -53,6 +53,17 @@ resourcePoolSetting:
     - name: "memory"
       defaults: 3145728
     - name: "nvidia.com/gpu"
+pypiSetting:
+  indexUrl: "http://$NEXUS_HOSTNAME:$PORT_NEXUS/repository/$REPO_NAME_PYPI/simple"
+  extraIndexUrl: "$SW_PYPI_EXTRA_INDEX_URL"
+  trustedHost: "$NEXUS_HOSTNAME"
+  retries: 10
+  timeout: 90
+datasetBuild:
+  resourcePool: "default"
+  image: "docker-registry.starwhale.cn/star-whale/base:latest"
+  clientVersion: "$PYPI_RELEASE_VERSION"
+  pythonVersion: "3.10"
 EOF
   )
   curl -X 'POST' \


### PR DESCRIPTION
## Description
Fix the wrong environment in the e2e workflow.
- previous
![image](https://github.com/star-whale/starwhale/assets/24869618/0ba2bc16-d78a-4add-8d7e-acc1525beefe)
![image](https://github.com/star-whale/starwhale/assets/24869618/36749663-6657-4014-b908-56698ce7c425)


- after tuned
![image](https://github.com/star-whale/starwhale/assets/24869618/0e3ad9f9-0307-40f5-8f71-b6d69b1c5d71)
![image](https://github.com/star-whale/starwhale/assets/24869618/0d23f970-ffd4-448c-a485-93e67891ef49)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
