### PR TITLE
chore(datastore): use revison instead of timestamp as record versions

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
@@ -311,7 +311,7 @@ public class DataStoreController {
                 .rawResult(request.isRawResult())
                 .encodeWithType(request.isEncodeWithType())
                 .ignoreNonExistingTable(request.isIgnoreNonExistingTable())
-                .timestamp(StringUtils.hasText(request.getRevision()) ? Long.parseLong(request.getRevision()) : 0)
+                .revision(StringUtils.hasText(request.getRevision()) ? Long.parseLong(request.getRevision()) : 0)
                 .build());
     }
 
@@ -502,13 +502,13 @@ public class DataStoreController {
                                         "table name should not be null or empty: " + x
                                 );
                             }
-                            var ts = StringUtils.hasText(x.getRevision()) ? Long.parseLong(x.getRevision()) : 0;
+                            var revision = StringUtils.hasText(x.getRevision()) ? Long.parseLong(x.getRevision()) : 0;
                             return DataStoreScanRequest.TableInfo.builder()
                                     .tableName(x.getTableName())
                                     .columnPrefix(x.getColumnPrefix())
                                     .columns(DataStoreController.convertColumns(x.getColumns()))
                                     .keepNone(x.isKeepNone())
-                                    .timestamp(ts)
+                                    .revision(revision)
                                     .build();
                         })
                         .collect(Collectors.toList()))

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreQueryRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreQueryRequest.java
@@ -31,7 +31,7 @@ public class DataStoreQueryRequest {
 
     private String tableName;
     // timestamp in milliseconds, used to filter out the data that is older than the timestamp for this table
-    private long timestamp;
+    private long revision;
     private Map<String, String> columns;
     private List<OrderByDesc> orderBy;
     private boolean descending;

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreScanRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStoreScanRequest.java
@@ -37,15 +37,14 @@ public class DataStoreScanRequest {
 
         private String tableName;
         // timestamp in milliseconds, used to filter out the data that is older than the timestamp for this table
-        private long timestamp;
+        private long revision;
         private String columnPrefix;
         private Map<String, String> columns;
         private boolean keepNone;
     }
 
     private List<TableInfo> tables;
-    // timestamp in milliseconds, used to filter out the data that is older than the timestamp for all tables
-    private long timestamp;
+    private long revision;
     private String start;
     private String startType;
     @Builder.Default

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
@@ -58,5 +58,7 @@ public interface MemoryTable {
 
     long getLastUpdateTime();
 
+    long getLastRevision();
+
     Map<String, ColumnStatistics> getColumnStatistics(Map<String, String> columnMapping);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryRecord.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryRecord.java
@@ -25,7 +25,7 @@ import lombok.Getter;
 @Builder
 public class MemoryRecord {
 
-    private long timestamp;
+    private long revision;
     private boolean deleted;
     private Map<String, BaseValue> values;
 

--- a/server/controller/src/main/protobuf/table_meta.proto
+++ b/server/controller/src/main/protobuf/table_meta.proto
@@ -5,4 +5,5 @@ option java_package = "ai.starwhale.mlops.datastore";
 message MetaData {
   int64 last_wal_log_id = 1;
   int64 last_update_time = 2;
+  int64 last_revision = 3;
 }

--- a/server/controller/src/main/protobuf/wal.proto
+++ b/server/controller/src/main/protobuf/wal.proto
@@ -50,5 +50,5 @@ message WalEntry {
   TableSchema table_schema = 3;
   repeated Record records = 4;
   int64 id = 5;
-  int64 timestamp = 6;
+  int64 revision = 6;
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
@@ -637,6 +637,7 @@ public class MemoryTableImplTest {
 
         @Test
         public void testUpdateFromWal() throws IOException {
+            this.memoryTable.setUseTimestampAsRevision(true);
             this.memoryTable.update(
                     new TableSchemaDesc("key", List.of(
                             ColumnSchemaDesc.builder().name("key").type("STRING").build(),
@@ -776,6 +777,7 @@ public class MemoryTableImplTest {
                     }
                 });
             }
+            this.memoryTable.setUseTimestampAsRevision(false);
             this.memoryTable.update(desc, records);
             MemoryTableImplTest.this.walManager.terminate();
             MemoryTableImplTest.this.walManager = new WalManager(MemoryTableImplTest.this.storageAccessService,
@@ -3085,24 +3087,17 @@ public class MemoryTableImplTest {
         }
 
         @Test
-        public void testQueryScanTimestamp() throws Exception {
-            var t1 = System.currentTimeMillis();
-            Thread.sleep(100);
-            this.memoryTable.update(this.memoryTable.getSchema().toTableSchemaDesc(),
+        public void testQueryScanVersion() {
+            var t1 = this.memoryTable.getLastRevision();
+            var t2 = this.memoryTable.update(this.memoryTable.getSchema().toTableSchemaDesc(),
                     List.of(Map.of("key", "0", "d", "7", "e", "8"),
                             Map.of("key", "9", "d", "6")));
-            var t2 = System.currentTimeMillis();
-            Thread.sleep(100);
-            this.memoryTable.update(this.memoryTable.getSchema().toTableSchemaDesc(),
+            var t3 = this.memoryTable.update(this.memoryTable.getSchema().toTableSchemaDesc(),
                     List.of(Map.of("key", "0", "d", "8", "h", "t"),
                             Map.of("key", "9", "-", "1")));
-            var t3 = System.currentTimeMillis();
-            Thread.sleep(100);
-            this.memoryTable.update(this.memoryTable.getSchema().toTableSchemaDesc(),
+            var t4 = this.memoryTable.update(this.memoryTable.getSchema().toTableSchemaDesc(),
                     List.of(Map.of("key", "0", "d", "9"),
                             Map.of("key", "9", "d", "8")));
-            var t4 = System.currentTimeMillis();
-            Thread.sleep(100);
             this.memoryTable.update(this.memoryTable.getSchema().toTableSchemaDesc(),
                     List.of(Map.of("key", "a", "d", "7")));
             var columns = Map.of("d", "d", "e", "e", "h", "h");


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
