### PR TITLE
chore(client): rm lock when dumping table

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -1906,13 +1906,12 @@ class LocalTable:
         mem_table.records.clear()
 
     def dump(self) -> None:
-        with self.lock:
-            if self._immutable_memory_table is not None:
-                self._dump(self.root_path, self._immutable_memory_table)
-                self._immutable_memory_table = None
-            if self.memory_table is not None:
-                self._dump(self.root_path, self.memory_table)
-                self.memory_table = None
+        if self._immutable_memory_table is not None:
+            self._dump(self.root_path, self._immutable_memory_table)
+            self._immutable_memory_table = None
+        if self.memory_table is not None:
+            self._dump(self.root_path, self.memory_table)
+            self.memory_table = None
 
     def _dump_manifest(self, manifest: Manifest) -> None:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:

--- a/client/tests/sdk/test_data_store.py
+++ b/client/tests/sdk/test_data_store.py
@@ -28,6 +28,7 @@ from starwhale.api._impl.data_store import (
     SwTupleType,
     IterWithRangeHint,
     TableWriterException,
+    datastore_max_dirty_records,
 )
 
 
@@ -2630,6 +2631,19 @@ def test_local_table_tombstones(tmp_path: Path):
         {"*": 1, "k": 1, "v": 2},
         {"*": 5, "k": 5, "v": 5},
     ]
+
+
+def test_local_table_dump(tmp_path: Path):
+    table = LocalTable("foo", tmp_path, key_column="k")
+    # put amount of rows to trigger auto dump
+    for i in range(datastore_max_dirty_records + 500):
+        table.insert({"k": i, "v": i})
+    # call dump manually
+    table.dump()
+
+    # open table again
+    table = LocalTable("foo", tmp_path, key_column="k")
+    assert len(list(table.scan())) == datastore_max_dirty_records + 500
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
