### PR TITLE
fix(controller): use lower case name in image build

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -696,7 +696,7 @@ public class RuntimeService {
             var user = userService.currentUserDetail();
             var image = new DockerImage(
                     dockerSetting.getRegistryForPull(),
-                    String.format("%s:%s", runtime.getName(), runtimeVersion.getVersionName())
+                    String.format("%s:%s", runtime.getName().toLowerCase(), runtimeVersion.getVersionName())
             );
             var job = k8sJobTemplate.loadJob(K8sJobTemplate.WORKLOAD_TYPE_IMAGE_BUILDER);
 
@@ -751,7 +751,7 @@ public class RuntimeService {
                         "--verbosity=debug",
                         "--destination=" + new DockerImage(
                                 registry,
-                                String.format("%s:%s", runtime.getName(), runtimeVersion.getVersionName())
+                                String.format("%s:%s", runtime.getName().toLowerCase(), runtimeVersion.getVersionName())
                         )
                 ));
                 if (dockerSetting.isInsecure()) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -696,6 +696,7 @@ public class RuntimeService {
             var user = userService.currentUserDetail();
             var image = new DockerImage(
                     dockerSetting.getRegistryForPull(),
+                    // repository can only contain the characters abcdefghijklmnopqrstuvwxyz0123456789_-./
                     String.format("%s:%s", runtime.getName().toLowerCase(), runtimeVersion.getVersionName())
             );
             var job = k8sJobTemplate.loadJob(K8sJobTemplate.WORKLOAD_TYPE_IMAGE_BUILDER);
@@ -751,6 +752,7 @@ public class RuntimeService {
                         "--verbosity=debug",
                         "--destination=" + new DockerImage(
                                 registry,
+                                // repository can only contain the characters abcdefghijklmnopqrstuvwxyz0123456789_-./
                                 String.format("%s:%s", runtime.getName().toLowerCase(), runtimeVersion.getVersionName())
                         )
                 ));


### PR DESCRIPTION
## Description
fix the error in kaniko when image containers Upper case like 'star-whale/Stable-diffusion-v1-4':
`error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: getting tag for destination: repository can only contain the characters abcdefghijklmnopqrstuvwxyz0123456789_-./`


## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
