### PR TITLE
fix(controller): oss path typo

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/filestorage/FileStorageService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/filestorage/FileStorageService.java
@@ -68,7 +68,7 @@ public class FileStorageService {
         if (!StringUtils.hasText(flag)) {
             throw new SwValidationException(SwValidationException.ValidSubject.OBJECT_STORE, "flag can't be null");
         }
-        return String.format("%s%s/%s/", dataRootPath, flag, UUID.randomUUID());
+        return standardPath(String.format("%s/%s/%s/", dataRootPath, flag, UUID.randomUUID()));
     }
 
     /**
@@ -96,7 +96,7 @@ public class FileStorageService {
         for (String file : files) {
             try {
                 var url = storageAccessService.signedPutUrl(
-                        pathPrefix + file, APPLICATION_OCTET_STREAM_VALUE, urlExpirationTimeMillis);
+                        standardPath(pathPrefix + file), APPLICATION_OCTET_STREAM_VALUE, urlExpirationTimeMillis);
                 // force to use https if server is https
                 if (isServerHttps && url.startsWith("http://")) {
                     url = url.replaceFirst("http://", "https://");
@@ -117,7 +117,7 @@ public class FileStorageService {
         }
         for (String file : files) {
             try {
-                storageAccessService.delete(pathPrefix + file);
+                storageAccessService.delete(standardPath(pathPrefix + file));
             } catch (IOException e) {
                 log.error("delete path:{} error.", pathPrefix + file, e);
                 throw new SwProcessException(SwProcessException.ErrorType.STORAGE, e.getMessage());
@@ -152,5 +152,9 @@ public class FileStorageService {
             log.error("path:{} list files error", pathPrefix, e);
             throw new SwProcessException(SwProcessException.ErrorType.STORAGE, e.getMessage());
         }
+    }
+
+    private String standardPath(String path) {
+        return path.replaceAll("//+", "/");
     }
 }

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ sw:
     expire-minutes: ${SW_JWT_TOKEN_EXPIRE_MINUTES:43200}
   dataset:
     build:
-      log-path: ${DATASET_BUILD_LOG_PREFIX:/dataset-build/logs}
+      log-path: ${DATASET_BUILD_LOG_PREFIX:dataset-build/logs}
       gc-rate: ${DATASET_BUILD_FILES_GC_RATE:0 0 0 * * ?}
     load:
       batch-size: ${DATASET_CONSUMPTION_BATCH_SIZE:50}

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/filestorage/FileStorageServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/filestorage/FileStorageServiceTest.java
@@ -72,20 +72,20 @@ public class FileStorageServiceTest {
                 fileStorageService.generateSignedPutUrls("invalidPath", Set.of("a.txt", "b.txt", "c.txt")));
 
         assertThat("signed put urls",
-                fileStorageService.generateSignedPutUrls(pathPrefix, Set.of("a.txt", "b.txt")),
+                fileStorageService.generateSignedPutUrls(pathPrefix, Set.of("a.txt", "/b.txt")),
                 is(Map.of(
                     "a.txt", "https://signedUrl",
-                    "b.txt", "https://signedUrl"
+                    "/b.txt", "https://signedUrl"
                 ))
         );
 
         // use the original schema of the storage access service
         var fssHttp = new FileStorageService(storageAccessService, rootPath, "4h", "http://localhost:8080");
         assertThat("signed put urls",
-                fssHttp.generateSignedPutUrls(pathPrefix, Set.of("a.txt", "b.txt")),
+                fssHttp.generateSignedPutUrls(pathPrefix, Set.of("a.txt", "/b.txt")),
                 is(Map.of(
                     "a.txt", "http://signedUrl",
-                    "b.txt", "https://signedUrl"
+                    "/b.txt", "https://signedUrl"
                 ))
         );
     }
@@ -111,7 +111,7 @@ public class FileStorageServiceTest {
         assertThrows(SwValidationException.class, () ->
                 fileStorageService.deleteFiles("invalidPath", Set.of()));
 
-        fileStorageService.deleteFiles(pathPrefix, Set.of("a.txt", "b.txt"));
+        fileStorageService.deleteFiles(pathPrefix, Set.of("a.txt", "/b.txt"));
         verify(storageAccessService, times(2)).delete(any());
     }
 


### PR DESCRIPTION
## Description

1. oss object can't prefix with "/"
2. fix the path contains multi "/", such as: a//b/c.log

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
