### PR TITLE
chore(workflow):add dataset builder to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
           PYPI_RELEASE_VERSION: ${{ steps.tag.outputs.tag }}
         run: |
           make build-server
+          make build-dataset-builder
 
   helm-charts-release:
     runs-on: ubuntu-latest

--- a/scripts/publish/image_sync.sh
+++ b/scripts/publish/image_sync.sh
@@ -42,7 +42,7 @@ function get_tags() {
 }
 
 # start to sync images
-declare -a starwhale_images=("server" "base" "cuda")
+declare -a starwhale_images=("server" "base" "cuda" "dataset_builder")
 for image in "${starwhale_images[@]}"; do
     tags=$(get_tags "$image")
     # if the image has already synced, regctl would skip it.

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -25,7 +25,7 @@ sw:
       image: ${SW_IMAGE_BUILD_IMAGE:gcr.io/kaniko-project/executor:latest}
     dataset-build:
       resource-pool: ${SW_DATASET_BUILD_RESOURCE_POOL:default}
-      image: ${SW_DATASET_BUILD_IMAGE:docker-registry.starwhale.cn/star-whale/base:latest}
+      image: ${SW_DATASET_BUILD_IMAGE:docker-registry.starwhale.cn/star-whale/dataset_builder:latest}
       client-version: ${SW_DATASET_BUILD_CLI_VERSION:0.5.6}
       python-version: ${SW_DATASET_BUILD_PYTHON_VERSION:3.10}
     pypi:


### PR DESCRIPTION
## Description

The dataset build will install starwhale and it's dependencies at first if use the image of base, so build an image that already installed starwhale which version is the same with server would speed up the build time.

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
