### PR TITLE
enhance(client): enhance dataset build from huggingface for subsets

### DIFF
--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -1188,7 +1188,7 @@ class Dataset:
         cls,
         name: str,
         repo: str,
-        subset: str | None = None,
+        subsets: t.List[str] | None = None,
         split: str | None = None,
         revision: str = "main",
         alignment_size: int | str = D_ALIGNMENT_SIZE,
@@ -1196,13 +1196,14 @@ class Dataset:
         mode: DatasetChangeMode | str = DatasetChangeMode.PATCH,
         cache: bool = True,
         tags: t.List[str] | None = None,
+        add_info: bool = True,
     ) -> Dataset:
         """Create a new dataset from huggingface datasets.
 
         Arguments:
             name: (str, required) The dataset name you would like to use.
             repo: (str, required) The huggingface datasets repo name.
-            subset: (str, optional) The subset name. If the huggingface dataset has multiple subsets, you must specify the subset name.
+            subsets: (list(str), optional) The list of subset names. If the subset names are not specified, the all subsets dataset will be built.
             split: (str, optional) The split name. If the split name is not specified, the all splits dataset will be built.
             revision: (str, optional) The huggingface datasets revision. The default value is `main`. The option value accepts tag name, or branch name, or commit hash.
             alignment_size: (int|str, optional) The blob alignment size. The default value is 128.
@@ -1211,6 +1212,10 @@ class Dataset:
             mode: (str|DatasetChangeMode, optional) The dataset change mode. The default value is `patch`. Mode choices are `patch` and `overwrite`.
             cache: (bool, optional) Whether to use huggingface dataset cache(download + local hf dataset). The default value is True.
             tags: (list(str), optional) The tags for the dataset version.
+            add_info: (bool, optional) Whether to add huggingface dataset info to the dataset rows,
+              currently support to add subset and split into the dataset rows.
+              subset uses _hf_subset field name, split uses _hf_split field name.
+              The default value is True.
 
         Returns:
                 A Dataset Object
@@ -1224,21 +1229,21 @@ class Dataset:
 
         ```python
         from starwhale import Dataset
-        myds = Dataset.from_huggingface("mmlu", "cais/mmlu", subset="anatomy", split="auxiliary_train", revision="7456cfb")
+        myds = Dataset.from_huggingface("mmlu", "cais/mmlu", subsets=["anatomy"], split="auxiliary_train", revision="7456cfb")
         ```
         """
         from starwhale.integrations.huggingface import iter_dataset
 
         StandaloneTag.check_tags_validation(tags)
 
-        # TODO: support auto build all subset datasets
         # TODO: support huggingface dataset info
         data_items = iter_dataset(
             repo=repo,
-            subset=subset,
+            subsets=subsets,
             split=split,
             revision=revision,
             cache=cache,
+            add_info=add_info,
         )
 
         with cls.dataset(name) as ds:

--- a/client/starwhale/core/dataset/model.py
+++ b/client/starwhale/core/dataset/model.py
@@ -101,7 +101,7 @@ class Dataset(BaseBundle, metaclass=ABCMeta):
     def build_from_huggingface(
         self,
         repo: str,
-        subset: str | None = None,
+        subsets: t.List[str] | None = None,
         split: str | None = None,
         revision: str = "main",
         alignment_size: int | str = D_ALIGNMENT_SIZE,
@@ -109,6 +109,7 @@ class Dataset(BaseBundle, metaclass=ABCMeta):
         mode: DatasetChangeMode = DatasetChangeMode.PATCH,
         cache: bool = True,
         tags: t.List[str] | None = None,
+        add_info: bool = True,
     ) -> None:
         raise NotImplementedError
 
@@ -271,7 +272,7 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
     def build_from_huggingface(
         self,
         repo: str,
-        subset: str | None = None,
+        subsets: t.List[str] | None = None,
         split: str | None = None,
         revision: str = "main",
         alignment_size: int | str = D_ALIGNMENT_SIZE,
@@ -279,13 +280,14 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
         mode: DatasetChangeMode = DatasetChangeMode.PATCH,
         cache: bool = True,
         tags: t.List[str] | None = None,
+        add_info: bool = True,
     ) -> None:
         from starwhale.api._impl.dataset.model import Dataset as SDKDataset
 
         ds = SDKDataset.from_huggingface(
             name=self.name,
             repo=repo,
-            subset=subset,
+            subsets=subsets,
             split=split,
             revision=revision,
             alignment_size=alignment_size,
@@ -293,6 +295,7 @@ class StandaloneDataset(Dataset, LocalStorageBundleMixin):
             mode=mode,
             cache=cache,
             tags=tags,
+            add_info=add_info,
         )
         console.print(
             f":hibiscus: congratulation! dataset build from https://huggingface.co/datasets/{repo} has been built. You can run "

--- a/client/starwhale/core/dataset/view.py
+++ b/client/starwhale/core/dataset/view.py
@@ -167,12 +167,13 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         project_uri: str,
         alignment_size: int | str,
         volume_size: int | str,
-        subset: str | None = None,
+        subsets: t.List[str] | None = None,
         split: str | None = None,
         revision: str = "main",
         mode: DatasetChangeMode = DatasetChangeMode.PATCH,
         cache: bool = True,
         tags: t.List[str] | None = None,
+        add_info: bool = True,
     ) -> None:
         dataset_uri = cls.prepare_build_bundle(
             project=project_uri,
@@ -183,7 +184,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         ds = Dataset.get_dataset(dataset_uri)
         ds.build_from_huggingface(
             repo=repo,
-            subset=subset,
+            subsets=subsets,
             split=split,
             revision=revision,
             alignment_size=alignment_size,
@@ -191,6 +192,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
             mode=mode,
             cache=cache,
             tags=tags,
+            add_info=add_info,
         )
 
     @classmethod

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -189,7 +189,7 @@ class StandaloneDatasetTestCase(TestCase):
         assert call_args
         assert call_args[0][0] == "mnist"
         assert call_args[1]["name"] == "huggingface-test"
-        assert call_args[1]["subset"] is None
+        assert len(call_args[1]["subsets"]) == 0
         assert not call_args[1]["cache"]
 
         DatasetTermView.build_from_huggingface(
@@ -198,7 +198,7 @@ class StandaloneDatasetTestCase(TestCase):
             project_uri="self",
             alignment_size="128",
             volume_size="128M",
-            subset="sub1",
+            subsets=["sub1"],
             split="train",
             revision="main",
         )


### PR DESCRIPTION
## Description
- changes:
  - Processing all subsets automatically.
  - Users can specify multi subsets.
- examples:
  ```bash
  swcli dataset build --name cmmlu -hf haonan-li/cmmlu
  ```
  - hf: https://huggingface.co/datasets/haonan-li/cmmlu
  - starwhale: https://cloud.starwhale.cn/projects/12/datasets/132/versions/189/files?pageNum=1&pageSize=10
  - ![image](https://github.com/star-whale/starwhale/assets/590748/794c7200-5f73-47ba-8d49-ca7c00774169)


## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
