### PR TITLE
bug(ci): fix no Makefile example for e2e

### DIFF
--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -368,6 +368,10 @@ class TestCli:
 
     def test_all(self) -> None:
         for name, example in ALL_EXAMPLES.items():
+            if not os.path.exists(os.path.join(example["workdir"], "Makefile")):
+                logger.info("no Makefile found, skip prepare data")
+                continue
+
             logger.info(f"preparing data for {example}")
             process = subprocess.Popen(
                 ["make", "CN=1", "prepare"],


### PR DESCRIPTION
## Description

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
