### PR TITLE
feat: add support for setting up a server instance in the manner of docker compose

### DIFF
--- a/docker/compose/Dockerfile.minikube_starter
+++ b/docker/compose/Dockerfile.minikube_starter
@@ -1,6 +1,6 @@
 FROM    ubuntu:22.04
 
-# installing docker. update your Docker Engine greater than 23.0 if you are not using Docker Desktop so that you could pass the heredoc grammar below
+# installing docker client. update your Docker Engine greater than 23.0 if you are not using Docker Desktop so that you could pass the heredoc grammar below
 RUN <<EOF
 apt-get -y update
 apt-get -y install ca-certificates curl gnupg lsb-release conntrack
@@ -9,7 +9,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
         $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 apt-get -y update
-apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+apt-get -y install docker-ce-cli
 apt-get clean all
 rm -rf /var/lib/apt/lists/* /tmp/*
 EOF

--- a/docker/compose/Dockerfile.minikube_starter
+++ b/docker/compose/Dockerfile.minikube_starter
@@ -1,0 +1,36 @@
+FROM    ubuntu:22.04
+
+# installing docker
+RUN     apt-get -y update
+RUN     apt-get -y install \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
+
+RUN     mkdir -p /etc/apt/keyrings
+RUN     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+RUN     echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+        $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN     apt-get -y update
+RUN     apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+# installing kubectl
+#RUN     apt-get install -y ca-certificates curl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+
+# installing other dependencies
+RUN     apt-get install conntrack
+
+# installing minikube
+RUN     curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+
+RUN     mkdir -p /usr/local/bin/
+RUN     install minikube-linux-amd64 /usr/local/bin/minikube
+
+CMD     minikube start --force --driver='docker' && tail -F /dev/null

--- a/docker/compose/Dockerfile.minikube_starter
+++ b/docker/compose/Dockerfile.minikube_starter
@@ -1,36 +1,28 @@
 FROM    ubuntu:22.04
 
-# installing docker
-RUN     apt-get -y update
-RUN     apt-get -y install \
-        ca-certificates \
-        curl \
-        gnupg \
-        lsb-release
-
-RUN     mkdir -p /etc/apt/keyrings
-RUN     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-
-RUN     echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+# installing docker. update your Docker Engine greater than 23.0 if you are not using Docker Desktop so that you could pass the heredoc grammar below
+RUN <<EOF
+apt-get -y update
+apt-get -y install ca-certificates curl gnupg lsb-release conntrack
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
         $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-RUN     apt-get -y update
-RUN     apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-
-# installing kubectl
-#RUN     apt-get install -y ca-certificates curl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+apt-get -y update
+apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+apt-get clean all
+rm -rf /var/lib/apt/lists/* /tmp/*
+EOF
 
 
-# installing other dependencies
-RUN     apt-get install conntrack
-
-# installing minikube
-RUN     curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-
-RUN     mkdir -p /usr/local/bin/
-RUN     install minikube-linux-amd64 /usr/local/bin/minikube
+# installing kubectl and minikube
+#RUN     apt-get install -y ca-certificates curl conntrack
+RUN <<EOF
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && rm kubectl
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+mkdir -p /usr/local/bin/
+install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
+EOF
 
 CMD     minikube start --force --driver='docker' && tail -F /dev/null

--- a/docker/compose/README.md
+++ b/docker/compose/README.md
@@ -1,5 +1,5 @@
 ---
-title: Docker Compose for Starwhale Cloud
+title: Docker Compose for Starwhale server
 ---
 
 ## Prerequisites
@@ -8,12 +8,16 @@ title: Docker Compose for Starwhale Cloud
 - [Docker Compose Plugin](https://docs.docker.com/compose/install/compose-plugin/) >= 2.3
 - x86-64 System(Linux, Windows and macOS)
 
-Docker Desktop is an easy-to-use way to run containers in your machine that includes all dependencies.
-
 ## Usage
 
+Start up the server
 ```bash
-docker compose up
+./star.sh --global-ip ${your_accessible_ip}
 ```
 
-Setup a Starwhale cloud environment in your single server. `compose.yaml` contains Starwhale base configuration. The override file `compose.override.yaml`, as its name implies, can contain configuration overrides for `server` and `agent` images. You can also override other configurations.
+Stop the server
+```bash
+./stop.sh
+```
+
+Setup a StarWhale server instance. `compose.yaml` contains Starwhale base configuration. The override file `compose.override.yaml`, as its name implies, can contain [configuration overrides](https://docs.docker.com/compose/reference/#specifying-multiple-compose-files) for `compose.yaml`.

--- a/docker/compose/compose.override.yaml
+++ b/docker/compose/compose.override.yaml
@@ -1,3 +1,5 @@
 services:
   controller:
-    image: homepage-bj.intra.starwhale.ai:5000/starwhaleai/server:0.5.6
+    image: docker-registry.starwhale.cn/starwhaleai/server:latest
+  minikube:
+    entrypoint: ["bash","-c","minikube update-context && minikube start --force --driver='docker' --image-mirror-country='cn' && tail -F /dev/null"]

--- a/docker/compose/compose.override.yaml
+++ b/docker/compose/compose.override.yaml
@@ -1,3 +1,3 @@
 services:
   controller:
-    image: ghcr.io/star-whale/server:0.2.0-beta.20
+    image: homepage-bj.intra.starwhale.ai:5000/starwhaleai/server:0.5.6

--- a/docker/compose/compose.override.yaml
+++ b/docker/compose/compose.override.yaml
@@ -2,4 +2,4 @@ services:
   controller:
     image: docker-registry.starwhale.cn/starwhaleai/server:latest
   minikube:
-    entrypoint: ["bash","-c","minikube update-context && minikube start --force --driver='docker' --image-mirror-country='cn' && tail -F /dev/null"]
+    entrypoint: ["bash","-c","minikube start --force --driver='docker' --image-mirror-country='cn' && tail -F /dev/null"]

--- a/docker/compose/compose.yaml
+++ b/docker/compose/compose.yaml
@@ -3,12 +3,13 @@ services:
     image: bitnami/mysql:8.0.29-debian-10-r2
     restart: always
     volumes:
-      - db_data:/var/lib/mysql
+      - db_data:/bitnami/mysql
     environment:
       - MYSQL_ROOT_PASSWORD=starwhale
       - MYSQL_USER=starwhale
       - MYSQL_PASSWORD=starwhale
       - MYSQL_DATABASE=starwhale
+    network_mode: "host"
 
   oss:
     image: bitnami/minio:2022.6.20-debian-11-r0
@@ -21,31 +22,57 @@ services:
       - MINIO_CONSOLE_PORT_NUMBER=9001
     volumes:
       - oss_data:/data
+    network_mode: "host"
+
+  minikube:
+    image: minikube
+    restart: always
+    privileged: true
+    healthcheck:
+      test: ["CMD","minikube", "kubectl", "--", "get", "pods", "-A"]
+    volumes:
+      - minikube_data:/root/.minikube
+      - kube_data:/root/.kube
+      - /var/run/docker.sock:/var/run/docker.sock
+    network_mode: "host"
 
   controller:
-    image: ghcr.io/star-whale/server:latest
+    image: homepage-bj.intra.starwhale.ai:5000/starwhaleai/server:latest
     restart: always
+    healthcheck:
+      test: [ "CMD","curl", "-f", "http://localhost:8082"]
+      interval: "60s"
+      timeout: "3s"
+      retries: 10
     depends_on:
       - db
       - oss
-    ports:
-      - 8082:8082
+      - minikube
+#    entrypoint: ["sh", "-c", "java $JAVA_OPTS -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=80.0 org.springframework.boot.loader.JarLauncher"]
+#    ports:
+#      - 8082:8082
     environment:
       - JAR=controller
-      - SW_HOST_IP=127.0.0.1
+      - KUBECONFIG=/root/.kube/config
+      - SW_IMAGE_BUILD_IMAGE=docker-registry.starwhale.cn/kaniko-cloud:v0.3
       - SW_JWT_TOKEN_EXPIRE_MINUTES=144000
       - SW_UPLOAD_MAX_FILE_SIZE=20480MB
-      - SW_METADATA_STORAGE_IP=db
+      - SW_METADATA_STORAGE_IP=192.168.1.20
       - SW_METADATA_STORAGE_PORT=3306
       - SW_METADATA_STORAGE_USER=starwhale
       - SW_METADATA_STORAGE_PASSWORD=starwhale
       - SW_STORAGE_BUCKET=starwhale
       - SW_STORAGE_ACCESSKEY=minioadmin
       - SW_STORAGE_SECRETKEY=minioadmin
-      - SW_STORAGE_ENDPOINT=http://oss:9000
+      - SW_STORAGE_ENDPOINT=http://192.168.1.20:9000
+      - SW_INSTANCE_URI=http://192.168.1.20:8082
+    volumes:
+      - minikube_data:/root/.minikube
+      - kube_data:/root/.kube
+    network_mode: "host"
 
 volumes:
-  db_data: {}
-  oss_data: {}
-  agent_data: {}
-  taskset_dind_data: {}
+  db_data:
+  oss_data:
+  minikube_data:
+  kube_data:

--- a/docker/compose/compose.yaml
+++ b/docker/compose/compose.yaml
@@ -25,7 +25,7 @@ services:
     network_mode: "host"
 
   minikube:
-    image: minikube
+    image: docker-registry.starwhale.cn/star-whale/minikube-starter:latest
     restart: always
     privileged: true
     healthcheck:
@@ -37,35 +37,28 @@ services:
     network_mode: "host"
 
   controller:
-    image: homepage-bj.intra.starwhale.ai:5000/starwhaleai/server:latest
+    image: docker-registry.starwhale.cn/starwhaleai/server:latest
     restart: always
-    healthcheck:
-      test: [ "CMD","curl", "-f", "http://localhost:8082"]
-      interval: "60s"
-      timeout: "3s"
-      retries: 10
     depends_on:
       - db
       - oss
       - minikube
-#    entrypoint: ["sh", "-c", "java $JAVA_OPTS -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=80.0 org.springframework.boot.loader.JarLauncher"]
-#    ports:
-#      - 8082:8082
     environment:
       - JAR=controller
       - KUBECONFIG=/root/.kube/config
       - SW_IMAGE_BUILD_IMAGE=docker-registry.starwhale.cn/kaniko-cloud:v0.3
       - SW_JWT_TOKEN_EXPIRE_MINUTES=144000
       - SW_UPLOAD_MAX_FILE_SIZE=20480MB
-      - SW_METADATA_STORAGE_IP=192.168.1.20
+      # the ${GLOBAL_IP} should be the ip of the host machine that is accessible by all swcli clients including swcli in a user shell and swcli in pods
+      - SW_METADATA_STORAGE_IP=${GLOBAL_IP}
       - SW_METADATA_STORAGE_PORT=3306
       - SW_METADATA_STORAGE_USER=starwhale
       - SW_METADATA_STORAGE_PASSWORD=starwhale
       - SW_STORAGE_BUCKET=starwhale
       - SW_STORAGE_ACCESSKEY=minioadmin
       - SW_STORAGE_SECRETKEY=minioadmin
-      - SW_STORAGE_ENDPOINT=http://192.168.1.20:9000
-      - SW_INSTANCE_URI=http://192.168.1.20:8082
+      - SW_STORAGE_ENDPOINT=http://${GLOBAL_IP}:9000
+      - SW_INSTANCE_URI=http://${GLOBAL_IP}:8082
     volumes:
       - minikube_data:/root/.minikube
       - kube_data:/root/.kube

--- a/docker/compose/start.sh
+++ b/docker/compose/start.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+--help() {
+  echo "Usage: start.sh [OPTIONS]"
+  echo "Options:"
+  echo "  --help        Show this message and exit."
+  echo "  --global-ip   use this ip as the access point of server. "
+  echo "                You don't need to set this option if you have set it before."
+  echo "                If you have a firewall configured, you'd better to ACCEPT the INPUT from the global-ip as dst ."
+}
+
+--global-ip(){
+  if test -z "$1"; then
+    echo "value is needed by this option"
+    exit 1
+  else
+    echo "GLOBAL_IP=$1" | tee .env
+    startup
+  fi
+}
+
+startup() {
+  if test -f ".env" ; then
+    docker compose up
+  else
+    echo "please use --global-ip option when you run the script for the first time"
+  fi
+}
+
+if test -z "$1"; then
+  startup
+else
+  $1 "$2"
+fi

--- a/docker/compose/stop.sh
+++ b/docker/compose/stop.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker compose down

--- a/server/controller/src/main/java/ai/starwhale/mlops/StarwhaleControllerApplication.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/StarwhaleControllerApplication.java
@@ -25,7 +25,9 @@ import de.codecentric.boot.admin.server.config.EnableAdminServer;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.event.ApplicationFailedEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationListener;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
@@ -37,6 +39,20 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class StarwhaleControllerApplication {
 
     public static void main(String[] args) {
-        new SpringApplicationBuilder(StarwhaleControllerApplication.class).run(args);
+        SpringApplicationBuilder springApplicationBuilder = new SpringApplicationBuilder(
+                StarwhaleControllerApplication.class);
+        springApplicationBuilder.application().addListeners(new FailFast());
+        springApplicationBuilder.run(args);
+    }
+
+    /**
+     * sometimes JVM won't exit even the spring context is initialized with error
+     */
+    static class FailFast implements ApplicationListener<ApplicationFailedEvent> {
+
+        @Override
+        public void onApplicationEvent(ApplicationFailedEvent event) {
+            System.exit(1);
+        }
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/k8s/K8sClient.java
@@ -84,13 +84,15 @@ public class K8sClient {
             AppsV1Api appsV1Api,
             @Value("${sw.infra.k8s.name-space}") String ns,
             SharedInformerFactory informerFactory
-    ) {
+    ) throws ApiException {
         this.client = client;
         this.coreV1Api = coreV1Api;
         this.batchV1Api = batchV1Api;
         this.appsV1Api = appsV1Api;
         this.ns = ns;
         this.informerFactory = informerFactory;
+        //detect if the k8s config is proper TODO: don't initialize this bean when k8s is not a need
+        coreV1Api.listNode(null, null, null, null, null, 1, null, null, 10, false);
     }
 
     /**

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/k8s/K8sClientTest.java
@@ -63,7 +63,7 @@ public class K8sClientTest {
     String nameSpace = "nameSpace";
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws ApiException {
         client = mock(ApiClient.class);
         coreV1Api = mock(CoreV1Api.class);
         batchV1Api = mock(BatchV1Api.class);


### PR DESCRIPTION
## Description
users could set up a server instance in the manner of docker compose

**Example**
```bash
./start.sh --global-ip 192.168.1.20
```

## Limitations

1. GPU is not supported

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
