### PR TITLE
fix(controller): restore SQL syntax error with multiQueries is true

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/backup/db/MysqlBackupService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/backup/db/MysqlBackupService.java
@@ -311,7 +311,7 @@ public class MysqlBackupService {
                 int endIndex = sql.indexOf(SQL_END_PATTERN);
                 String executable = sql.substring(startIndex, endIndex).trim();
                 log.debug("adding executable SQL chunk to batch:{}", executable);
-                statement.addBatch(executable);
+                statement.addBatch(simplifySql(executable));
                 sql = sql.substring(endIndex + 1);
             }
             statement.addBatch("SET FOREIGN_KEY_CHECKS = 1");
@@ -320,5 +320,20 @@ public class MysqlBackupService {
                     results.length, Arrays.toString(results));
             return true;
         }
+    }
+
+    public static String simplifySql(String sql) {
+        String[] lines = sql.split("\n");
+        StringBuilder sb = new StringBuilder();
+
+        for (String line : lines) {
+            // remove the comment lines
+            if (!line.startsWith("--")) {
+                // remove the semicolon(;) at the end of the line
+                sb.append(line.endsWith(";") ? line.substring(0, line.lastIndexOf(";")) : line).append("\n");
+            }
+        }
+
+        return sb.toString();
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/backup/db/MysqlBackupServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/backup/db/MysqlBackupServiceTest.java
@@ -34,6 +34,37 @@ import org.junit.jupiter.api.Test;
 public class MysqlBackupServiceTest extends MySqlContainerHolder {
 
     @Test
+    public void testSimplifySql() {
+        String sql = "-- start: insert \n"
+                + "insert into test_r (id) values\n"
+                + "(1),\n"
+                + "(2),\n"
+                + "(3),\n"
+                + "(4),\n"
+                + "(5);\n"
+                + "-- end: insert\n";
+        String simplifiedSql = MysqlBackupService.simplifySql(sql);
+        assertThat(simplifiedSql, is(
+                "insert into test_r (id) values\n"
+                    + "(1),\n"
+                    + "(2),\n"
+                    + "(3),\n"
+                    + "(4),\n"
+                    + "(5)\n"
+        ));
+
+        // unnecessary to simplify
+        sql = "insert into test_r (id) values\n"
+                + "(1),\n"
+                + "(2),\n"
+                + "(3),\n"
+                + "(4),\n"
+                + "(5)\n";
+        simplifiedSql = MysqlBackupService.simplifySql(sql);
+        assertThat(simplifiedSql, is(sql));
+    }
+
+    @Test
     public void testBackupAndRestore() throws SQLException, ClassNotFoundException {
         assertThat("extract db",
                 MysqlBackupService.extractDatabaseFromUrl(mySqlDB.getJdbcUrl()), is("arbitrary_dbname"));

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/MySqlContainerHolder.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/MySqlContainerHolder.java
@@ -32,7 +32,7 @@ public abstract class MySqlContainerHolder {
                 .withUrlParam("useUnicode", "true")
                 .withUrlParam("characterEncoding", "UTF-8")
                 .withUrlParam("createDatabaseIfNotExist", "true")
-                //.withUrlParam("allowMultiQueries", "true")
+                .withUrlParam("allowMultiQueries", "true")
                 .withUrlParam("useJDBCCompliantTimezoneShift", "true")
                 .withUrlParam("serverTimezone", "UTC")
                 .withUrlParam("useLegacyDatetimeCode", "false")


### PR DESCRIPTION
## Description

There will occur an SQL syntax error when allowMultiQueries=true, the reason is that the content of dump sql script contains semicolon(;) at the line of end.

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
