### PR TITLE
fix(controller): prevent readLine quit before read all log lines

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/log/TaskLogStreamingCollectorDocker.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/log/TaskLogStreamingCollectorDocker.java
@@ -105,7 +105,7 @@ public class TaskLogStreamingCollectorDocker implements TaskLogStreamingCollecto
 
     @Override
     public String readLine(Long waitTimeSeconds) throws IOException {
-        if (this.closed) {
+        if (this.closed && logLines.isEmpty()) {
             return null;
         }
         try {

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/impl/docker/log/TaskLogStreamingCollectorDockerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/impl/docker/log/TaskLogStreamingCollectorDockerTest.java
@@ -64,7 +64,7 @@ public class TaskLogStreamingCollectorDockerTest {
         }
     }
 
-    private void doCollectLog(String containerName) throws IOException {
+    private void doCollectLog(String containerName) throws IOException, InterruptedException {
         ContainerTaskMapper containerTaskMapper = mock(ContainerTaskMapper.class);
         Task task = Task.builder().id(1L).step(new Step()).build();
         Container container = mock(Container.class);
@@ -73,6 +73,10 @@ public class TaskLogStreamingCollectorDockerTest {
         when(containerTaskMapper.containerOfTask(task)).thenReturn(container);
         when(containerTaskMapper.taskIfOfContainer(container)).thenReturn(1L);
         logStreamingCollector = new TaskLogStreamingCollectorDocker(task, dockerClientFinder, containerTaskMapper);
+
+        // sleep for a while to wait for the log collector done,
+        // and check if there is no bug in the log collector `close` signal
+        Thread.sleep(1000);
 
         String log = "";
         StringBuilder wholeLog = new StringBuilder();


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
