### PR TITLE
chore(console):  tiptap editor default role caused the internal selector  disabled, report preview error, etc

### DIFF
--- a/console/packages/starwhale-core/src/datastore/hooks/useDatastorePage.tsx
+++ b/console/packages/starwhale-core/src/datastore/hooks/useDatastorePage.tsx
@@ -101,19 +101,25 @@ function useDatastorePage({
         page: $page,
         setPage: React.useCallback(
             (tmp: DatastorePageT, lastKey?: string) => {
-                setPage({
-                    ...tmp,
-                })
-                setLastKeyMap((prev) => {
-                    if (!lastKey || !tmp?.pageNum) return prev
-                    // if set same page, ignore, prevent lastKey set when click prev page
-                    if (prev[tmp?.pageNum]) return prev
+                setPage((prevPage) => {
+                    if (prevPage.pageSize !== tmp.pageSize) {
+                        setLastKeyMap({})
+                    } else {
+                        setLastKeyMap((prev) => {
+                            if (!lastKey || !tmp?.pageNum) return prev
+                            // if set same page, ignore, prevent lastKey set when click prev page
+                            if (prev[tmp?.pageNum]) return prev
 
+                            return {
+                                ...prev,
+                                [tmp?.pageNum]: lastKey,
+                                // first page lastKey is empty
+                                1: '',
+                            }
+                        })
+                    }
                     return {
-                        ...prev,
-                        [tmp?.pageNum]: lastKey,
-                        // first page lastKey is empty
-                        1: '',
+                        ...tmp,
                     }
                 })
             },

--- a/console/packages/starwhale-core/src/store/store.ts
+++ b/console/packages/starwhale-core/src/store/store.ts
@@ -40,6 +40,7 @@ export function createCustomStore(initState: Partial<WidgetStateT> = {}) {
                         isInit: false,
                         ...(initState as any),
                         key: name,
+                        editable: true,
                         isEditable: () => get().editable,
                         getRawConfigs: () => _.pick(get(), SYNCKESY),
                         setRawConfigs: (configs: any) => {

--- a/console/packages/starwhale-ui/src/AutoResizer/GridResizerVertical.tsx
+++ b/console/packages/starwhale-ui/src/AutoResizer/GridResizerVertical.tsx
@@ -2,6 +2,9 @@ import IconFont from '../IconFont'
 import classNames from 'classnames'
 import React, { useCallback, useState } from 'react'
 import { themedUseStyletron } from '../theme/styletron'
+import { ExtendButton } from '../Button'
+import useTranslation from '@/hooks/useTranslation'
+import { expandBorderRadius } from '../utils'
 
 const RESIZEBAR_WIDTH = 60
 
@@ -134,6 +137,7 @@ export type ResizeBarPropsT = {
 
 function ResizeBar2({ mode: gridMode = 0, resizeTitle = '', onModeChange, resizeRef }: ResizeBarPropsT) {
     const [css] = themedUseStyletron()
+    const [t] = useTranslation()
 
     return (
         <div
@@ -175,15 +179,19 @@ function ResizeBar2({ mode: gridMode = 0, resizeTitle = '', onModeChange, resize
                     borderRadius: '4px',
                     alignSelf: 'flex-end',
                     padding: '6px 0 ',
+                    display: 'flex',
                 })}
             >
                 {['layout-1', 'layout-2', 'layout-3'].map((icon, index) => {
+                    const trans = [t('grid.view.collapse'), t('grid.view.half'), t('grid.view.expand')]
                     return (
-                        <i
+                        <ExtendButton
                             key={icon}
-                            role='button'
-                            tabIndex={index}
+                            kind='tertiary'
+                            tooltip={trans[index]}
+                            as='link'
                             onClick={() => onModeChange(index)}
+                            // @ts-ignore
                             style={{
                                 display: 'inline-flex',
                                 width: '40px',
@@ -192,6 +200,7 @@ function ResizeBar2({ mode: gridMode = 0, resizeTitle = '', onModeChange, resize
                                 alignItems: 'center',
                                 borderLeft: index === 1 ? '1px solid #CFD7E6' : 'none',
                                 borderRight: index === 1 ? '1px solid #CFD7E6' : 'none',
+                                ...expandBorderRadius('0px'),
                             }}
                         >
                             <IconFont
@@ -202,7 +211,7 @@ function ResizeBar2({ mode: gridMode = 0, resizeTitle = '', onModeChange, resize
                                     marginBottom: '2px',
                                 }}
                             />
-                        </i>
+                        </ExtendButton>
                     )
                 })}
             </div>

--- a/console/packages/starwhale-ui/src/Pagination/Pagination.tsx
+++ b/console/packages/starwhale-ui/src/Pagination/Pagination.tsx
@@ -87,7 +87,7 @@ function Pagination(paginationProps: IPaginationProps) {
     const currentPage = start ?? 1
 
     return (
-        <div className='pagination flex items-center mt-20px gap-20px lh-20px' data-pm-draggable='false'>
+        <div className='pagination flex items-center mt-20px gap-20px lh-20px'>
             <div className='flex-1' />
             {Boolean(total) && (
                 <div className='pagination-counts color-[rgba(2,16,43,0.60)] py-3px'>

--- a/console/packages/starwhale-ui/src/TiptapEditor/index.tsx
+++ b/console/packages/starwhale-ui/src/TiptapEditor/index.tsx
@@ -88,16 +88,15 @@ export default function TiptapEditor({ id = '', initialContent, editable, onSave
 
     return (
         <div
-            onClick={() => {
-                // editor?.chain().focus().run()
-            }}
-            role='button'
-            tabIndex={0}
+            // notice 1: role=button will cause selector component interactive disabled
+            // notice 2: onclick focus will cause page jitter
+            // onClick={() => {
+            //     editor?.chain().focus().run()
+            // }}
+            // role='button'
+            // tabIndex={0}
             className='relative self-center min-h-[500px] w-full h-full bg-white sm:mb-[calc(10px)] sm:rounded-lg'
         >
-            {/* <div className='absolute right-5 top-5 mb-5 rounded-lg bg-stone-100 px-2 py-1 text-sm text-stone-400'>
-                {saveStatus}
-            </div> */}
             {editor && <EditorBubbleMenu editor={editor} />}
             <EditorContent editor={editor} />
         </div>

--- a/console/packages/starwhale-widgets/src/SectionWidget/component/ChartConfigGroup.tsx
+++ b/console/packages/starwhale-widgets/src/SectionWidget/component/ChartConfigGroup.tsx
@@ -3,7 +3,8 @@ import { createUseStyles } from 'react-jss'
 import IconFont from '@starwhale/ui/IconFont'
 import classnames from 'classnames'
 import ChartConfigPopover from './ChartConfigPopover'
-import Button from '@starwhale/ui/Button'
+import { ExtendButton } from '@starwhale/ui/Button'
+import useTranslation from '@/hooks/useTranslation'
 
 const useStyles = createUseStyles({
     chartGroup: {
@@ -44,6 +45,7 @@ export default function ChartConfigGroup({
         edit: onEdit,
         delete: onDelete,
     }
+    const [t] = useTranslation()
 
     return (
         <div className={classnames('panel-operator', styles.chartGroup)}>
@@ -53,10 +55,11 @@ export default function ChartConfigGroup({
                     actions?.[item?.type]()
                 }}
             />
-            <Button
+            <ExtendButton
                 kind='tertiary'
                 className={styles.icon}
                 onClick={() => onReload()}
+                tooltip={t('panel.chart.reload')}
                 overrides={{
                     BaseButton: {
                         style: {
@@ -76,11 +79,12 @@ export default function ChartConfigGroup({
                 }}
             >
                 <IconFont type='reset' size={12} />
-            </Button>
-            <Button
+            </ExtendButton>
+            <ExtendButton
                 kind='tertiary'
                 className={styles.icon}
                 onClick={() => onDownload()}
+                tooltip={t('panel.chart.download')}
                 overrides={{
                     BaseButton: {
                         style: {
@@ -100,11 +104,12 @@ export default function ChartConfigGroup({
                 }}
             >
                 <IconFont type='download' size={12} />
-            </Button>
-            <Button
+            </ExtendButton>
+            <ExtendButton
                 kind='tertiary'
                 className={styles.icon}
                 onClick={() => onPreview()}
+                tooltip={t('panel.chart.preview')}
                 overrides={{
                     BaseButton: {
                         style: {
@@ -124,7 +129,7 @@ export default function ChartConfigGroup({
                 }}
             >
                 <IconFont type='fullscreen' size={12} />
-            </Button>
+            </ExtendButton>
         </div>
     )
 }

--- a/console/packages/starwhale-widgets/src/SectionWidget/component/ChartConfigPopover.tsx
+++ b/console/packages/starwhale-widgets/src/SectionWidget/component/ChartConfigPopover.tsx
@@ -6,7 +6,7 @@ import { ConfirmButton } from '@starwhale/ui/Modal'
 import { expandMargin, expandPadding } from '@starwhale/ui/utils'
 import useTranslation from '@/hooks/useTranslation'
 import { themedUseStyletron } from '@starwhale/ui/theme/styletron'
-import { Button } from '@starwhale/ui/Button'
+import { ExtendButton } from '@starwhale/ui/Button'
 import { createUseStyles } from 'react-jss'
 
 const useStyles = createUseStyles({
@@ -102,9 +102,10 @@ export default function ChartConfigPopover({ onOptionSelect }) {
                 />
             )}
         >
-            <Button
+            <ExtendButton
                 kind='tertiary'
                 className={styles.icon}
+                tooltip={t('panel.chart.settings')}
                 overrides={{
                     BaseButton: {
                         style: {
@@ -124,7 +125,7 @@ export default function ChartConfigPopover({ onOptionSelect }) {
                 }}
             >
                 <IconFont type='setting' size={12} />
-            </Button>
+            </ExtendButton>
         </StatefulPopover>
     )
 }

--- a/console/packages/starwhale-widgets/src/SectionWidget/index.tsx
+++ b/console/packages/starwhale-widgets/src/SectionWidget/index.tsx
@@ -373,8 +373,6 @@ function SectionWidget(props: WidgetRendererProps<OptionConfig, any>) {
 
     const isChartAdd = isEvaluationList ? Object.keys(evalSelectData || {}).length > 0 : true
 
-    console.log(editable)
-
     return (
         <PanelContextProvider value={{ evalSelectData }}>
             <SectionAccordionPanel

--- a/console/packages/starwhale-widgets/src/SectionWidget/index.tsx
+++ b/console/packages/starwhale-widgets/src/SectionWidget/index.tsx
@@ -107,7 +107,7 @@ const selector = (s: WidgetStoreState) => ({
 function SectionWidget(props: WidgetRendererProps<OptionConfig, any>) {
     const { store } = useEditorContext()
     const api = store(selector, shallow)
-    const { editable } = api
+    const { editable = true } = api
     const [editWidget, setEditWidget] = useState<{
         type?: string
         path?: any[]
@@ -372,6 +372,8 @@ function SectionWidget(props: WidgetRendererProps<OptionConfig, any>) {
     // })
 
     const isChartAdd = isEvaluationList ? Object.keys(evalSelectData || {}).length > 0 : true
+
+    console.log(editable)
 
     return (
         <PanelContextProvider value={{ evalSelectData }}>

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -12,10 +12,7 @@ import { AuthProvider } from './api/Auth'
 import i18n from './i18n'
 import locales from '@starwhale/ui/i18n'
 import { NoneBackgroundPending } from '@/pages/Home/Pending'
-import { apiInit } from '@/api'
 import useGlobalState from './hooks/global'
-
-apiInit()
 
 const Routes = React.lazy(() => import('./routes'))
 const RoutesSimple = React.lazy(() => import('./routesSimple'))
@@ -39,7 +36,7 @@ export default function App({ simple = false }): any {
             <StyletronProvider value={engine}>
                 <BaseProvider theme={DeepTheme}>
                     <LocaleProvider locale={overrideLanguage}>
-                        <AuthProvider>
+                        <AuthProvider simple={simple}>
                             <ToasterContainer autoHideDuration={3000} />
                             <ConfirmCtxProvider>
                                 <SidebarContext.Provider value={sidebarData}>

--- a/console/src/api/Auth.tsx
+++ b/console/src/api/Auth.tsx
@@ -31,7 +31,7 @@ export const useAuth = () => {
 // eslint-disable-next-line
 const location = window.location
 
-export const AuthProvider = ({ children }: any) => {
+export const AuthProvider = ({ children, simple = false }: any) => {
     const token = useSearchParam('token') ?? ''
     if (!getToken()) {
         setToken(token)
@@ -39,7 +39,10 @@ export const AuthProvider = ({ children }: any) => {
 
     const [currentToken, setCurrentToken] = React.useState(getToken())
 
-    const userInfo = useQuery(['currentUser', currentToken], fetchCurrentUser, { staleTime: Infinity })
+    const userInfo = useQuery(['currentUser', currentToken], fetchCurrentUser, {
+        staleTime: Infinity,
+        enabled: !simple,
+    })
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const { setCurrentUser } = useCurrentUser()

--- a/console/src/api/index.ts
+++ b/console/src/api/index.ts
@@ -21,13 +21,13 @@ export const setToken = (token: string | undefined) => {
     store.setItem(key, token)
 }
 
-export function apiInit() {
+export function apiInit(simple = false) {
     axios.interceptors.request.use((config) => {
-        config.headers.Authorization = getToken()
+        config.headers.Authorization = simple ? '' : getToken()
         return config
     })
     axios.interceptors.response.use((response) => {
-        if (response.headers?.authorization) setToken(response.headers.authorization)
+        if (response.headers?.authorization && !simple) setToken(response.headers.authorization)
         return typeof response.data === 'object' && 'data' in response.data ? response.data : response
     })
 }

--- a/console/src/i18n/locales.ts
+++ b/console/src/i18n/locales.ts
@@ -76,6 +76,14 @@ const basic = {
         en: 'Collapse details',
         zh: '收起视图',
     },
+    'yes': {
+        en: 'Yes',
+        zh: '是',
+    },
+    'no': {
+        en: 'No',
+        zh: '否',
+    },
 }
 
 const dataset = {

--- a/console/src/i18n/locales.ts
+++ b/console/src/i18n/locales.ts
@@ -716,6 +716,22 @@ const widget = {
         en: 'Chart Type',
         zh: '图表类型',
     },
+    'panel.chart.reload': {
+        en: 'Reload',
+        zh: '刷新',
+    },
+    'panel.chart.download': {
+        en: 'Download',
+        zh: '下载',
+    },
+    'panel.chart.preview': {
+        en: 'Preview',
+        zh: '预览',
+    },
+    'panel.chart.settings': {
+        en: 'Setting',
+        zh: '设置',
+    },
     'panel.chart.table.name': {
         en: 'Table Name',
         zh: '数据表',

--- a/console/src/i18n/locales.ts
+++ b/console/src/i18n/locales.ts
@@ -64,6 +64,18 @@ const basic = {
         en: '{{0}} per page',
         zh: '{{0}}条/页',
     },
+    'grid.view.expand': {
+        en: 'Expand details',
+        zh: '全屏视图',
+    },
+    'grid.view.half': {
+        en: 'Split in half',
+        zh: '分屏视图',
+    },
+    'grid.view.collapse': {
+        en: 'Collapse details',
+        zh: '收起视图',
+    },
 }
 
 const dataset = {

--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -11,6 +11,7 @@ import { registerLocales } from './i18n/locales'
 // for uno or tailwind
 import '@unocss/reset/tailwind.css'
 import 'virtual:uno.css'
+import { apiInit } from '@/api'
 
 // eslint-disable-next-line
 // @ts-ignore
@@ -53,6 +54,8 @@ async function init() {
     const simple = window.location.pathname.startsWith('/simple')
 
     const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+
+    apiInit(simple)
 
     root.render(<App simple={simple} />)
 }

--- a/console/src/pages/Evaluation/EvaluationListCard.tsx
+++ b/console/src/pages/Evaluation/EvaluationListCard.tsx
@@ -96,6 +96,11 @@ export default function EvaluationListCard() {
                     ...column,
                     renderCell: ({ value }) => <p title={value.toString()}>{durationToStr(value.value)}</p>,
                 })
+            if (column.key === 'sys/dev_mode')
+                return CustomColumn<RecordAttr, any>({
+                    ...column,
+                    renderCell: ({ value }) => <p title={value.toString()}>{value.value ? t('yes') : t('no')}</p>,
+                })
             if (column.key === 'sys/job_status')
                 return CustomColumn<RecordAttr, any>({
                     ...column,
@@ -115,7 +120,7 @@ export default function EvaluationListCard() {
                     renderCell: ({ value }) => {
                         return (
                             <span className='line-clamp line-clamp-2' title={value.toString()}>
-                                {formatTimestampDateTime(value.value)}
+                                {Number(value.value) > 0 ? formatTimestampDateTime(value.value) : '-'}
                             </span>
                         )
                     },


### PR DESCRIPTION
## Description

1. Fixed scantable paging errors caused by the number of pages that can be modified
2. Optimize grid icon and chart icon to add tooltip
3. Fixed an issue where the tiptap editor default role caused the internal selector to fail
4. Fixed the existing token exception caused by report preview public token and adjusted it to an independent token logic
5. Optimizes translation dev mode and currency decimal when creating job

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
