### PR TITLE
feat(client): support custom starwhale version in runtime yaml

### DIFF
--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -182,6 +182,7 @@ class Environment(ASDictMixin):
         self.cuda = str(cuda).strip()
         self.cudnn = str(cudnn).strip()
         self.docker = DockerEnv(**kw.get("docker", {}))
+        self.starwhale_version = str(kw.get("starwhale_version", "")).strip()
 
         self._do_validate()
 
@@ -1357,7 +1358,9 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
         self._manifest["environment"].update(
             {
                 "lock": {
-                    "starwhale_version": self._detected_sw_version or STARWHALE_VERSION,
+                    "starwhale_version": swrt_config.environment.starwhale_version
+                    or self._detected_sw_version
+                    or STARWHALE_VERSION,
                     "system": platform.system(),
                     "shell": {
                         "python_env": sh_py_env,

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -887,7 +887,9 @@ def install_starwhale(
 
     req = [SW_PYPI_PKG_NAME]
     if version:
-        req = [version] if re.match(r"^git", version) else [f"{req}=={version}"]
+        req = [
+            version if re.match(r"^git", version) else f"{SW_PYPI_PKG_NAME}=={version}"
+        ]
 
     configs = configs or {}
     if mode == PythonRunEnv.CONDA:

--- a/client/starwhale/utils/venv.py
+++ b/client/starwhale/utils/venv.py
@@ -885,11 +885,11 @@ def install_starwhale(
     if version == "" or version == SW_DEV_DUMMY_VERSION:
         version = get_downloadable_sw_version()
 
-    req = [SW_PYPI_PKG_NAME]
+    req = SW_PYPI_PKG_NAME
     if version:
-        req = [
+        req = (
             version if re.match(r"^git", version) else f"{SW_PYPI_PKG_NAME}=={version}"
-        ]
+        )
 
     configs = configs or {}
     if mode == PythonRunEnv.CONDA:

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -816,6 +816,9 @@ class StandaloneRuntimeTestCase(TestCase):
         runtime_config = self.get_runtime_config()
         runtime_config["environment"]["cuda"] = "11.5"
         runtime_config["environment"]["cudnn"] = "8"
+        runtime_config["environment"][
+            "starwhale_version"
+        ] = "git+https://github.com/star-whale/starwhale.git@main#subdirectory=client&setup_py=client/setup.py#egg=starwhale"
         runtime_config["dependencies"].extend(
             [
                 {
@@ -903,6 +906,10 @@ class StandaloneRuntimeTestCase(TestCase):
         assert _manifest["version"] == sr.uri.version
         assert _manifest["environment"]["mode"] == "venv"
         assert _manifest["environment"]["lock"]["shell"]["use_venv"]
+        assert (
+            _manifest["environment"]["lock"]["starwhale_version"]
+            == "git+https://github.com/star-whale/starwhale.git@main#subdirectory=client&setup_py=client/setup.py#egg=starwhale"
+        )
         assert _manifest["artifacts"]["wheels"] == ["wheels/dummy.whl"]
         assert _manifest["artifacts"]["files"][0] == {
             "dest": "bin/../bin/prepare.sh",

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -1574,6 +1574,56 @@ class StandaloneRuntimeTestCase(TestCase):
     @patch("starwhale.utils.venv.check_user_python_pkg_exists")
     @patch("starwhale.utils.venv.virtualenv.cli_run")
     @patch("starwhale.utils.venv.check_call")
+    def test_restore_venv_with_custom_version(
+        self, m_call: MagicMock, m_venv: MagicMock, m_exists: MagicMock
+    ):
+        custom_cases = [
+            {"version": "", "expect_cmd": "starwhale"},
+            {"version": "0.5.6", "expect_cmd": "starwhale==0.5.6"},
+            {
+                "version": "git+https://github.com/star-whale/starwhale.git@main#subdirectory=client&setup_py=client/setup.py#egg=starwhale",
+                "expect_cmd": "git+https://github.com/star-whale/starwhale.git@main#subdirectory=client&setup_py=client/setup.py#egg=starwhale",
+            },
+        ]
+        for i, case in enumerate(custom_cases):
+            workdir = f"/home/starwhale/myproject-{i}"
+            export_dir = os.path.join(workdir, "export")
+            ensure_dir(workdir)
+
+            self.fs.create_file(
+                os.path.join(workdir, DEFAULT_MANIFEST_NAME),
+                contents=yaml.safe_dump(
+                    {
+                        "environment": {
+                            "mode": "venv",
+                            "python": "3.7",
+                            "arch": [SupportArch.AMD64],
+                            "lock": {"starwhale_version": case["version"]},
+                        },
+                        "dependencies": {
+                            "local_packaged_env": False,
+                            "raw_deps": [
+                                {
+                                    "kind": "pip_pkg",
+                                    "deps": ["a", "b"],
+                                },
+                            ],
+                        },
+                    }
+                ),
+            )
+            ensure_dir(export_dir)
+
+            m_exists.return_value = False
+            Runtime.restore(Path(workdir))
+
+            pip_cmds = [mc[0][0][6:] for mc in m_call.call_args_list]
+            assert pip_cmds == [["a"], ["b"], [case["expect_cmd"]]]
+            m_call.call_args_list.clear()
+
+    @patch("starwhale.utils.venv.check_user_python_pkg_exists")
+    @patch("starwhale.utils.venv.virtualenv.cli_run")
+    @patch("starwhale.utils.venv.check_call")
     def test_restore_venv_with_auto_lock(
         self, m_call: MagicMock, m_venv: MagicMock, m_exists: MagicMock
     ):
@@ -1845,6 +1895,127 @@ class StandaloneRuntimeTestCase(TestCase):
         assert (Path(workdir) / "export/venv/bin/prepare.sh").exists()
 
         RuntimeTermView.restore(workdir)
+
+    @patch("starwhale.utils.venv.check_user_python_pkg_exists")
+    @patch("starwhale.core.runtime.model.platform.machine")
+    @patch("starwhale.utils.fs.tarfile.open")
+    @patch("starwhale.utils.venv.check_call")
+    def test_restore_conda_with_custom_version(
+        self,
+        m_call: MagicMock,
+        m_tar: MagicMock,
+        m_machine: MagicMock,
+        m_exists: MagicMock,
+    ):
+        custom_cases = [
+            {"version": "", "expect_cmd": "starwhale"},
+            {"version": "0.5.6", "expect_cmd": "starwhale==0.5.6"},
+            {
+                "version": "git+https://github.com/star-whale/starwhale.git@main#subdirectory=client&setup_py=client/setup.py#egg=starwhale",
+                "expect_cmd": "git+https://github.com/star-whale/starwhale.git@main#subdirectory=client&setup_py=client/setup.py#egg=starwhale",
+            },
+        ]
+        for i, case in enumerate(custom_cases):
+            name = f"rttest-{i}"
+            version = "1234"
+            sw = SWCliConfigMixed()
+            workdir = str(
+                sw.rootdir
+                / "self"
+                / "workdir"
+                / "runtime"
+                / name
+                / version[:VERSION_PREFIX_CNT]
+                / version
+            )
+            ensure_dir(workdir)
+
+            self.fs.create_dir(os.path.join(workdir, "configs"))
+            condarc_path = os.path.join(workdir, "configs", "condarc")
+            self.fs.create_file(
+                condarc_path,
+                contents=yaml.safe_dump({"verbosity": 3}, default_flow_style=False),
+            )
+
+            self.fs.create_file(
+                os.path.join(workdir, DEFAULT_MANIFEST_NAME),
+                contents=yaml.safe_dump(
+                    {
+                        "environment": {
+                            "python": "3.7",
+                            "mode": "conda",
+                            "arch": [SupportArch.ARM64],
+                            "lock": {"starwhale_version": case["version"]},
+                        },
+                        "dependencies": {
+                            "local_packaged_env": False,
+                            "raw_deps": [
+                                {
+                                    "kind": "pip_pkg",
+                                    "deps": ["a"],
+                                },
+                            ],
+                        },
+                    }
+                ),
+            )
+
+            export_dir = os.path.join(workdir, "export")
+            ensure_dir(export_dir)
+            dep_dir = os.path.join(workdir, "dependencies")
+            lock_dir = os.path.join(dep_dir, ".starwhale", "lock")
+            ensure_dir(lock_dir)
+
+            m_machine.return_value = "arm64"
+            m_exists.return_value = False
+            Runtime.restore(Path(workdir))
+
+            conda_cmds = [cm[0][0] for cm in m_call.call_args_list]
+            conda_prefix_dir = os.path.join(export_dir, "conda")
+            assert conda_cmds == [
+                [
+                    "conda",
+                    "create",
+                    "--yes",
+                    "--quiet",
+                    "--prefix",
+                    conda_prefix_dir,
+                    "python=3.7",
+                ],
+                [
+                    "conda",
+                    "run",
+                    "--live-stream",
+                    "--prefix",
+                    conda_prefix_dir,
+                    "python3",
+                    "-m",
+                    "pip",
+                    "install",
+                    "--exists-action",
+                    "w",
+                    "--timeout=90",
+                    "--retries=10",
+                    "a",
+                ],
+                [
+                    "conda",
+                    "run",
+                    "--live-stream",
+                    "--prefix",
+                    conda_prefix_dir,
+                    "python3",
+                    "-m",
+                    "pip",
+                    "install",
+                    "--exists-action",
+                    "w",
+                    "--timeout=90",
+                    "--retries=10",
+                    case["expect_cmd"],
+                ],
+            ]
+            m_call.call_args_list.clear()
 
     @patch("starwhale.core.runtime.model.platform.machine")
     @patch("starwhale.utils.fs.tarfile.open")


### PR DESCRIPTION
## Description

- Support custom starwhale version in yaml.
- Support `git+https...` format with version.

Details:
1. The effective priority is: 
`environment.starwhale_version in yaml > starwhale dependency in requirements > current starwhale.`
2. Build with custom starwhale version
```
api_version: 1.1
configs:
  conda:
    channels:
      - conda-forge
dependencies:
  - pip:
      - numpy
  - requirements-sw-lock.txt
environment:
  arch: noarch
  os: ubuntu:20.04
  starwhale_version: git+https://github.com/star-whale/starwhale.git@main#subdirectory=client&setup_py=client/setup.py#egg=starwhale
mode: venv
name: simple-test
```
[![asciicast](https://asciinema.org/a/g0kgCrcMMW9R7hqrnozNoCFlC.svg)](https://asciinema.org/a/g0kgCrcMMW9R7hqrnozNoCFlC)


3. Restore In Cloud(base entrypoint):
![image](https://github.com/star-whale/starwhale/assets/24869618/8f8836f7-d22a-4988-9785-3bc0ad16281b)

4. Restore In Standalone(venv)
![image](https://github.com/star-whale/starwhale/assets/24869618/3327a97c-04b5-4e3d-bb85-ca84c79e65a1)

5. Restore In Standalone(conda)
![image](https://github.com/star-whale/starwhale/assets/24869618/35228715-fe20-4ece-9eb5-bb17c377f2d7)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
