### PR TITLE
chore(ci): upgrade mypy related libs version

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -46,7 +46,7 @@ ci-lint:
 
 ci-mypy:
 	echo "run mypy"
-	mypy . ../example/mnist ../scripts/client_test
+	mypy . ../example/mnist ../scripts/client_test --show-traceback
 
 ci-isort:
 	echo "run isort"

--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -2,8 +2,8 @@
 black==22.3.0
 jupyter-black==0.3.1
 flake8==4.0.1
-mypy~=0.981
-mypy-extensions==0.4.3
+mypy>=1.4.1
+mypy-extensions==1.0.0
 profimp==0.1.0
 types-PyYAML
 types-click
@@ -35,7 +35,7 @@ openapi-spec-validator
 # for jupyternotebook
 jupyter
 # for trio typing
-trio-typing[mypy] >= 0.7.0
+trio-typing[mypy] >= 0.9.0
 # trio>=0.22 has already removed async_generator dependency, but the trio_typing lib still hooks it.
 # So we need to install async_generator>=1.9 to workaround the warning.
 async_generator >= 1.9


### PR DESCRIPTION
## Description
- issue:  https://github.com/star-whale/starwhale/actions/runs/5995061241/job/16257541837
- reason:  fastapi upgrade `fastapi-0.101.1` -> `fastapi-0.103.0`
  ![image](https://github.com/star-whale/starwhale/assets/590748/54629d22-68d5-4830-a0d0-f90274db1162)
  ![image](https://github.com/star-whale/starwhale/assets/590748/9b3128c3-3de3-4fdd-84a1-5fc787770653)
- use the latest mypy version to fix the internal error

## Modules
- [x] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
