### PR TITLE
chore(controller): refine resource info vo

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/DatasetInfoVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/DatasetInfoVo.java
@@ -38,34 +38,13 @@ public class DatasetInfoVo implements Serializable {
     @JsonProperty("name")
     private String name;
 
-    @JsonProperty("versionId")
-    private String versionId;
-
-    @JsonProperty("versionName")
-    private String versionName;
-
-    @JsonProperty("versionAlias")
-    private String versionAlias;
-
-    /**
-     * the table name for index in DataStore
-     */
-    String indexTable;
-
-    @JsonProperty("versionTag")
-    private String versionTag;
-
-    @JsonProperty("versionMeta")
-    private String versionMeta;
-
-    @JsonProperty("shared")
-    private Integer shared;
-
-    @JsonProperty("createdTime")
-    private Long createdTime;
-
     @JsonProperty("files")
     @Valid
     private List<FlattenFileVo> files;
 
+    // leave this field for backward compatibility, client uses this field
+    @JsonProperty("versionMeta")
+    private String versionMeta;
+
+    private DatasetVersionVo versionInfo;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/DatasetVersionVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/DatasetVersionVo.java
@@ -55,4 +55,9 @@ public class DatasetVersionVo implements Serializable {
 
     @JsonProperty("shared")
     private Integer shared;
+
+    /**
+     * the table name for index in DataStore
+     */
+    String indexTable;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/model/ModelInfoVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/model/ModelInfoVo.java
@@ -35,26 +35,5 @@ public class ModelInfoVo implements Serializable {
     @JsonProperty("name")
     private String name;
 
-    @JsonProperty("versionAlias")
-    private String versionAlias;
-
-    @JsonProperty("versionId")
-    private String versionId;
-
-    @JsonProperty("versionName")
-    private String versionName;
-
-    @JsonProperty("versionTag")
-    private String versionTag;
-
-    @JsonProperty("createdTime")
-    private Long createdTime;
-
-    @JsonProperty("shared")
-    private Integer shared;
-
-    public static ModelInfoVo empty() {
-        return new ModelInfoVo("", "", "", "", "", "", 0L, 0);
-    }
-
+    private ModelVersionVo versionInfo;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/runtime/RuntimeInfoVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/runtime/RuntimeInfoVo.java
@@ -38,35 +38,9 @@ public class RuntimeInfoVo implements Serializable {
     @JsonProperty("name")
     private String name;
 
-    @JsonProperty("versionId")
-    private String versionId;
-
-    @JsonProperty("versionName")
-    private String versionName;
-
-    @JsonProperty("versionAlias")
-    private String versionAlias;
-
-    @JsonProperty("versionTag")
-    private String versionTag;
-
-    @JsonProperty("versionMeta")
-    private String versionMeta;
-
-    @JsonProperty("manifest")
-    private String manifest;
-
-    @JsonProperty("shared")
-    private Integer shared;
-
-    @JsonProperty("createdTime")
-    private Long createdTime;
+    private RuntimeVersionVo versionInfo;
 
     @JsonProperty("files")
     @Valid
     private List<FlattenFileVo> files;
-
-    public static RuntimeInfoVo empty() {
-        return new RuntimeInfoVo("", "", "", "", "", "", "", "", 0, 0L, List.of());
-    }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/DatasetService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/DatasetService.java
@@ -302,17 +302,17 @@ public class DatasetService {
         try {
             String storagePath = versionEntity.getStoragePath();
             List<FlattenFileVo> collect = storageService.listStorageFile(storagePath);
+            var tags = bundleVersionTagDao.getTagsByBundleVersions(
+                    BundleAccessor.Type.DATASET, ds.getId(), List.of(versionEntity));
             return DatasetInfoVo.builder()
                     .id(idConvertor.convert(ds.getId()))
                     .name(ds.getDatasetName())
-                    .versionId(idConvertor.convert(versionEntity.getId()))
-                    .versionName(versionEntity.getVersionName())
-                    .versionAlias(versionAliasConvertor.convert(versionEntity.getVersionOrder()))
-                    .versionTag(versionEntity.getVersionTag())
                     .versionMeta(versionEntity.getVersionMeta())
-                    .createdTime(versionEntity.getCreatedTime().getTime())
-                    .indexTable(versionEntity.getIndexTable())
-                    .shared(toInt(versionEntity.getShared()))
+                    .versionInfo(versionConvertor.convert(
+                            versionEntity,
+                            versionEntity,
+                            tags.get(versionEntity.getId())
+                    ))
                     .files(collect)
                     .build();
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/converter/DatasetVersionVoConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/converter/DatasetVersionVoConverter.java
@@ -52,6 +52,7 @@ public class DatasetVersionVoConverter {
                 .meta(entity.getVersionMeta())
                 .shared(toInt(entity.getShared()))
                 .createdTime(entity.getCreatedTime().getTime())
+                .indexTable(entity.getIndexTable())
                 .build();
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelService.java
@@ -203,8 +203,8 @@ public class ModelService {
         return Model.fromEntity(entity);
     }
 
-    public ModelVersion findModelVersion(String versioUrl) {
-        ModelVersionEntity modelVersion = modelDao.getModelVersion(versioUrl);
+    public ModelVersion findModelVersion(String versionUrl) {
+        ModelVersionEntity modelVersion = modelDao.getModelVersion(versionUrl);
         return ModelVersion.fromEntity(modelVersion);
     }
 
@@ -307,15 +307,15 @@ public class ModelService {
     }
 
     private ModelInfoVo toModelInfoVo(ModelEntity model, ModelVersionEntity version) {
+        var tags = bundleVersionTagDao.getTagsByBundleVersions(
+                BundleAccessor.Type.MODEL,
+                model.getId(),
+                List.of(version)
+        );
         return ModelInfoVo.builder()
                 .id(idConvertor.convert(model.getId()))
                 .name(model.getModelName())
-                .versionId(idConvertor.convert(version.getId()))
-                .versionAlias(versionAliasConvertor.convert(version.getVersionOrder()))
-                .versionName(version.getVersionName())
-                .versionTag(version.getVersionTag())
-                .createdTime(version.getCreatedTime().getTime())
-                .shared(toInt(version.getShared()))
+                .versionInfo(versionConvertor.convert(version, version, tags.get(version.getId())))
                 .build();
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -309,7 +309,8 @@ public class RuntimeService {
         RuntimeVersionEntity versionEntity = null;
         if (!StrUtil.isEmpty(runtimeQuery.getRuntimeVersionUrl())) {
             Long versionId = bundleManager.getBundleVersionId(BundleVersionUrl
-                                                                      .create(runtimeQuery.getProjectUrl(),
+                                                                      .create(
+                                                                              runtimeQuery.getProjectUrl(),
                                                                               runtimeQuery.getRuntimeUrl(),
                                                                               runtimeQuery.getRuntimeVersionUrl()
                                                                       ));
@@ -332,17 +333,17 @@ public class RuntimeService {
         try {
             String storagePath = versionEntity.getStoragePath();
             List<FlattenFileVo> collect = storageService.listStorageFile(storagePath);
+            var tags = bundleVersionTagDao.getTagsByBundleVersions(
+                    BundleAccessor.Type.RUNTIME, rt.getId(), List.of(versionEntity));
 
             return RuntimeInfoVo.builder()
                     .id(idConvertor.convert(rt.getId()))
                     .name(rt.getRuntimeName())
-                    .versionId(idConvertor.convert(versionEntity.getId()))
-                    .versionAlias(versionAliasConvertor.convert(versionEntity.getVersionOrder()))
-                    .versionName(versionEntity.getVersionName())
-                    .versionTag(versionEntity.getVersionTag())
-                    .versionMeta(versionEntity.getVersionMeta())
-                    .shared(toInt(versionEntity.getShared()))
-                    .createdTime(versionEntity.getCreatedTime().getTime())
+                    .versionInfo(versionConvertor.convert(
+                            versionEntity,
+                            versionEntity,
+                            tags.get(versionEntity.getId())
+                    ))
                     .files(collect)
                     .build();
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetServiceTest.java
@@ -156,6 +156,7 @@ public class DatasetServiceTest {
                     return DatasetVersionVo.builder()
                             .id(String.valueOf(entity.getId()))
                             .name(entity.getName())
+                            .alias("v" + entity.getVersionOrder())
                             .build();
                 });
 
@@ -311,29 +312,26 @@ public class DatasetServiceTest {
         given(datasetVersionMapper.findByLatest(same(1L)))
                 .willReturn(DatasetVersionEntity.builder().id(1L).versionOrder(2L).shared(false).build());
 
-        var res = service.getDatasetInfo(DatasetQuery.builder()
-                                                 .projectUrl("1")
-                                                 .datasetUrl("d1")
-                                                 .datasetVersionUrl("v1")
-                                                 .build());
+        var res = service.getDatasetInfo(
+                DatasetQuery.builder()
+                        .projectUrl("1")
+                        .datasetUrl("d1")
+                        .datasetVersionUrl("v1")
+                        .build());
 
-        assertThat(res, allOf(
-                hasProperty("id", is("1")),
-                hasProperty("versionAlias", is("v2"))
-        ));
+        assertEquals("1", res.getId());
+        assertEquals("v2", res.getVersionInfo().getAlias());
 
         given(datasetVersionMapper.findByLatest(same(1L)))
                 .willReturn(DatasetVersionEntity.builder().id(1L).versionOrder(2L).shared(false).build());
 
-        res = service.getDatasetInfo(DatasetQuery.builder()
-                                             .projectUrl("1")
-                                             .datasetUrl("d1")
-                                             .build());
-
-        assertThat(res, allOf(
-                hasProperty("id", is("1")),
-                hasProperty("versionAlias", is("v2"))
-        ));
+        res = service.getDatasetInfo(
+                DatasetQuery.builder()
+                        .projectUrl("1")
+                        .datasetUrl("d1")
+                        .build());
+        assertEquals("1", res.getId());
+        assertEquals("v2", res.getVersionInfo().getAlias());
 
         assertThrows(
                 SwNotFoundException.class,
@@ -404,10 +402,9 @@ public class DatasetServiceTest {
                 .willReturn(List.of(DatasetVersionEntity.builder().versionOrder(2L).shared(false).build()));
 
         var res = service.listDs("1", "d1");
-        assertThat(res, hasItem(allOf(
-                hasProperty("id", is("1")),
-                hasProperty("versionAlias", is("v2"))
-        )));
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+        assertEquals("v2", res.get(0).getVersionInfo().getAlias());
 
         given(projectService.findProject(same("1")))
                 .willReturn(Project.builder().id(1L).build());
@@ -415,15 +412,11 @@ public class DatasetServiceTest {
                 .willReturn(List.of(DatasetEntity.builder().id(1L).build()));
 
         res = service.listDs("1", "");
-        assertThat(res, hasItem(allOf(
-                hasProperty("id", is("1")),
-                hasProperty("versionAlias", is("v2"))
-        )));
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+        assertEquals("v2", res.get(0).getVersionInfo().getAlias());
 
-        assertThrows(
-                SwNotFoundException.class,
-                () -> service.listDs("2", "d1")
-        );
+        assertThrows(SwNotFoundException.class, () -> service.listDs("2", "d1"));
     }
 
     @Test

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/model/ModelServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/model/ModelServiceTest.java
@@ -612,7 +612,8 @@ public class ModelServiceTest extends MySqlContainerHolder {
     public void testFindModel() {
         var modelInfo = modelService.getModelInfo("1", "m", "v1");
         var modelId = Long.parseLong(modelInfo.getId());
-        var versionId = Long.parseLong(modelInfo.getVersionId());
+        var versionInfo = modelInfo.getVersionInfo();
+        var versionId = Long.parseLong(versionInfo.getId());
         var res = modelService.findModel(modelId);
         assertThat(res, allOf(
                 notNullValue(),
@@ -620,7 +621,7 @@ public class ModelServiceTest extends MySqlContainerHolder {
                 hasProperty("name", is("m"))
         ));
 
-        assertThat(modelService.findModelVersion(versionId), allOf(
+        assertThat(modelService.findModelVersion(versionInfo.getId()), allOf(
                 notNullValue(),
                 hasProperty("id", is(versionId)),
                 hasProperty("modelId", is(modelId)),
@@ -670,17 +671,12 @@ public class ModelServiceTest extends MySqlContainerHolder {
     @Test
     public void testListModelInfo() {
         var res = modelService.listModelInfo("1", "m1");
-        assertThat(res, hasItem(allOf(
-                hasProperty("name", is("m1")),
-                hasProperty("versionAlias", is("v1")))));
+        assertEquals(1, res.size());
+        assertEquals("m1", res.get(0).getName());
+        assertEquals("v1", res.get(0).getVersionInfo().getAlias());
 
         res = modelService.listModelInfo("1", "");
-        assertThat(res, allOf(
-                iterableWithSize(5),
-                hasItem(allOf(hasProperty("name", is("m")),
-                        hasProperty("versionAlias", is("v1")))),
-                hasItem(allOf(hasProperty("name", is("m1")),
-                        hasProperty("versionAlias", is("v1"))))));
+        assertEquals(5, res.size());
 
         assertThrows(SwNotFoundException.class,
                 () -> modelService.listModelInfo("1", "m2"));
@@ -699,18 +695,16 @@ public class ModelServiceTest extends MySqlContainerHolder {
                 .modelVersionUrl("v1")
                 .build());
 
-        assertThat(res, allOf(
-                hasProperty("name", is("m")),
-                hasProperty("versionAlias", is("v1"))));
+        assertEquals("m", res.getName());
+        assertEquals("v1", res.getVersionInfo().getAlias());
 
         res = modelService.getModelInfo(ModelQuery.builder()
                 .projectUrl("1")
                 .modelUrl("m1")
                 .build());
 
-        assertThat(res, allOf(
-                hasProperty("name", is("m1")),
-                hasProperty("versionAlias", is("v1"))));
+        assertEquals("m1", res.getName());
+        assertEquals("v1", res.getVersionInfo().getAlias());
     }
 
     @Test

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/runtime/RuntimeServiceTest.java
@@ -158,6 +158,7 @@ public class RuntimeServiceTest {
                     RuntimeVersionEntity entity = invocation.getArgument(0);
                     return RuntimeVersionVo.builder()
                             .id(String.valueOf(entity.getId()))
+                            .alias("v" + entity.getVersionOrder())
                             .name(entity.getName())
                             .build();
                 });
@@ -378,10 +379,9 @@ public class RuntimeServiceTest {
                 .willReturn(List.of(RuntimeVersionEntity.builder().versionOrder(2L).shared(false).build()));
 
         var res = service.listRuntimeInfo("1", "r1");
-        assertThat(res, hasItem(allOf(
-                hasProperty("id", is("1")),
-                hasProperty("versionAlias", is("v2"))
-        )));
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+        assertEquals("v2", res.get(0).getVersionInfo().getAlias());
 
         given(projectService.getProjectId(same("1")))
                 .willReturn(1L);
@@ -389,10 +389,9 @@ public class RuntimeServiceTest {
                 .willReturn(List.of(RuntimeEntity.builder().id(1L).build()));
 
         res = service.listRuntimeInfo("1", "");
-        assertThat(res, hasItem(allOf(
-                hasProperty("id", is("1")),
-                hasProperty("versionAlias", is("v2"))
-        )));
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+        assertEquals("v2", res.get(0).getVersionInfo().getAlias());
 
         assertThrows(SwNotFoundException.class,
                 () -> service.listRuntimeInfo("2", "r1"));
@@ -421,10 +420,8 @@ public class RuntimeServiceTest {
                 .runtimeVersionUrl("v1")
                 .build());
 
-        assertThat(res, allOf(
-                hasProperty("id", is("1")),
-                hasProperty("versionAlias", is("v2"))
-        ));
+        assertEquals("1", res.getId());
+        assertEquals("v2", res.getVersionInfo().getAlias());
 
         given(runtimeVersionMapper.findByLatest(same(1L)))
                 .willReturn(RuntimeVersionEntity.builder().id(1L).versionOrder(2L).shared(false).build());
@@ -434,10 +431,8 @@ public class RuntimeServiceTest {
                 .runtimeUrl("r1")
                 .build());
 
-        assertThat(res, allOf(
-                hasProperty("id", is("1")),
-                hasProperty("versionAlias", is("v2"))
-        ));
+        assertEquals("1", res.getId());
+        assertEquals("v2", res.getVersionInfo().getAlias());
 
         assertThrows(BundleException.class,
                 () -> service.getRuntimeInfo(RuntimeQuery.builder().projectUrl("1").runtimeUrl("2").build()));


### PR DESCRIPTION
## Description

Deleted the tiled version field in the structure and use the `ResourceVesionVo` instead
And then we can get the alias, latest, tags

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
