### PR TITLE
e2e: remove upgrade test from e2e

### DIFF
--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -250,9 +250,9 @@ api_test() {
   python3 -m pip install -r requirements.txt
   pytest --host ${CONTROLLER_HOST} --port 80 || exit 1
   popd
-  if ! in_github_action; then
-    source upgrade_test.sh
-  fi
+  # if ! in_github_action; then
+  #   source upgrade_test.sh
+  # fi
 }
 
 console_test() {


### PR DESCRIPTION
## Description
since upgrade feature can't be used boldly, remove it from e2e 
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
