### PR TITLE
chore(e2e): add white list for e2e clean script

### DIFF
--- a/scripts/e2e_test/remove_test_env.sh
+++ b/scripts/e2e_test/remove_test_env.sh
@@ -3,15 +3,18 @@
 # $2 the host for the pv path
 
 set -x
+if [ -f "$HOME"/.config/e2e.config ];then
+  white_list_array=($(grep white_list "$HOME"/.config/e2e.config | cut -d "=" -f2 | tr ',' ' '))
 
-white_list_array=($(grep white_list ~/.config/e2e.config | cut -d "=" -f2 | tr ',' ' '))
-
-for ns in "${white_list_array[@]}";do
-  if [ "$ns" == "$1" ];then
-    echo "$1 is in white list, skip cleanup"
-    exit 0
-  fi
-done
+  for ns in "${white_list_array[@]}";do
+    if [ "$ns" == "$1" ];then
+      echo "$1 is in white list, skip cleanup"
+      exit 0
+    fi
+  done
+else
+  echo "$HOME/.config/e2e.config does not exist, skip white list check."
+fi
 
 helm uninstall "$1" -n "$1" || echo "helm uninstall ns error"
 kubectl delete ns "$1" || echo "kubectl delete ns error"

--- a/scripts/e2e_test/remove_test_env.sh
+++ b/scripts/e2e_test/remove_test_env.sh
@@ -4,6 +4,15 @@
 
 set -x
 
+white_list_array=($(grep white_list ~/.config/e2e.config | cut -d "=" -f2 | tr ',' ' '))
+
+for ns in "${white_list_array[@]}";do
+  if [ "$ns" == "$1" ];then
+    echo "$1 is in white list, skip cleanup"
+    exit 0
+  fi
+done
+
 helm uninstall "$1" -n "$1" || echo "helm uninstall ns error"
 kubectl delete ns "$1" || echo "kubectl delete ns error"
 ssh "$2" "sudo rm -rf /mnt/data/starwhale/$1"


### PR DESCRIPTION
## Description
Config the whitelist in file: ~/.config/e2e.config, the content like this:
```txt
[default]
white_list=e2e-0810,e2e-0811
```
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
