### PR TITLE
fix(datastore): query limit without deleted rows

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
@@ -260,7 +260,11 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
                 --skipCount;
             }
             while (iterator.hasNext() && limitCount > 0) {
-                results.add(iterator.next());
+                var r = iterator.next();
+                if (r.isDeleted()) {
+                    continue;
+                }
+                results.add(r);
                 --limitCount;
             }
             String lastKey;
@@ -290,7 +294,6 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
                 columnSchemaMap = null;
             }
             var records = results.stream()
-                    .filter(r -> !r.isDeleted())
                     .map(r -> RecordEncoder.encodeRecord(r.getValues(), req.isRawResult(), req.isEncodeWithType()))
                     .collect(Collectors.toList());
             return new RecordList(columnSchemaMap,

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/DataStoreTest.java
@@ -245,6 +245,17 @@ public class DataStoreTest {
                         .columnValueHints(List.of("1", "2", "3", "4", "5"))
                         .build())));
 
+        // query with limit without deleted rows
+        this.dataStore.update("t1", desc, List.of(Map.of("k", "0", "-", "1")));
+        recordList = this.dataStore.query(DataStoreQueryRequest.builder().tableName("t1").limit(2).build());
+        assertThat("test",
+                   recordList.getRecords(),
+                   is(List.of(Map.of("k", "1", "a", "00000004"),
+                              Map.of("k", "2", "a", "00000003"))));
+
+        // revert deleted rows
+        this.dataStore.update("t1", desc, List.of(Map.of("k", "0", "a", "5")));
+
         recordList = this.dataStore.query(DataStoreQueryRequest.builder()
                 .tableName("t1")
                 .filter(TableQueryFilter.builder()


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
