### PR TITLE
fix(controller): save to db failed on the stage of create job

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForSchedule.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForSchedule.java
@@ -93,8 +93,7 @@ public class TaskWatcherForSchedule implements TaskStatusChangeWatcher {
     }
 
     private void addToDeleteQueue(Task task) {
-        var deleteTime = task.getStartTime() == null ? System.currentTimeMillis() + deletionDelayMilliseconds
-                : task.getStartTime() + deletionDelayMilliseconds;
+        var deleteTime = System.currentTimeMillis() + deletionDelayMilliseconds;
         taskToDeletes.put(new TaskToDelete(task, deleteTime));
         log.debug("add task {} to delete queue, delete time {}", task.getId(), deleteTime);
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForSchedule.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForSchedule.java
@@ -23,6 +23,7 @@ import ai.starwhale.mlops.domain.task.status.TaskStatusMachine;
 import ai.starwhale.mlops.schedule.SwTaskScheduler;
 import ai.starwhale.mlops.schedule.log.TaskLogSaver;
 import ai.starwhale.mlops.schedule.reporting.TaskReportReceiver;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.DelayQueue;
@@ -93,7 +94,7 @@ public class TaskWatcherForSchedule implements TaskStatusChangeWatcher {
     }
 
     private void addToDeleteQueue(Task task) {
-        var deleteTime = System.currentTimeMillis() + deletionDelayMilliseconds;
+        var deleteTime = Instant.now().toEpochMilli() + deletionDelayMilliseconds;
         taskToDeletes.put(new TaskToDelete(task, deleteTime));
         log.debug("add task {} to delete queue, delete time {}", task.getId(), deleteTime);
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForSchedule.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/status/watchers/TaskWatcherForSchedule.java
@@ -93,7 +93,8 @@ public class TaskWatcherForSchedule implements TaskStatusChangeWatcher {
     }
 
     private void addToDeleteQueue(Task task) {
-        var deleteTime = task.getStartTime() + deletionDelayMilliseconds;
+        var deleteTime = task.getStartTime() == null ? System.currentTimeMillis() + deletionDelayMilliseconds
+                : task.getStartTime() + deletionDelayMilliseconds;
         taskToDeletes.put(new TaskToDelete(task, deleteTime));
         log.debug("add task {} to delete queue, delete time {}", task.getId(), deleteTime);
     }
@@ -108,6 +109,10 @@ public class TaskWatcherForSchedule implements TaskStatusChangeWatcher {
             toDelete = taskToDeletes.poll();
         }
         swTaskScheduler.stop(tasks);
+    }
+
+    public boolean hasTaskToDelete() {
+        return taskToDeletes.size() > 0;
     }
 
     static class TaskToDelete implements Delayed {


### PR DESCRIPTION
## Description
cc @tianweidut 
There occurs an error when create job（scheduled failed because of resource problem）:

```
483360 ^[[2m2023-08-28 15:09:10.851^[[0;39m ^[[31mERROR [star-whale-controller,fe57fd63928c93c9,fe57fd63928c93c9]^[[0;39m ^[[35m7^[[0;39m ^[[2m---^[[0;39m ^[[2m[nio-8082-exec-1]^[[0;39m ^[[36ma.s.m.c.CommonExceptionHandler          ^[[0;39m ^[[2m:^[[0;       39m handleInternalServerError /api/v1/project/349/job
483361
483362
483363 java.lang.NullPointerException: null
483364         at ai.starwhale.mlops.domain.task.status.watchers.TaskWatcherForSchedule.addToDeleteQueue(TaskWatcherForSchedule.java:96) ~[classes/:0.1.0-SNAPSHOT]
483365         at ai.starwhale.mlops.domain.task.status.watchers.TaskWatcherForSchedule.onTaskStatusChange(TaskWatcherForSchedule.java:87) ~[classes/:0.1.0-SNAPSHOT]
483366         at ai.starwhale.mlops.domain.task.status.watchers.TaskWatcherForSchedule$$FastClassBySpringCGLIB$$3d83c43b.invoke(<generated>) ~[classes/:0.1.0-SNAPSHOT]
483367         at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.24.jar:5.3.24]
483368         at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.24.jar:5.3.24]
483369         at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.24.jar:5.3.24]
483370         at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.24.jar:5.3.24]
483371         at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.24.jar:5.3.24]
483372         at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.24.jar:5.3.24]
483373         at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.24.jar:5.3.24]
483374         at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.24.jar:5.3.24]
483375         at ai.starwhale.mlops.domain.task.status.watchers.TaskWatcherForSchedule$$EnhancerBySpringCGLIB$$2a5124cd.onTaskStatusChange(<generated>) ~[classes/:0.1.0-SNAPSHOT]
483376         at ai.starwhale.mlops.domain.task.status.WatchableTask.lambda$updateStatus$1(WatchableTask.java:77) ~[classes/:0.1.0-SNAPSHOT]
483377         at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) ~[na:na]
483378         at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177) ~[na:na]
483379         at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655) ~[na:na]
483380         at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[na:na]
483381         at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[na:na]
483382         at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[na:na]
483383         at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[na:na]
483384         at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:na]
483385         at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) ~[na:na]
483386         at ai.starwhale.mlops.domain.task.status.WatchableTask.updateStatus(WatchableTask.java:77) ~[classes/:0.1.0-SNAPSHOT]
483387         at ai.starwhale.mlops.schedule.impl.k8s.K8sSwTaskScheduler.taskFailed(K8sSwTaskScheduler.java:238) ~[classes/:0.1.0-SNAPSHOT]
483388         at ai.starwhale.mlops.schedule.impl.k8s.K8sSwTaskScheduler.deployTaskToK8s(K8sSwTaskScheduler.java:187) ~[classes/:0.1.0-SNAPSHOT]
483389         at java.base/java.lang.Iterable.forEach(Iterable.java:75) ~[na:na]
483390         at ai.starwhale.mlops.schedule.impl.k8s.K8sSwTaskScheduler.schedule(K8sSwTaskScheduler.java:83) ~[classes/:0.1.0-SNAPSHOT]
483391         at ai.starwhale.mlops.domain.job.cache.JobLoader.scheduleReadyTasks(JobLoader.java:98) ~[classes/:0.1.0-SNAPSHOT]
483392         at ai.starwhale.mlops.domain.job.cache.JobLoader.load(JobLoader.java:70) ~[classes/:0.1.0-SNAPSHOT]
483393         at ai.starwhale.mlops.domain.job.JobService.createJob(JobService.java:292) ~[classes/:0.1.0-SNAPSHOT]
483394         at ai.starwhale.mlops.domain.job.JobService$$FastClassBySpringCGLIB$$34e4adfb.invoke(<generated>) ~[classes/:0.1.0-SNAPSHOT]
483395         at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.24.jar:5.3.24]
483396         at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793)
```


## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
