### PR TITLE
fix(controller): resume can not work if delay deletion is configured

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobServiceForWeb.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobServiceForWeb.java
@@ -154,11 +154,21 @@ public class JobServiceForWeb {
     }
 
     @Transactional
-    public Long createJob(String projectUrl,
-            String modelVersionUrl, String datasetVersionUrls, String runtimeVersionUrl,
-            String comment, String resourcePool,
-            String handler, String stepSpecOverWrites, JobType type,
-            DevWay devWay, boolean devMode, String devPassword, Long ttlInSec) {
+    public Long createJob(
+            String projectUrl,
+            String modelVersionUrl,
+            String datasetVersionUrls,
+            String runtimeVersionUrl,
+            String comment,
+            String resourcePool,
+            String handler,
+            String stepSpecOverWrites,
+            JobType type,
+            DevWay devWay,
+            boolean devMode,
+            String devPassword,
+            Long ttlInSec
+    ) {
         User user = userService.currentUserDetail();
         var project = projectService.findProject(projectUrl);
         return jobCreator.createJob(project, modelVersionUrl, datasetVersionUrls, runtimeVersionUrl, comment,

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
@@ -85,6 +85,7 @@ public class JobLoader {
                     // FAIL -> ready is forbidden by status machine, so make it to CREATED at first
                     ((WatchableTask) t).unwrap().updateStatus(TaskStatus.CREATED);
                     t.updateStatus(TaskStatus.READY);
+                    t.setGeneration(System.currentTimeMillis());
                 });
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/task/bo/Task.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/task/bo/Task.java
@@ -67,6 +67,10 @@ public class Task extends TimeConcern {
     String ip;
     DevWay devWay;
 
+    // use for task status change checking
+    // must be bigger than before when updating
+    Long generation;
+
     public void updateStatus(TaskStatus status) {
         this.status = status;
     }
@@ -85,6 +89,10 @@ public class Task extends TimeConcern {
 
     public void setIp(String ip) {
         this.ip = ip;
+    }
+
+    public void setGeneration(Long generation) {
+        this.generation = generation;
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/ContainerTaskMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/ContainerTaskMapper.java
@@ -28,6 +28,7 @@ import org.springframework.util.CollectionUtils;
 public class ContainerTaskMapper {
 
     static final String CONTAINER_LABEL_TASK_ID = "starwhale-task-id";
+    public static final String CONTAINER_LABEL_GENERATION = "starwhale-generation";
 
     final DockerClientFinder dockerClientFinder;
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/SwTaskSchedulerDocker.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/SwTaskSchedulerDocker.java
@@ -96,6 +96,7 @@ public class SwTaskSchedulerDocker implements SwTaskScheduler {
                             .startTimeMillis(System.currentTimeMillis())
                             .retryCount(0)
                             .ip(nodeIp)
+                            .generation(task.getGeneration())
                             .build();
                     taskReportReceiver.receive(List.of(rt));
                 }
@@ -115,6 +116,7 @@ public class SwTaskSchedulerDocker implements SwTaskScheduler {
                             .retryCount(0)
                             .failedReason(throwable.getMessage())
                             .ip(nodeIp)
+                            .generation(task.getGeneration())
                             .build();
                     taskReportReceiver.receive(List.of(rt));
 
@@ -122,8 +124,11 @@ public class SwTaskSchedulerDocker implements SwTaskScheduler {
 
                 @Override
                 public void onComplete() {
-                    Map labels = new HashMap();
+                    var labels = new HashMap<String, String>();
                     labels.put(ContainerTaskMapper.CONTAINER_LABEL_TASK_ID, task.getId().toString());
+                    if (task.getGeneration() != null) {
+                        labels.put(ContainerTaskMapper.CONTAINER_LABEL_GENERATION, task.getGeneration().toString());
+                    }
                     labels.putAll(CONTAINER_LABELS);
 
                     CreateContainerCmd createContainerCmd = dockerClient.createContainerCmd(image)
@@ -148,6 +153,7 @@ public class SwTaskSchedulerDocker implements SwTaskScheduler {
                             .startTimeMillis(System.currentTimeMillis())
                             .retryCount(0)
                             .ip(nodeIp)
+                            .generation(task.getGeneration())
                             .build();
                     taskReportReceiver.receive(List.of(rt));
                 }
@@ -164,10 +170,9 @@ public class SwTaskSchedulerDocker implements SwTaskScheduler {
 
     @NotNull
     private List<String> buildEnvs(Map<String, String> env) {
-        List<String> envs = env.entrySet().stream().map(
+        return env.entrySet().stream().map(
                 es -> String.format("%s=%s", es.getKey(), es.getValue())
         ).collect(Collectors.toList());
-        return envs;
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/reporting/DockerTaskReporter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/reporting/DockerTaskReporter.java
@@ -91,7 +91,17 @@ public class DockerTaskReporter {
         TaskStatus status = containerStatusExplainer.statusOf(c);
         Long stopMilli = taskStatusMachine.isFinal(status) ? System.currentTimeMillis() : null;
         String failReason = TaskStatus.FAIL == status ? c.getStatus() : null;
-        return new ReportedTask(containerTaskMapper.taskIfOfContainer(c), status, 0, null, null, stopMilli, failReason);
+        return ReportedTask.builder()
+                .id(containerTaskMapper.taskIfOfContainer(c))
+                .status(status)
+                .retryCount(0)
+                .ip(null)
+                .startTimeMillis(null)
+                .stopTimeMillis(stopMilli)
+                .failedReason(failReason)
+                // use the current time as generation, make sure that the receiver will deal with it
+                .generation(System.currentTimeMillis())
+                .build();
     }
 
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/reporting/DockerTaskReporter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/docker/reporting/DockerTaskReporter.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.schedule.impl.docker.reporting;
 
+import static ai.starwhale.mlops.schedule.impl.docker.ContainerTaskMapper.CONTAINER_LABEL_GENERATION;
+
 import ai.starwhale.mlops.domain.system.SystemSettingService;
 import ai.starwhale.mlops.domain.system.resourcepool.bo.ResourcePool;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
@@ -31,10 +33,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.Nullable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 public class DockerTaskReporter {
@@ -76,7 +79,7 @@ public class DockerTaskReporter {
         distinctDockerClients.forEach(dockerClient -> {
             List<Container> containers = dockerClient.listContainersCmd()
                     .withLabelFilter(SwTaskSchedulerDocker.CONTAINER_LABELS).withShowAll(true).exec();
-            taskReportReceiver.receive(containers.stream().map(c -> containerToTaskReport(c)).filter(Objects::nonNull)
+            taskReportReceiver.receive(containers.stream().map(this::containerToTaskReport).filter(Objects::nonNull)
                     .collect(Collectors.toList()));
         });
 
@@ -86,11 +89,23 @@ public class DockerTaskReporter {
         taskReportReceiver.receive(List.of(containerToTaskReport(c)));
     }
 
-    @Nullable
+    @NotNull
     private ReportedTask containerToTaskReport(Container c) {
         TaskStatus status = containerStatusExplainer.statusOf(c);
         Long stopMilli = taskStatusMachine.isFinal(status) ? System.currentTimeMillis() : null;
         String failReason = TaskStatus.FAIL == status ? c.getStatus() : null;
+        var labels = c.getLabels();
+        Long generation = null;
+        if (!CollectionUtils.isEmpty(labels)) {
+            var str = labels.get(CONTAINER_LABEL_GENERATION);
+            if (StringUtils.hasText(str)) {
+                try {
+                    generation = Long.parseLong(str);
+                } catch (Exception e) {
+                    log.warn("failed to parse generation label {}", str, e);
+                }
+            }
+        }
         return ReportedTask.builder()
                 .id(containerTaskMapper.taskIfOfContainer(c))
                 .status(status)
@@ -99,8 +114,7 @@ public class DockerTaskReporter {
                 .startTimeMillis(null)
                 .stopTimeMillis(stopMilli)
                 .failedReason(failReason)
-                // use the current time as generation, make sure that the receiver will deal with it
-                .generation(System.currentTimeMillis())
+                .generation(generation)
                 .build();
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/JobEventHandler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/JobEventHandler.java
@@ -95,7 +95,7 @@ public class JobEventHandler implements ResourceEventHandler<V1Job> {
         if (null != conditions) {
             List<V1JobCondition> collect = conditions.stream().filter(c -> "True".equalsIgnoreCase(c.getStatus()))
                     .collect(Collectors.toList());
-            if (collect.size() == 0) {
+            if (collect.isEmpty()) {
                 log.warn("no True status conditions for job {}", conditionsLogString(conditions));
             } else {
                 if (collect.size() > 1) {
@@ -157,6 +157,7 @@ public class JobEventHandler implements ResourceEventHandler<V1Job> {
                 .startTimeMillis(startTime)
                 .stopTimeMillis(stopTime)
                 .retryCount(retryNum)
+                .generation(Util.getTaskGeneration(job.getMetadata()))
                 .failedReason(StringUtils.hasText(failedReason) ? failedReason : null)
                 .build();
         taskReportReceiver.receive(List.of(report));
@@ -182,7 +183,7 @@ public class JobEventHandler implements ResourceEventHandler<V1Job> {
                 .map(p -> Util.k8sTimeToMs(p.getStatus().getStartTime()))
                 .filter(Objects::nonNull).collect(Collectors.toList());
 
-        if (startTimes.size() == 0) {
+        if (startTimes.isEmpty()) {
             return null;
         }
         return startTimes.stream().min(Long::compareTo).get();
@@ -196,7 +197,7 @@ public class JobEventHandler implements ResourceEventHandler<V1Job> {
                 .map(p -> joinReasons(p.getStatus().getReason(), p.getStatus().getMessage()))
                 .filter(Objects::nonNull).collect(Collectors.toList());
 
-        if (failedReasons.size() == 0) {
+        if (failedReasons.isEmpty()) {
             return null;
         }
         // join all failed reasons

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/K8sJobTemplate.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/K8sJobTemplate.java
@@ -140,6 +140,7 @@ public class K8sJobTemplate {
         if (jobSpec.getTemplate().getMetadata() == null) {
             jobSpec.getTemplate().metadata(new V1ObjectMeta());
         }
+        updateAnnotations(job.getMetadata(), annotations);
         updateAnnotations(jobSpec.getTemplate().getMetadata(), annotations);
         updateLabels(job, starwhaleJobLabel);
         updateLabels(job, Map.of(JOB_IDENTITY_LABEL, jobName));

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/K8sSwTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/K8sSwTaskScheduler.java
@@ -154,7 +154,7 @@ public class K8sSwTaskScheduler implements SwTaskScheduler {
             }
             Map<String, String> nodeSelector = pool != null ? pool.getNodeSelector() : Map.of();
             List<Toleration> tolerations = pool != null ? pool.getTolerations() : null;
-            var annotations = getStringStringMap(task, job);
+            var annotations = generateAnnotations(task, job);
             if (pool != null && !CollectionUtils.isEmpty(pool.getMetadata())) {
                 annotations.putAll(pool.getMetadata());
             }
@@ -197,8 +197,8 @@ public class K8sSwTaskScheduler implements SwTaskScheduler {
     }
 
     @NotNull
-    private static Map<String, String> getStringStringMap(Task task, Job job) {
-        Map<String, String> annotations = new HashMap<>();
+    private static Map<String, String> generateAnnotations(Task task, Job job) {
+        var annotations = new HashMap<String, String>();
 
         var userId = job.getOwner() == null ? "" : job.getOwner().getId().toString();
         annotations.put(ANNOTATION_KEY_JOB_ID, job.getId().toString());

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/K8sSwTaskScheduler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/K8sSwTaskScheduler.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.schedule.impl.k8s;
 
+import ai.starwhale.mlops.domain.job.bo.Job;
 import ai.starwhale.mlops.domain.runtime.RuntimeResource;
 import ai.starwhale.mlops.domain.system.resourcepool.bo.Toleration;
 import ai.starwhale.mlops.domain.task.bo.Task;
@@ -89,7 +90,11 @@ public class K8sSwTaskScheduler implements SwTaskScheduler {
             try {
                 k8sClient.deleteJob(task.getId().toString());
             } catch (ApiException e) {
-                log.warn("delete k8s job failed {}, {}", task.getId(), e.getResponseBody(), e);
+                if (e.getCode() == 404) {
+                    log.debug("delete k8s task {} not found", task.getId());
+                } else {
+                    log.warn("delete k8s job failed {}, {}", task.getId(), e.getResponseBody(), e);
+                }
             }
         });
     }
@@ -115,6 +120,7 @@ public class K8sSwTaskScheduler implements SwTaskScheduler {
     static final String ANNOTATION_KEY_TASK_ID = "starwhale.ai/task-id";
     static final String ANNOTATION_KEY_USER_ID = "starwhale.ai/user-id";
     static final String ANNOTATION_KEY_PROJECT_ID = "starwhale.ai/project-id";
+    static final String ANNOTATION_KEY_TASK_GENERATION = "starwhale.ai/task-generation";
 
     private void deployTaskToK8s(Task task) {
         log.debug("deploying task to k8s {} ", task.getId());
@@ -148,13 +154,7 @@ public class K8sSwTaskScheduler implements SwTaskScheduler {
             }
             Map<String, String> nodeSelector = pool != null ? pool.getNodeSelector() : Map.of();
             List<Toleration> tolerations = pool != null ? pool.getTolerations() : null;
-            Map<String, String> annotations = new HashMap<>();
-
-            var userId = job.getOwner() == null ? "" : job.getOwner().getId().toString();
-            annotations.put(ANNOTATION_KEY_JOB_ID, job.getId().toString());
-            annotations.put(ANNOTATION_KEY_TASK_ID, task.getId().toString());
-            annotations.put(ANNOTATION_KEY_USER_ID, userId);
-            annotations.put(ANNOTATION_KEY_PROJECT_ID, job.getProject().getId().toString());
+            var annotations = getStringStringMap(task, job);
             if (pool != null && !CollectionUtils.isEmpty(pool.getMetadata())) {
                 annotations.putAll(pool.getMetadata());
             }
@@ -194,6 +194,21 @@ public class K8sSwTaskScheduler implements SwTaskScheduler {
             log.error(" schedule task failed ", e);
             taskFailed(task);
         }
+    }
+
+    @NotNull
+    private static Map<String, String> getStringStringMap(Task task, Job job) {
+        Map<String, String> annotations = new HashMap<>();
+
+        var userId = job.getOwner() == null ? "" : job.getOwner().getId().toString();
+        annotations.put(ANNOTATION_KEY_JOB_ID, job.getId().toString());
+        annotations.put(ANNOTATION_KEY_TASK_ID, task.getId().toString());
+        annotations.put(ANNOTATION_KEY_USER_ID, userId);
+        annotations.put(ANNOTATION_KEY_PROJECT_ID, job.getProject().getId().toString());
+        if (task.getGeneration() != null) {
+            annotations.put(ANNOTATION_KEY_TASK_GENERATION, task.getGeneration().toString());
+        }
+        return annotations;
     }
 
     private ResourceOverwriteSpec getResourceSpec(Task task) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/Util.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/Util.java
@@ -16,13 +16,46 @@
 
 package ai.starwhale.mlops.schedule.impl.k8s;
 
-import java.time.OffsetDateTime;
+import static ai.starwhale.mlops.schedule.impl.k8s.K8sSwTaskScheduler.ANNOTATION_KEY_TASK_GENERATION;
 
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import java.time.OffsetDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+@Slf4j
 public class Util {
     public static Long k8sTimeToMs(OffsetDateTime time) {
         if (time == null) {
             return null;
         }
         return time.toInstant().toEpochMilli();
+    }
+
+    /**
+     * Retrieves the task generation from the given V1ObjectMeta.
+     *
+     * @param meta the V1ObjectMeta from which to retrieve the task generation
+     * @return the task generation as a Long, or null if it cannot be retrieved
+     */
+    public static Long getTaskGeneration(V1ObjectMeta meta) {
+        if (meta == null) {
+            return null;
+        }
+        var annotations = meta.getAnnotations();
+        if (annotations == null) {
+            return null;
+        }
+        var str = annotations.get(ANNOTATION_KEY_TASK_GENERATION);
+        if (!StringUtils.hasText(str)) {
+            return null;
+        }
+
+        try {
+            return Long.parseLong(str);
+        } catch (Exception e) {
+            log.warn("task generation is not a number {}", str);
+            return null;
+        }
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/reporting/PodEventHandler.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/k8s/reporting/PodEventHandler.java
@@ -135,6 +135,7 @@ public class PodEventHandler implements ResourceEventHandler<V1Pod> {
                 .ip(pod.getStatus().getPodIP())
                 .startTimeMillis(startTime)
                 .stopTimeMillis(null)
+                .generation(Util.getTaskGeneration(pod.getMetadata()))
                 .build();
         taskReportReceiver.receive(List.of(report));
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/reporting/ReportedTask.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/reporting/ReportedTask.java
@@ -38,4 +38,5 @@ public class ReportedTask {
     final Long startTimeMillis;
     final Long stopTimeMillis;
     final String failedReason;
+    final Long generation;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/reporting/SimpleTaskReportReceiver.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/reporting/SimpleTaskReportReceiver.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -52,8 +53,12 @@ public class SimpleTaskReportReceiver implements TaskReportReceiver {
             }
 
             Collection<Task> optionalTasks = jobHolder.tasksOfIds(List.of(reportedTask.getId()));
+            Task inMemoryTask = null;
+            if (!CollectionUtils.isEmpty(optionalTasks)) {
+                inMemoryTask = optionalTasks.iterator().next();
+            }
 
-            if (null == optionalTasks || optionalTasks.isEmpty()) {
+            if (inMemoryTask == null) {
                 log.warn("un-cached tasks reported {}, status directly update to DB", reportedTask.getId());
                 if (reportedTask.getRetryCount() != null && reportedTask.getRetryCount() > 0) {
                     taskMapper.updateRetryNum(reportedTask.getId(), reportedTask.getRetryCount());
@@ -75,26 +80,36 @@ public class SimpleTaskReportReceiver implements TaskReportReceiver {
                 }
                 return;
             }
+            // prevent all the task status update before the task resume
+            if (inMemoryTask.getGeneration() != null) {
+                if (reportedTask.getGeneration() == null) {
+                    // no generation, must be the task before resume
+                    return;
+                }
+                if (reportedTask.getGeneration() < inMemoryTask.getGeneration()) {
+                    // generation is smaller, must be the task before resume
+                    return;
+                }
+            }
+
             if (reportedTask.getRetryCount() != null && reportedTask.getRetryCount() > 0) {
-                optionalTasks.forEach(task -> task.setRetryNum(reportedTask.getRetryCount()));
+                inMemoryTask.setRetryNum(reportedTask.getRetryCount());
                 taskMapper.updateRetryNum(reportedTask.getId(), reportedTask.getRetryCount());
             }
             if (StringUtils.hasText(reportedTask.getIp())) {
-                optionalTasks.forEach(task -> task.setIp(reportedTask.getIp()));
+                inMemoryTask.setIp(reportedTask.getIp());
                 taskMapper.updateIp(reportedTask.getId(), reportedTask.getIp());
             }
             if (reportedTask.status != TaskStatus.UNKNOWN) {
-                optionalTasks.forEach(task -> {
-                    // update time before status because only the updateStatus will trigger the watcher
-                    // TODO optimize the update time logic
-                    if (task.getStartTime() == null) {
-                        task.setStartTime(reportedTask.getStartTimeMillis());
-                    }
-                    if (task.getFinishTime() == null) {
-                        task.setFinishTime(reportedTask.getStopTimeMillis());
-                    }
-                    task.updateStatus(reportedTask.getStatus());
-                });
+                // update time before status because only the updateStatus will trigger the watcher
+                // TODO optimize the update time logic
+                if (inMemoryTask.getStartTime() == null) {
+                    inMemoryTask.setStartTime(reportedTask.getStartTimeMillis());
+                }
+                if (inMemoryTask.getFinishTime() == null) {
+                    inMemoryTask.setFinishTime(reportedTask.getStopTimeMillis());
+                }
+                inMemoryTask.updateStatus(reportedTask.getStatus());
             }
         });
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/reporting/SimpleTaskReportReceiver.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/reporting/SimpleTaskReportReceiver.java
@@ -83,11 +83,12 @@ public class SimpleTaskReportReceiver implements TaskReportReceiver {
             // prevent all the task status update before the task resume
             if (inMemoryTask.getGeneration() != null) {
                 if (reportedTask.getGeneration() == null) {
-                    // no generation, must be the task before resume
+                    log.debug("no generation from report {}, ignore", reportedTask.getId());
                     return;
                 }
                 if (reportedTask.getGeneration() < inMemoryTask.getGeneration()) {
-                    // generation is smaller, must be the task before resume
+                    log.debug("generation from report {} {} is less than cached generation {}, ignore",
+                            reportedTask.getId(), reportedTask.getGeneration(), inMemoryTask.getGeneration());
                     return;
                 }
             }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/JobLoaderTest.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.domain.job;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -88,5 +89,8 @@ public class JobLoaderTest {
         jobLoader.load(mockJob, true);
         verify(failedTask, times(mockJob.getSteps().size())).updateStatus(TaskStatus.READY);
         verify(jobHolder).adopt(mockJob);
+        mockJob.getSteps().get(0).getTasks().forEach(t -> {
+            assertNotNull(t.getGeneration());
+        });
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/reporting/TaskReportReceiverImpTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/reporting/TaskReportReceiverImpTest.java
@@ -16,7 +16,10 @@
 
 package ai.starwhale.mlops.reporting;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +28,7 @@ import ai.starwhale.mlops.domain.job.cache.HotJobHolder;
 import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.mapper.TaskMapper;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
+import ai.starwhale.mlops.domain.task.status.WatchableTask;
 import ai.starwhale.mlops.schedule.reporting.ReportedTask;
 import ai.starwhale.mlops.schedule.reporting.SimpleTaskReportReceiver;
 import java.util.Collections;
@@ -76,5 +80,51 @@ public class TaskReportReceiverImpTest {
         verify(taskMapper, times(0)).updateTaskStatus(List.of(1L), TaskStatus.READY);
         Assertions.assertEquals(TaskStatus.READY, task.getStatus());
 
+    }
+
+    @Test
+    public void testReportIgnoredByGeneration() {
+        Task task = mock(WatchableTask.class);
+        when(jobHolder.tasksOfIds(List.of(1L))).thenReturn(Set.of(task));
+        var report = ReportedTask.builder()
+                .id(1L)
+                .status(TaskStatus.READY)
+                .ip("127.0.0.1")
+                .generation(7L)
+                .build();
+        taskStatusReceiver.receive(List.of(report));
+        // no generation info in the in-memory task
+        // the updateStatus will be triggered
+        verify(task, times(1)).updateStatus(TaskStatus.READY);
+
+        // bigger generation in the in-memory task
+        // the updateStatus will not be triggered
+        reset(task);
+        when(task.getGeneration()).thenReturn(8L);
+        taskStatusReceiver.receive(List.of(report));
+        verify(task, never()).updateStatus(any());
+
+        reset(task);
+        when(task.getGeneration()).thenReturn(6L);
+        taskStatusReceiver.receive(List.of(report));
+        verify(task, times(1)).updateStatus(any());
+
+
+        // report without generation
+        report = ReportedTask.builder()
+                .id(1L)
+                .status(TaskStatus.READY)
+                .ip("127.0.0.1")
+                .build();
+        reset(task);
+        when(task.getGeneration()).thenReturn(6L);
+        taskStatusReceiver.receive(List.of(report));
+        verify(task, never()).updateStatus(any());
+
+
+        reset(task);
+        when(task.getGeneration()).thenReturn(null);
+        taskStatusReceiver.receive(List.of(report));
+        verify(task, times(1)).updateStatus(any());
     }
 }


### PR DESCRIPTION
## Description

Resume a failed job will make the job status become `canceled`

<hr/>

**The Reason**:

before resume:
- Job status is `fail`
- Step status is `fail`

resume action do the following actions:
1. change all the failed (paused, canceled) tasks to the `ready` state
2. deploy the `ready` tasks

the `deploy` will try to delete the existing k8s job and then deploy the task

and then the `JobEventHandler` will receive a k8s job deletion event and change the step status to `canceled` (calc via `StepHelper.desiredStepStatus`)

then `JobStatusCalculator.desiredJobStatus` will return `canceled`

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
