### PR TITLE
fix(e2e): can not find pytest after open api test

### DIFF
--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -238,6 +238,7 @@ open_api_model_test() {
       git diff
       exit 1
     fi
+    popd
 }
 
 client_test() {


### PR DESCRIPTION
## Description

```
python -m datamodel_code_generator --allow-population-by-field-name --disable-timestamp --custom-file-header '# Generated by make gen-model. DO NOT EDIT!' --url http://e2e-20230925.pre.intra.starwhale.ai/v3/api-docs/Api --snake-case-field --output starwhale/base/client/models/models.py
The input file type was determined to be: openapi
This can be specificied explicitly with the `--input-file-type` option.
/starwhale/.venv/lib/python3.8/site-packages/pydantic/main.py:309: UserWarning: Pydantic serializer warnings:
  Expected `Union[list[definition-ref], definition-ref, bool]` but got `JsonSchemaObject` - serialized value may not be as expected
  return self.__pydantic_serializer__.to_python(
/starwhale/.venv/lib/python3.8/site-packages/pydantic/main.py:309: UserWarning: Pydantic serializer warnings:
  Expected `Union[list[definition-ref], definition-ref, bool]` but got `JsonSchemaObject` - serialized value may not be as expected
  Expected `Union[definition-ref, bool]` but got `JsonSchemaObject` - serialized value may not be as expected
  return self.__pydantic_serializer__.to_python(
+ git diff --exit-code
+ echo 'openapi model is up to date'
+ api_test
openapi model is up to date
+ pushd ../apitest/pytest
start_test.sh: line 264: pushd: ../apitest/pytest: No such file or directory
+ exit_hook
```

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
