### PR TITLE
chore(controller): enable compression for web server

### DIFF
--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -157,6 +157,9 @@ mybatis:
 server:
   port: ${SW_CONTROLLER_PORT:8082}
   shutdown: graceful
+  compression:
+    enabled: true
+    min-response-size: 512KB # default is 2KB
 logging:
   level:
     root: ${SW_ROOT_LOG_LEVEL:warn}

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -158,8 +158,9 @@ server:
   port: ${SW_CONTROLLER_PORT:8082}
   shutdown: graceful
   compression:
-    enabled: true
-    min-response-size: 512KB # default is 2KB
+    enabled: ${SW_COMPRESS_ENABLED:true}
+    mime-types: ${SW_COMPRESS_MIME_TYPES:text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml}
+    min-response-size: ${SW_COMPRESS_MIN_RESPONSE_SIZE:128KB} # default is 2KB
 logging:
   level:
     root: ${SW_ROOT_LOG_LEVEL:warn}

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -160,7 +160,7 @@ server:
   compression:
     enabled: ${SW_COMPRESS_ENABLED:true}
     mime-types: ${SW_COMPRESS_MIME_TYPES:text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml}
-    min-response-size: ${SW_COMPRESS_MIN_RESPONSE_SIZE:128KB} # default is 2KB
+    min-response-size: ${SW_COMPRESS_MIN_RESPONSE_SIZE:8096} # default is 2KB
 logging:
   level:
     root: ${SW_ROOT_LOG_LEVEL:warn}


### PR DESCRIPTION
## Description

1. doc: https://docs.spring.io/spring-boot/docs/2.7.9/reference/html/howto.html#howto.webserver.enable-response-compression
2. default MIME types are:[text/html, text/xml, text/plain, text/css, text/javascript, application/javascript, application/json, application/xml]
3. 
![image](https://github.com/star-whale/starwhale/assets/24869618/74f8a549-c914-419e-acb3-f408a55eb3b9)


## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
