### PR TITLE
fix(controller): tune data read log table constrain

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
@@ -218,7 +218,7 @@ public class DatasetController {
                         .consumerId(dataRangeRequest.getConsumerId())
                         .isSerial(dataRangeRequest.isSerial())
                         .datasetName(dataset.getDatasetName())
-                        .datasetVersion(dataset.getVersionName())
+                        .datasetVersionId(dataset.getId())
                         .tableName(dataset.getIndexTable())
                         .start(dataRangeRequest.getStart())
                         .startInclusive(dataRangeRequest.isStartInclusive())

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DatasetController.java
@@ -216,7 +216,6 @@ public class DatasetController {
                 DataReadRequest.builder()
                         .sessionId(dataRangeRequest.getSessionId())
                         .consumerId(dataRangeRequest.getConsumerId())
-                        .isSerial(dataRangeRequest.isSerial())
                         .datasetName(dataset.getDatasetName())
                         .datasetVersionId(dataset.getId())
                         .tableName(dataset.getIndexTable())

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/dataloader/DataConsumptionRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/dataset/dataloader/DataConsumptionRequest.java
@@ -31,6 +31,7 @@ public class DataConsumptionRequest {
      * True: auto processed the previous data
      * False: determined by processedData
      */
+    @Deprecated
     private boolean isSerial = false;
 
     private int batchSize;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataLoader.java
@@ -49,7 +49,7 @@ public class DataLoader {
             }
         }
 
-        dataReadManager.handleConsumerData(consumerId, request.isSerial(), request.getProcessedData(), session);
+        dataReadManager.handleConsumerData(consumerId, request.getProcessedData(), session);
 
         // this lock can be replaced by select fot update in future
         var lock = new KeyLock<>(String.format("dl-assignment-%s", session.getId()));

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataLoader.java
@@ -16,7 +16,9 @@
 
 package ai.starwhale.mlops.domain.dataset.dataloader;
 
+import ai.starwhale.mlops.common.KeyLock;
 import ai.starwhale.mlops.domain.dataset.dataloader.bo.DataReadLog;
+import ai.starwhale.mlops.domain.dataset.dataloader.bo.Session;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -29,11 +31,34 @@ public class DataLoader {
 
     public DataReadLog next(DataReadRequest request) {
         var consumerId = request.getConsumerId();
-        var session = dataReadManager.getOrGenerateSession(request);
+        var sessionId = request.getSessionId();
+        var datasetVersionId = request.getDatasetVersionId();
+        Session session = dataReadManager.getSession(request);
+        if (session == null) {
+            // ensure serially in the same session with the same dataset version
+            // this lock should wrap the transaction and use double check
+            var sessionLock = new KeyLock<>(String.format("dl-session-generate-%s-%s", sessionId, datasetVersionId));
+            try {
+                sessionLock.lock();
+                session = dataReadManager.getSession(request);
+                if (session == null) {
+                    session = dataReadManager.generateSession(request);
+                }
+            } finally {
+                sessionLock.unlock();
+            }
+        }
 
         dataReadManager.handleConsumerData(consumerId, request.isSerial(), request.getProcessedData(), session);
 
-        return dataReadManager.assignmentData(consumerId, session);
+        // this lock can be replaced by select fot update in future
+        var lock = new KeyLock<>(String.format("dl-assignment-%s", session.getId()));
+        try {
+            lock.lock();
+            return dataReadManager.assignmentData(consumerId, session);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
@@ -123,18 +123,13 @@ public class DataReadManager {
 
     @Transactional
     public void handleConsumerData(
-            String consumerId, boolean isSerial, List<DataIndexDesc> processedData, Session session) {
+            String consumerId, List<DataIndexDesc> processedData, Session session) {
         var sid = session.getId();
         // update processed data
         if (CollectionUtils.isNotEmpty(processedData)) {
             for (DataIndexDesc indexDesc : processedData) {
                 dataReadLogDao.updateToProcessed(sid, consumerId, indexDesc.getStart(), indexDesc.getEnd());
             }
-        }
-        // Whether to process serially under the same consumer,
-        // if serial is true, unassigned the previous unprocessed data
-        if (isSerial) {
-            dataReadLogDao.updateUnProcessedToUnAssigned(sid, consumerId);
         }
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
@@ -53,17 +53,17 @@ public class DataReadManager {
     Session getOrGenerateSession(DataReadRequest request) {
         var sessionId = request.getSessionId();
         var datasetName = request.getDatasetName();
-        var datasetVersion = request.getDatasetVersion();
+        var datasetVersionId = request.getDatasetVersionId();
         // ensure serially in the same session
-        var sessionLock = new KeyLock<>(String.format("%s-%s-%s", sessionId, datasetName, datasetVersion));
+        var sessionLock = new KeyLock<>(String.format("%s-%s-%s", sessionId, datasetName, datasetVersionId));
         try {
             sessionLock.lock();
-            var session = sessionDao.selectOne(sessionId, datasetName, datasetVersion);
+            var session = sessionDao.selectOne(sessionId, datasetName, String.valueOf(datasetVersionId));
             if (session == null) {
                 session = Session.builder()
                         .sessionId(sessionId)
                         .datasetName(request.getDatasetName())
-                        .datasetVersion(request.getDatasetVersion())
+                        .datasetVersion(String.valueOf(request.getDatasetVersionId()))
                         .tableName(request.getTableName())
                         .start(request.getStart())
                         .startInclusive(request.isStartInclusive())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadManager.java
@@ -16,10 +16,7 @@
 
 package ai.starwhale.mlops.domain.dataset.dataloader;
 
-import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
-
 import ai.starwhale.mlops.api.protocol.dataset.dataloader.DataIndexDesc;
-import ai.starwhale.mlops.common.KeyLock;
 import ai.starwhale.mlops.domain.dataset.dataloader.bo.DataIndex;
 import ai.starwhale.mlops.domain.dataset.dataloader.bo.DataReadLog;
 import ai.starwhale.mlops.domain.dataset.dataloader.bo.Session;
@@ -49,61 +46,55 @@ public class DataReadManager {
         this.dataIndexProvider = dataIndexProvider;
     }
 
-    @Transactional(propagation = REQUIRES_NEW)
-    Session getOrGenerateSession(DataReadRequest request) {
+    public Session getSession(DataReadRequest request) {
         var sessionId = request.getSessionId();
-        var datasetName = request.getDatasetName();
         var datasetVersionId = request.getDatasetVersionId();
-        // ensure serially in the same session
-        var sessionLock = new KeyLock<>(String.format("%s-%s-%s", sessionId, datasetName, datasetVersionId));
-        try {
-            sessionLock.lock();
-            var session = sessionDao.selectOne(sessionId, datasetName, String.valueOf(datasetVersionId));
-            if (session == null) {
-                session = Session.builder()
-                        .sessionId(sessionId)
-                        .datasetName(request.getDatasetName())
-                        .datasetVersion(String.valueOf(request.getDatasetVersionId()))
-                        .tableName(request.getTableName())
-                        .start(request.getStart())
-                        .startInclusive(request.isStartInclusive())
-                        .end(request.getEnd())
-                        .endInclusive(request.isEndInclusive())
-                        .batchSize(request.getBatchSize())
-                        .build();
-                // insert session
-                sessionDao.insert(session);
-                // get data index
-                List<DataIndex> dataIndices = dataIndexProvider.returnDataIndex(
-                        QueryDataIndexRequest.builder()
-                            .tableName(session.getTableName())
-                            .batchSize(session.getBatchSize())
-                            .start(session.getStart())
-                            .startInclusive(session.isStartInclusive())
-                            .end(session.getEnd())
-                            .endInclusive(session.isEndInclusive())
-                            .build()
-                );
-                Long sid = session.getId();
-                Iterables.partition(
-                    dataIndices.stream()
-                        .map(dataIndex -> DataReadLog.builder()
-                            .sessionId(sid)
-                            .start(dataIndex.getStart())
-                            .startInclusive(dataIndex.isStartInclusive())
-                            .end(dataIndex.getEnd())
-                            .endInclusive(dataIndex.isEndInclusive())
-                            .size(dataIndex.getSize())
-                            .status(Status.DataStatus.UNPROCESSED)
-                            .build())
-                        .collect(Collectors.toList()),
-                    1000).forEach(dataReadLogDao::batchInsert);
 
-            }
-            return session;
-        } finally {
-            sessionLock.unlock();
-        }
+        return sessionDao.selectOne(sessionId, String.valueOf(datasetVersionId));
+    }
+
+    @Transactional
+    public Session generateSession(DataReadRequest request) {
+        var session = Session.builder()
+                    .sessionId(request.getSessionId())
+                    .datasetName(request.getDatasetName())
+                    .datasetVersion(String.valueOf(request.getDatasetVersionId()))
+                    .tableName(request.getTableName())
+                    .start(request.getStart())
+                    .startInclusive(request.isStartInclusive())
+                    .end(request.getEnd())
+                    .endInclusive(request.isEndInclusive())
+                    .batchSize(request.getBatchSize())
+                    .build();
+        // insert session
+        sessionDao.insert(session);
+        // get data index
+        List<DataIndex> dataIndices = dataIndexProvider.returnDataIndex(
+                QueryDataIndexRequest.builder()
+                    .tableName(session.getTableName())
+                    .batchSize(session.getBatchSize())
+                    .start(session.getStart())
+                    .startInclusive(session.isStartInclusive())
+                    .end(session.getEnd())
+                    .endInclusive(session.isEndInclusive())
+                    .build()
+        );
+        Long sid = session.getId();
+        Iterables.partition(
+            dataIndices.stream()
+                .map(dataIndex -> DataReadLog.builder()
+                    .sessionId(sid)
+                    .start(dataIndex.getStart())
+                    .startInclusive(dataIndex.isStartInclusive())
+                    .end(dataIndex.getEnd())
+                    .endInclusive(dataIndex.isEndInclusive())
+                    .size(dataIndex.getSize())
+                    .status(Status.DataStatus.UNPROCESSED)
+                    .build())
+                .collect(Collectors.toList()),
+            1000).forEach(dataReadLogDao::batchInsert);
+
+        return session;
 
     }
 
@@ -115,56 +106,40 @@ public class DataReadManager {
      * @return data
      */
     @Transactional
-    DataReadLog assignmentData(String consumerId, Session session) {
+    public DataReadLog assignmentData(String consumerId, Session session) {
         var sid = session.getId();
 
-        var sessionId = session.getSessionId();
-        var datasetName = session.getDatasetName();
-        var datasetVersion = session.getDatasetVersion();
-        // ensure serially in the same session
-        var sessionLock = new KeyLock<>(String.format("%s-%s-%s", sessionId, datasetName, datasetVersion));
-        try {
-            sessionLock.lock();
-            // get first
-            var dataRange = dataReadLogDao.selectTop1UnAssignedData(sid);
+        // get first
+        var dataRange = dataReadLogDao.selectTop1UnAssignedData(sid);
 
-            if (Objects.nonNull(dataRange)) {
-                dataRange.setConsumerId(consumerId);
-                dataRange.setAssignedNum(dataRange.getAssignedNum() + 1);
-                dataReadLogDao.updateToAssigned(dataRange);
-            }
-            return dataRange;
-        } finally {
-            sessionLock.unlock();
+        if (Objects.nonNull(dataRange)) {
+            dataRange.setConsumerId(consumerId);
+            dataRange.setAssignedNum(dataRange.getAssignedNum() + 1);
+            dataReadLogDao.updateToAssigned(dataRange);
+            log.info("Assignment data id: {} to consumer:{}", dataRange.getId(), dataRange.getConsumerId());
         }
-
+        return dataRange;
     }
 
     @Transactional
-    void handleConsumerData(String consumerId, boolean isSerial, List<DataIndexDesc> processedData, Session session) {
+    public void handleConsumerData(
+            String consumerId, boolean isSerial, List<DataIndexDesc> processedData, Session session) {
         var sid = session.getId();
-        var lock = new KeyLock<>(consumerId);
-        try {
-            lock.lock();
-            // update processed data
-            if (CollectionUtils.isNotEmpty(processedData)) {
-                for (DataIndexDesc indexDesc : processedData) {
-                    dataReadLogDao.updateToProcessed(sid, consumerId, indexDesc.getStart(), indexDesc.getEnd());
-                }
+        // update processed data
+        if (CollectionUtils.isNotEmpty(processedData)) {
+            for (DataIndexDesc indexDesc : processedData) {
+                dataReadLogDao.updateToProcessed(sid, consumerId, indexDesc.getStart(), indexDesc.getEnd());
             }
-            // Whether to process serially under the same consumer,
-            // if serial is true, unassigned the previous unprocessed data
-            if (isSerial) {
-                dataReadLogDao.updateUnProcessedToUnAssigned(sid, consumerId);
-            }
-        } finally {
-            lock.unlock();
         }
-
+        // Whether to process serially under the same consumer,
+        // if serial is true, unassigned the previous unprocessed data
+        if (isSerial) {
+            dataReadLogDao.updateUnProcessedToUnAssigned(sid, consumerId);
+        }
     }
 
     @Transactional
-    void resetUnProcessedData(String consumerId) {
+    public void resetUnProcessedData(String consumerId) {
         var res = dataReadLogDao.updateUnProcessedToUnAssigned(consumerId);
         log.info("Reset unprocessed data for consumer:{}, result:{}", consumerId, res);
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadRequest.java
@@ -30,7 +30,6 @@ import lombok.NoArgsConstructor;
 public class DataReadRequest {
     private String sessionId;
     private String consumerId;
-    private boolean isSerial = false;
 
     private String datasetName;
     private Long datasetVersionId;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataReadRequest.java
@@ -33,7 +33,7 @@ public class DataReadRequest {
     private boolean isSerial = false;
 
     private String datasetName;
-    private String datasetVersion;
+    private Long datasetVersionId;
     private String tableName;
 
     private int batchSize;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/dao/SessionDao.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/dao/SessionDao.java
@@ -40,8 +40,8 @@ public class SessionDao {
         return rows > 0;
     }
 
-    public Session selectOne(String sessionId, String datasetName, String datasetVersion) {
-        var entity = mapper.selectOne(sessionId, datasetName, datasetVersion);
+    public Session selectOne(String sessionId, String datasetVersion) {
+        var entity = mapper.selectOne(sessionId, datasetVersion);
         return entity != null ? converter.revert(entity) : null;
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/mapper/DataReadLogMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/mapper/DataReadLogMapper.java
@@ -97,7 +97,7 @@ public interface DataReadLogMapper {
     @Select("SELECT * from dataset_read_log "
             + "WHERE session_id=#{sessionId} and (consumer_id is null or consumer_id = '') and status=#{status} "
             + "ORDER BY id "
-            + "LIMIT 1")
+            + "LIMIT 1 ")
     DataReadLogEntity selectTop1UnAssigned(Long sessionId, String status);
 
     @Select("SELECT * from dataset_read_log "

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/mapper/SessionMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/mapper/SessionMapper.java
@@ -37,8 +37,8 @@ public interface SessionMapper {
     int insert(SessionEntity session);
 
     @Select("SELECT * from dataset_read_session "
-            + "WHERE session_id=#{sessionId} and dataset_name=#{datasetName} and dataset_version=#{datasetVersion}")
-    SessionEntity selectOne(String sessionId, String datasetName, String datasetVersion);
+            + "WHERE session_id=#{sessionId} and dataset_version=#{datasetVersion}")
+    SessionEntity selectOne(String sessionId, String datasetVersion);
 
     @Select("SELECT * from dataset_read_session WHERE id=#{id} FOR UPDATE")
     SessionEntity selectForUpdate(Long id);

--- a/server/controller/src/main/resources/db/migration/v0_4_0/V0_4_0_020__alter_constraint_for_dataset_read_session.sql
+++ b/server/controller/src/main/resources/db/migration/v0_4_0/V0_4_0_020__alter_constraint_for_dataset_read_session.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+ALTER TABLE dataset_read_session
+    DROP INDEX dataset_read_session_UN,
+    ADD UNIQUE INDEX dataset_read_session_UN(session_id,dataset_version) USING BTREE;

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/MultiConsumerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/MultiConsumerTest.java
@@ -121,10 +121,10 @@ public class MultiConsumerTest extends MySqlContainerHolder {
             private final String datasetName;
             private final String datasetVersion;
             private final int errorNum;
-            private final int datasetNum;
+            private final long datasetNum;
             private int retryNum = 0;
 
-            ConsumerMock(String consumerId, String datasetName, String datasetVersion, int errorNum, int datasetNum) {
+            ConsumerMock(String consumerId, String datasetName, String datasetVersion, int errorNum, long datasetNum) {
                 this.consumerId = consumerId;
                 this.datasetName = datasetName;
                 this.datasetVersion = datasetVersion;
@@ -139,7 +139,6 @@ public class MultiConsumerTest extends MySqlContainerHolder {
                             .consumerId(consumerId)
                             .isSerial(isSerial)
                             .datasetName(datasetName)
-                            .datasetVersion(datasetVersion)
                             .tableName("test-table-name")
                             .processedData(List.of())
                             .batchSize(batchSize)
@@ -148,9 +147,9 @@ public class MultiConsumerTest extends MySqlContainerHolder {
                             .end(null)
                             .endInclusive(true)
                             .build();
-                for (int i = 0; i < datasetNum; i++) {
+                for (long i = 0; i < datasetNum; i++) {
                     // mock multi datasets
-                    request.setDatasetVersion(datasetVersion + i);
+                    request.setDatasetVersionId(i);
                     // TODO
                     request.setProcessedData(null);
                     for (; ; ) {

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/MultiConsumerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/MultiConsumerTest.java
@@ -44,12 +44,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -84,27 +82,24 @@ public class MultiConsumerTest extends MySqlContainerHolder {
     @Autowired
     private DataReadLogConverter dataReadLogConverter;
 
-    public static Stream<Arguments> provideMultiParams() {
-        return Stream.of(
-            Arguments.of(0, false, 1),
-            Arguments.of(2, false, 1),
-            Arguments.of(6, false, 1),
-            Arguments.of(10, false, 1),
-            Arguments.of(0, true, 2),
-            Arguments.of(2, true, 2),
-            Arguments.of(6, true, 2),
-            Arguments.of(10, true, 2),
-            Arguments.of(0, false, 3),
-            Arguments.of(2, false, 3),
-            Arguments.of(6, false, 3),
-            Arguments.of(10, false, 3)
-        );
-    }
-
     @ParameterizedTest
-    @MethodSource("provideMultiParams")
-    public void testMultiConsumerRead(int errorNumPerConsumer, boolean isSerial, int datasetNum)
-            throws InterruptedException, ExecutionException {
+    @CsvSource(value = {
+            "1,0,false,1",
+            "2,2,false,1",
+            "3,6,false,1",
+            "4,10,false,1",
+            "5,0,true,2",
+            "6,2,true,2",
+            "7,6,true,2",
+            "8,10,true,2",
+            "9,0,false,3",
+            "10,2,false,3",
+            "11,6,false,3",
+            "12,10,false,3"
+    })
+    public void testMultiConsumerRead(
+            String consumptionRound, int errorNumPerConsumer, boolean isSerial, int datasetNum
+    ) throws InterruptedException, ExecutionException {
 
         var sessionId = "session" + errorNumPerConsumer + isSerial + datasetNum;
         var datasetName = "test-name";
@@ -119,15 +114,13 @@ public class MultiConsumerTest extends MySqlContainerHolder {
         class ConsumerMock implements Runnable {
             private final String consumerId;
             private final String datasetName;
-            private final String datasetVersion;
             private final int errorNum;
             private final long datasetNum;
             private int retryNum = 0;
 
-            ConsumerMock(String consumerId, String datasetName, String datasetVersion, int errorNum, long datasetNum) {
+            ConsumerMock(String consumerId, String datasetName, int errorNum, long datasetNum) {
                 this.consumerId = consumerId;
                 this.datasetName = datasetName;
-                this.datasetVersion = datasetVersion;
                 this.errorNum = errorNum;
                 this.datasetNum = datasetNum;
             }
@@ -150,7 +143,6 @@ public class MultiConsumerTest extends MySqlContainerHolder {
                 for (long i = 0; i < datasetNum; i++) {
                     // mock multi datasets
                     request.setDatasetVersionId(i);
-                    // TODO
                     request.setProcessedData(null);
                     for (; ; ) {
                         var dataRange = dataLoader.next(request);
@@ -198,12 +190,12 @@ public class MultiConsumerTest extends MySqlContainerHolder {
         // first consumption with error
         List<Future<?>> futures = new ArrayList<>();
         for (int i = 0; i < consumerNum; i++) {
-            var consumerId = String.valueOf(i);
+            var consumerId = consumptionRound + i;
             if (errorNumPerConsumer > 0) {
                 errorConsumers.add(consumerId);
             }
             futures.add(executor.submit(
-                new ConsumerMock(consumerId, datasetName, datasetVersion, errorNumPerConsumer, datasetNum)));
+                new ConsumerMock(consumerId, datasetName, errorNumPerConsumer, datasetNum)));
         }
 
         for (Future<?> future : futures) {
@@ -221,9 +213,9 @@ public class MultiConsumerTest extends MySqlContainerHolder {
 
         // try again
         futures.clear();
-        for (int i = 0; i < 2; i++) {
+        for (String errorConsumer : errorConsumers) {
             futures.add(executor.submit(
-                    new ConsumerMock(String.valueOf(i), datasetName, datasetVersion, 0, datasetNum)));
+                    new ConsumerMock(errorConsumer, datasetName, 0, datasetNum)));
         }
 
         for (Future<?> future : futures) {
@@ -275,7 +267,7 @@ public class MultiConsumerTest extends MySqlContainerHolder {
         // insert a session
         var sessionId = "000000000000000001";
         var datasetName = "test-name";
-        var datasetVersion = "test-version";
+        var datasetVersion = "1";
         var session = Session.builder()
                 .sessionId(sessionId)
                 .datasetName(datasetName)
@@ -290,7 +282,7 @@ public class MultiConsumerTest extends MySqlContainerHolder {
 
         assertEquals(1, sessionMapper.insert(sessionConverter.convert(session)));
 
-        var result = sessionMapper.selectOne(sessionId, datasetName, datasetVersion);
+        var result = sessionMapper.selectOne(sessionId, datasetVersion);
 
         assertEquals(session.getDatasetName(), result.getDatasetName());
         assertEquals(session.getDatasetVersion(), result.getDatasetVersion());

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/MultiConsumerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/MultiConsumerTest.java
@@ -84,26 +84,24 @@ public class MultiConsumerTest extends MySqlContainerHolder {
 
     @ParameterizedTest
     @CsvSource(value = {
-            "1,0,false,1",
-            "2,2,false,1",
-            "3,6,false,1",
-            "4,10,false,1",
-            "5,0,true,2",
-            "6,2,true,2",
-            "7,6,true,2",
-            "8,10,true,2",
-            "9,0,false,3",
-            "10,2,false,3",
-            "11,6,false,3",
-            "12,10,false,3"
+            "1,0,1",
+            "2,2,1",
+            "3,6,1",
+            "4,10,1",
+            "5,0,2",
+            "6,2,2",
+            "7,6,2",
+            "8,10,2",
+            "9,0,3",
+            "10,2,3",
+            "11,6,3",
+            "12,10,3"
     })
-    public void testMultiConsumerRead(
-            String consumptionRound, int errorNumPerConsumer, boolean isSerial, int datasetNum
-    ) throws InterruptedException, ExecutionException {
+    public void testMultiConsumerRead(String consumptionRound, int errorNumPerConsumer, int datasetNum)
+            throws InterruptedException, ExecutionException {
 
-        var sessionId = "session" + errorNumPerConsumer + isSerial + datasetNum;
+        var sessionId = "session" + errorNumPerConsumer + datasetNum;
         var datasetName = "test-name";
-        var datasetVersion = "test-version";
         var batchSize = 10;
 
         AtomicInteger count = new AtomicInteger(0);
@@ -130,7 +128,6 @@ public class MultiConsumerTest extends MySqlContainerHolder {
                 var request = DataReadRequest.builder()
                             .sessionId(sessionId)
                             .consumerId(consumerId)
-                            .isSerial(isSerial)
                             .datasetName(datasetName)
                             .tableName("test-table-name")
                             .processedData(List.of())

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/ReadRangeTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/ReadRangeTest.java
@@ -155,7 +155,7 @@ public class ReadRangeTest {
         var sid = 2L;
         var sessionId = "1-session";
         var datasetName = "test-name";
-        var datasetVersion = "test-version";
+        var datasetVersion = 1L;
         var tableName = "test-table-name";
         var consumerIdFor1 = "1";
         var consumerIdFor2 = "2";
@@ -164,7 +164,7 @@ public class ReadRangeTest {
                 .consumerId(consumerIdFor1)
                 .tableName(tableName)
                 .datasetName(datasetName)
-                .datasetVersion(datasetVersion)
+                .datasetVersionId(datasetVersion)
                 .isSerial(isSerial)
                 .processedData(List.of())
                 .batchSize(2)
@@ -175,7 +175,7 @@ public class ReadRangeTest {
                 .build();
 
         // case 1: generate
-        given(sessionDao.selectOne(sessionId, datasetName, datasetVersion))
+        given(sessionDao.selectOne(sessionId, datasetName, String.valueOf(datasetVersion)))
                 .willReturn(null);
         given(sessionDao.insert(any())).willAnswer((Answer<Boolean>) invocation -> {
             var session = invocation.getArgument(0, Session.class);
@@ -257,7 +257,7 @@ public class ReadRangeTest {
                 .batchSize(2)
                 .build();
 
-        given(sessionDao.selectOne(sessionId, datasetName, datasetVersion))
+        given(sessionDao.selectOne(sessionId, datasetName, String.valueOf(datasetVersion)))
                 .willReturn(session);
         given(dataReadLogDao.selectTop1UnAssignedData(sid))
                 .willReturn(DataReadLog.builder()

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/ReadRangeTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/ReadRangeTest.java
@@ -175,8 +175,7 @@ public class ReadRangeTest {
                 .build();
 
         // case 1: generate
-        given(sessionDao.selectOne(sessionId, datasetName, String.valueOf(datasetVersion)))
-                .willReturn(null);
+        given(sessionDao.selectOne(sessionId, String.valueOf(datasetVersion))).willReturn(null);
         given(sessionDao.insert(any())).willAnswer((Answer<Boolean>) invocation -> {
             var session = invocation.getArgument(0, Session.class);
             session.setId(sid);
@@ -257,8 +256,7 @@ public class ReadRangeTest {
                 .batchSize(2)
                 .build();
 
-        given(sessionDao.selectOne(sessionId, datasetName, String.valueOf(datasetVersion)))
-                .willReturn(session);
+        given(sessionDao.selectOne(sessionId, String.valueOf(datasetVersion))).willReturn(session);
         given(dataReadLogDao.selectTop1UnAssignedData(sid))
                 .willReturn(DataReadLog.builder()
                         .id(2L)

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/ReadRangeTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/ReadRangeTest.java
@@ -19,7 +19,6 @@ package ai.starwhale.mlops.domain.dataset.dataloader;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -35,12 +34,8 @@ import ai.starwhale.mlops.domain.dataset.dataloader.dao.DataReadLogDao;
 import ai.starwhale.mlops.domain.dataset.dataloader.dao.SessionDao;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.stubbing.Answer;
 
 public class ReadRangeTest {
@@ -142,16 +137,8 @@ public class ReadRangeTest {
         verify(dataStore, times(4)).scan(any());
     }
 
-    public static Stream<Arguments> provideMultiParams() {
-        return Stream.of(
-                Arguments.of(true, 2),
-                Arguments.of(false, 0)
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideMultiParams")
-    public void testNextDataRange(boolean isSerial, int executeCount) {
+    @Test
+    public void testNextDataRange() {
         var sid = 2L;
         var sessionId = "1-session";
         var datasetName = "test-name";
@@ -165,7 +152,6 @@ public class ReadRangeTest {
                 .tableName(tableName)
                 .datasetName(datasetName)
                 .datasetVersionId(datasetVersion)
-                .isSerial(isSerial)
                 .processedData(List.of())
                 .batchSize(2)
                 .start("0000-000")
@@ -283,7 +269,6 @@ public class ReadRangeTest {
 
         verify(dataStore, times(1)).scan(any());
         verify(dataReadLogDao, times(2)).updateToAssigned(any());
-        verify(dataReadLogDao, times(executeCount)).updateUnProcessedToUnAssigned(eq(sid), eq(consumerIdFor1));
         verify(dataReadLogDao, times(1))
                 .updateToProcessed(sid, consumerIdFor1, "0000-000", "0000-001");
         verify(sessionDao, times(1)).insert(any());


### PR DESCRIPTION
## Description

1. tune method to public when annotation with transactional
2. tune the constrain of data read log from dataset version to dataset version id
3. remove isSerial param

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
