### PR TITLE
fix(controller): fix job load blocked by write operation

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobServiceForWeb.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobServiceForWeb.java
@@ -294,6 +294,7 @@ public class JobServiceForWeb {
     /**
      * jobStatus PAUSED->RUNNING; taskStatus PAUSED->CREATED jobStatus FAILED->RUNNING; taskStatus PAUSED->CREATED
      */
+    @WriteOperation
     public void resumeJob(String jobUrl) {
         Long jobId = jobDao.getJobId(jobUrl);
         Job job = jobDao.findJobById(jobId);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/cache/JobLoader.java
@@ -22,7 +22,6 @@ import ai.starwhale.mlops.domain.task.bo.Task;
 import ai.starwhale.mlops.domain.task.status.TaskStatus;
 import ai.starwhale.mlops.domain.task.status.WatchableTask;
 import ai.starwhale.mlops.domain.task.status.WatchableTaskFactory;
-import ai.starwhale.mlops.domain.upgrade.rollup.aspectcut.WriteOperation;
 import ai.starwhale.mlops.schedule.SwTaskScheduler;
 import ai.starwhale.mlops.schedule.reporting.TaskReportReceiver;
 import java.util.Collection;
@@ -56,7 +55,6 @@ public class JobLoader {
         this.taskReportReceiver = taskReportReceiver;
     }
 
-    @WriteOperation
     public Job load(@NotNull Job job, Boolean resumePausedOrFailTasks) {
         //wrap task with watchers
         job.getSteps().forEach(step -> {


### PR DESCRIPTION
## Description
`HotJobsLoader` loads jobs when old instance `READY_DOWN`, but `WriteOperationCare` blocks `jobloader.load` until old instance `DOWN`
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
