### PR TITLE
bug(sdk): resolve the 'evaluate phase cannot read tables in standalone' issue

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -1355,7 +1355,7 @@ class LocalDataStore:
         self,
         prefixes: List[str],
     ) -> List[str]:
-        table_names = []
+        table_names = set()
 
         for prefix in prefixes:
             prefix_path = Path(self.root_path) / prefix.strip("/")
@@ -1366,9 +1366,13 @@ class LocalDataStore:
                 table_name = str(fpath.relative_to(self.root_path)).split(
                     datastore_table_file_ext
                 )[0]
-                table_names.append(table_name)
+                table_names.add(table_name)
 
-        return table_names
+            for table in self.tables:
+                if table.startswith(prefix):
+                    table_names.add(table)
+
+        return list(table_names)
 
     def update_table(
         self,

--- a/client/starwhale/api/_impl/evaluation.py
+++ b/client/starwhale/api/_impl/evaluation.py
@@ -365,8 +365,7 @@ class PipelineHandler(metaclass=ABCMeta):
                         duration_seconds=_duration,
                     )
 
-        if self.predict_auto_log:
-            self.evaluation_store.flush_results()
+        self.evaluation_store.flush_all()
 
         console.info(
             f"{self.context.step}-{self.context.index} received {received_rows_cnt} data items for dataset {self.dataset_uris}"

--- a/client/tests/sdk/test_data_store.py
+++ b/client/tests/sdk/test_data_store.py
@@ -1103,7 +1103,7 @@ class TestLocalDataStore(BaseTestCase):
     def test_list_tables(self) -> None:
         ds = data_store.LocalDataStore(self.datastore_root)
 
-        prefix = "/project/self/eval/test-0/"
+        prefix = "project/self/eval/test-0/"
 
         tables = ds.list_tables([prefix])
         assert tables == []
@@ -1118,10 +1118,22 @@ class TestLocalDataStore(BaseTestCase):
         ensure_dir(root / "mock-dir.sw-datastore.zip")
         ensure_file(root / "dummy.file", "abc", parents=True)
 
+        m_table_name = f"{prefix}memory-test-table"
+        ds.tables[m_table_name] = data_store.MemoryTable(
+            m_table_name, ColumnSchema("k", INT64)
+        )
+
         tables = ds.list_tables([prefix])
         assert set(tables) == {
             f"{prefix.strip('/')}/{k}"
-            for k in {"labels", "results", "roc/0", "roc/1", "roc/2"}
+            for k in {
+                "labels",
+                "results",
+                "roc/0",
+                "roc/1",
+                "roc/2",
+                "memory-test-table",
+            }
         }
 
     def test_data_store_scan(self) -> None:


### PR DESCRIPTION
## Description
for `huge-tasks` example in standalone:
[![asciicast](https://asciinema.org/a/608835.svg)](https://asciinema.org/a/608835)

- changes:
  - add `flush_all` for predict phase
  - tune `list_tables` in standalone 

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
