### PR TITLE
feat(client): support auto copy artifact when run or serve

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -42,30 +42,21 @@ prepare(){
         $(bash "${SW_USER_RUNTIME_WORKDIR:-/opt/starwhale.user/runtime}"/activate.sw)
     fi
 
-    if [ "${SW_INSTANCE_URI}" == "local" ]; then
-        if [ -z "${SW_MODEL_URI}" ]; then
-            SW_MODEL_URI="local/project/${SW_PROJECT}/model/${SW_MODEL_VERSION}"
-        fi
-        if [ -z "${SW_RUNTIME_URI}" ]; then
-            SW_RUNTIME_URI="local/project/${SW_PROJECT}/runtime/${SW_RUNTIME_VERSION}"
-        fi
-    else
-        echo '-->[Preparing] login...'
-        swcli instance login --token "${SW_TOKEN}" --alias server ${SW_INSTANCE_URI}
-        if [ -z "${SW_MODEL_URI}" ]; then
-            SW_MODEL_URI="cloud://server/project/${SW_PROJECT}/model/${SW_MODEL_VERSION}"
-        fi
-        if [ -z "${SW_RUNTIME_URI}" ]; then
-            SW_RUNTIME_URI="cloud://server/project/${SW_PROJECT}/runtime/${SW_RUNTIME_VERSION}"
-        fi
+    if [ "${SW_INSTANCE_URI}" != "local" ]; then
+        echo '-->[Preparing] login to server...'
+        swcli instance login --token "${SW_TOKEN}" --alias server "${SW_INSTANCE_URI}"
     fi
 }
 
-run() {
-    if [ -z "${SW_PROJECT_URI}" ]; then
-        echo "-->[Error] There needs an environment variable: SW_PROJECT_URI, now will exit."
+# since 0.6.0
+compatibility_check() {
+    if [ -z "${SW_PROJECT_URI}" ] || [ -z "${SW_MODEL_URI}" ] || { [ -z "${SW_RUNTIME_URI}" ] && [ "${RUNTIME_RESTORED}" != "1" ];}; then
+        echo "-->[Error] The following variables are missing: SW_PROJECT_URI or SW_MODEL_URI or SW_RUNTIME_URI, possible reason: your server version is lower, please upgrade the server to at least 0.6.0, now will exit."
         exit 1
     fi;
+}
+
+run() {
     if [ "${SW_TASK_DISABLE_DEBUG}" = "1" ]; then
         echo "-->[Preparing] debug config ..."
         VERBOSE="-v"
@@ -160,10 +151,10 @@ ds_build_and_upload () {
 welcome "$1"
 case "$1" in
     run|evaluation|fine_tune)
-        prepare && run
+        compatibility_check && prepare && run
         ;;
     serve|serving)
-        prepare && serve
+        compatibility_check && prepare && serve
         ;;
     dev)
         prepare && run_code_server

--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -22,8 +22,10 @@ welcome() {
     echo "Date: `date -u +%Y-%m-%dT%H:%M:%SZ`"
     echo "Version: `swcli --version`"
     echo "Run: $1 "
-    echo "Model Version: ${SW_MODEL_VERSION}"
-    echo "Runtime Version: ${SW_RUNTIME_VERSION}"
+    echo "Instance: ${SW_INSTANCE_URI}"
+    echo "Project: ${SW_PROJECT_URI}, ${SW_PROJECT}"
+    echo "Model Version: ${SW_MODEL_URI}, ${SW_MODEL_VERSION}"
+    echo "Runtime Version: ${SW_RUNTIME_URI}, ${SW_RUNTIME_VERSION}"
     echo "Runtime Restored: ${SW_USER_RUNTIME_RESTORED}"
     echo "Local User: ${SW_USER:-root}"
     echo "===================================="
@@ -36,53 +38,49 @@ welcome() {
 
 prepare(){
     if [ "${RUNTIME_RESTORED}" == "1" ]; then
+        echo '-->[Preparing] Runtime has been restored, activate it...'
         $(bash "${SW_USER_RUNTIME_WORKDIR:-/opt/starwhale.user/runtime}"/activate.sw)
     fi
 
-    if [ "${SW_INSTANCE_URI}" != "local" ]
-    then
-        # only remote
-        echo '-->[Preparing] pulling model ...'
+    if [ "${SW_INSTANCE_URI}" == "local" ]; then
+        if [ -z "${SW_MODEL_URI}" ]; then
+            SW_MODEL_URI="local/project/${SW_PROJECT}/model/${SW_MODEL_VERSION}"
+        fi
+        if [ -z "${SW_RUNTIME_URI}" ]; then
+            SW_RUNTIME_URI="local/project/${SW_PROJECT}/runtime/${SW_RUNTIME_VERSION}"
+        fi
+    else
+        echo '-->[Preparing] login...'
         swcli instance login --token "${SW_TOKEN}" --alias server ${SW_INSTANCE_URI}
         if [ -z "${SW_MODEL_URI}" ]; then
-            swcli model copy cloud://server/project/${SW_PROJECT}/model/${SW_MODEL_VERSION} .
-        else
-            swcli model copy ${SW_MODEL_URI} .
+            SW_MODEL_URI="cloud://server/project/${SW_PROJECT}/model/${SW_MODEL_VERSION}"
         fi
-        if [ "${RUNTIME_RESTORED}" != "1" ]; then
-            echo '-->[Preparing] pulling runtime ...'
-            if [ -z "${SW_RUNTIME_URI}" ]; then
-                swcli runtime copy cloud://server/project/${SW_PROJECT}/runtime/${SW_RUNTIME_VERSION} .
-            else
-                swcli runtime copy ${SW_RUNTIME_URI} .
-            fi
+        if [ -z "${SW_RUNTIME_URI}" ]; then
+            SW_RUNTIME_URI="cloud://server/project/${SW_PROJECT}/runtime/${SW_RUNTIME_VERSION}"
         fi
     fi
 }
 
 run() {
+    if [ -z "${SW_PROJECT_URI}" ]; then
+        echo "-->[Error] There needs an environment variable: SW_PROJECT_URI, now will exit."
+        exit 1
+    fi;
     if [ "${SW_TASK_DISABLE_DEBUG}" = "1" ]; then
         echo "-->[Preparing] debug config ..."
         VERBOSE="-v"
     fi
     echo "-->[Running] start to run model: ${STEP}, use $(which swcli) cli ..."
     if [ "${RUNTIME_RESTORED}" != "1" ]; then
-        runtime_args="--runtime ${SW_RUNTIME_VERSION}"
+        runtime_args="--runtime ${SW_RUNTIME_URI}"
     else
         runtime_args="--forbid-packaged-runtime"
     fi
-    if [ -z "${SW_PROJECT_URI}" ]; then
-        echo "-->[Error] There needs an environment variable: SW_PROJECT_URI, now will exit."
-        exit 1
-    else
-        # http://controller:8082/project/starwhale:starwhale
-        log_project="${SW_PROJECT_URI}"
-    fi;
 
     swcli ${VERBOSE} model run --handler="${HANDLER}" --step="${STEP}" \
         --task-index="${TASK_INDEX}" --override-task-num="${TASK_NUM}" \
-        --uri="${SW_MODEL_VERSION}" --version="${SW_JOB_VERSION}" \
-        --log-project="${log_project}" \
+        --uri="${SW_MODEL_URI}" --version="${SW_JOB_VERSION}" \
+        --log-project="${SW_PROJECT_URI}" \
         --forbid-snapshot \
         ${runtime_args} -- "${SW_TASK_EXTRA_CMD_ARGS}" || exit 1
 }
@@ -91,9 +89,9 @@ serve() {
     echo "-->[Serving] start to serve, use $(which swcli) cli ..."
     export
     if [ "${RUNTIME_RESTORED}" != "1" ]; then
-        swcli ${VERBOSE} model serve --uri "${SW_MODEL_VERSION}" --runtime "${SW_RUNTIME_VERSION}" --host 0.0.0.0 || exit 1
+        swcli ${VERBOSE} model serve --uri "${SW_MODEL_URI}" --runtime "${SW_RUNTIME_URI}" --host 0.0.0.0 || exit 1
     else
-        swcli ${VERBOSE} model serve --uri "${SW_MODEL_VERSION}" --host 0.0.0.0 --forbid-packaged-runtime || exit 1
+        swcli ${VERBOSE} model serve --uri "${SW_MODEL_URI}" --host 0.0.0.0 --forbid-packaged-runtime || exit 1
     fi
 }
 

--- a/client/starwhale/base/bundle_copy.py
+++ b/client/starwhale/base/bundle_copy.py
@@ -139,7 +139,7 @@ class BundleCopy(CloudRequestMixed):
     def _get_versioned_resource_path(self, uri: Resource) -> Path:
         if not uri.instance.is_local:
             raise NoSupportError(f"{uri} to get target dir path")
-
+        # TODO move it to resource uri or resource store to build up
         return (
             self._sw_config.rootdir
             / uri.project.id

--- a/client/starwhale/base/store.py
+++ b/client/starwhale/base/store.py
@@ -34,7 +34,11 @@ class BaseStorage(metaclass=ABCMeta):
     def __init__(self, uri: Resource) -> None:
         self.uri = uri
         self.sw_config = SWCliConfigMixed()
-        self.project_dir = self.sw_config.rootdir / self.uri.project.id
+        if self.uri.instance.is_cloud:
+            self.project_dir = self.sw_config.rootdir / ".cache" / self.uri.project.id
+            # TODO check if exist and download to local?
+        else:
+            self.project_dir = self.sw_config.rootdir / self.uri.project.id
         self.blob_dir = self.sw_config.rootdir / ".swblob"
         self.loc, self.id = self._guess()
 

--- a/client/starwhale/base/store.py
+++ b/client/starwhale/base/store.py
@@ -34,11 +34,7 @@ class BaseStorage(metaclass=ABCMeta):
     def __init__(self, uri: Resource) -> None:
         self.uri = uri
         self.sw_config = SWCliConfigMixed()
-        if self.uri.instance.is_cloud:
-            self.project_dir = self.sw_config.rootdir / ".cache" / self.uri.project.id
-            # TODO check if exist and download to local?
-        else:
-            self.project_dir = self.sw_config.rootdir / self.uri.project.id
+        self.project_dir = self.sw_config.rootdir / self.uri.project.id
         self.blob_dir = self.sw_config.rootdir / ".swblob"
         self.loc, self.id = self._guess()
 

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -6,7 +6,6 @@ import typing as t
 import threading
 from copy import deepcopy
 from enum import Enum, unique
-from uuid import uuid1
 from queue import Queue
 from types import TracebackType
 from functools import partial
@@ -14,7 +13,7 @@ from collections import UserDict, defaultdict
 
 from typing_extensions import Protocol
 
-from starwhale.utils import console, validate_obj_name
+from starwhale.utils import console, gen_uniq_version, validate_obj_name
 from starwhale.consts import ENV_POD_NAME
 from starwhale.utils.fs import DIGEST_SIZE
 from starwhale.base.mixin import ASDictMixin, _do_asdict_convert
@@ -585,7 +584,7 @@ class CloudTDSC(TabularDatasetSessionConsumption):
         self.session_end = session_end
         self.dataset_uri = dataset_uri
         self.run_env = _RunEnvType.POD
-        self.consumer_id = os.environ.get(ENV_POD_NAME) or uuid1().hex
+        self.consumer_id = os.environ.get(ENV_POD_NAME) or gen_uniq_version()
 
         self._do_validate()
 

--- a/client/starwhale/core/dataset/tabular.py
+++ b/client/starwhale/core/dataset/tabular.py
@@ -6,6 +6,7 @@ import typing as t
 import threading
 from copy import deepcopy
 from enum import Enum, unique
+from uuid import uuid1
 from queue import Queue
 from types import TracebackType
 from functools import partial
@@ -584,7 +585,7 @@ class CloudTDSC(TabularDatasetSessionConsumption):
         self.session_end = session_end
         self.dataset_uri = dataset_uri
         self.run_env = _RunEnvType.POD
-        self.consumer_id = os.environ.get(ENV_POD_NAME)
+        self.consumer_id = os.environ.get(ENV_POD_NAME) or uuid1().hex
 
         self._do_validate()
 

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -17,7 +17,7 @@ from starwhale.consts.env import SWEnv
 from starwhale.utils.error import NoSupportError
 from starwhale.core.model.view import get_term_view, ModelTermView
 from starwhale.base.uri.project import Project
-from starwhale.core.model.model import ModelConfig, ModelInfoFilter
+from starwhale.core.model.model import ModelConfig, ModelInfoFilter, Model
 from starwhale.core.model.store import ModelStorage
 from starwhale.base.uri.resource import Resource, ResourceType
 from starwhale.core.runtime.process import Process
@@ -777,6 +777,13 @@ def _prepare_model_run_args(
 
     if model:
         model_uri = Resource(model, typ=ResourceType.model)
+        if model_uri.instance.is_cloud:
+            Model.copy(
+                src_uri=model_uri,
+                dest_uri=".",
+                force=False,
+                dest_local_project_uri="local/project/.sw_project_cache", # TODO 是否隐藏该项目？
+            )
         model_store = ModelStorage(model_uri)
         model_src_dir = model_store.src_dir
 
@@ -792,6 +799,9 @@ def _prepare_model_run_args(
             runtime_uri = model_uri
     else:
         model_src_dir = Path(workdir)
+
+    if runtime_uri.instance.is_cloud:
+
 
     model_src_dir = model_src_dir.absolute().resolve()
     if model_yaml is None:

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -12,15 +12,15 @@ from click_option_group import (
 )
 
 from starwhale.consts import DefaultYAMLName, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
-from starwhale.core.runtime.model import Runtime
 from starwhale.utils.cli import AliasedGroup
 from starwhale.consts.env import SWEnv
 from starwhale.utils.error import NoSupportError
 from starwhale.core.model.view import get_term_view, ModelTermView
 from starwhale.base.uri.project import Project
-from starwhale.core.model.model import ModelConfig, ModelInfoFilter, Model
+from starwhale.core.model.model import Model, ModelConfig, ModelInfoFilter
 from starwhale.core.model.store import ModelStorage
 from starwhale.base.uri.resource import Resource, ResourceType
+from starwhale.core.runtime.model import Runtime
 from starwhale.core.runtime.process import Process
 
 
@@ -761,6 +761,9 @@ def _serve(
     )
 
 
+_cache_project_uri = "local/project/.cache"
+
+
 def _prepare_model_run_args(
     model: str,
     runtime: str,
@@ -782,9 +785,12 @@ def _prepare_model_run_args(
             Model.copy(
                 src_uri=model_uri,
                 dest_uri=".",
-                dest_local_project_uri="local/project/.cache",
+                dest_local_project_uri=_cache_project_uri,
             )
-            model_uri = Resource(f"local/project/.cache/{model_uri.name}/version/{model_uri.version}", typ=ResourceType.model)
+            model_uri = Resource(
+                f"{_cache_project_uri}/{model_uri.name}/version/{model_uri.version}",
+                typ=ResourceType.model,
+            )
         model_store = ModelStorage(model_uri)
         model_src_dir = model_store.src_dir
 
@@ -801,13 +807,16 @@ def _prepare_model_run_args(
     else:
         model_src_dir = Path(workdir)
 
-    if runtime_uri.instance.is_cloud:
+    if runtime_uri and runtime_uri.instance.is_cloud:
         Runtime.copy(
             src_uri=runtime_uri,
             dest_uri=".",
-            dest_local_project_uri="local/project/.cache",
+            dest_local_project_uri=_cache_project_uri,
         )
-        runtime_uri = Resource(f"local/project/.cache/{runtime_uri.name}/version/{runtime_uri.version}", typ=ResourceType.runtime)
+        runtime_uri = Resource(
+            f"{_cache_project_uri}/{runtime_uri.name}/version/{runtime_uri.version}",
+            typ=ResourceType.runtime,
+        )
 
     model_src_dir = model_src_dir.absolute().resolve()
     if model_yaml is None:

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -12,6 +12,7 @@ from click_option_group import (
 )
 
 from starwhale.consts import DefaultYAMLName, DEFAULT_PAGE_IDX, DEFAULT_PAGE_SIZE
+from starwhale.core.runtime.model import Runtime
 from starwhale.utils.cli import AliasedGroup
 from starwhale.consts.env import SWEnv
 from starwhale.utils.error import NoSupportError
@@ -781,9 +782,9 @@ def _prepare_model_run_args(
             Model.copy(
                 src_uri=model_uri,
                 dest_uri=".",
-                force=False,
-                dest_local_project_uri="local/project/.sw_project_cache", # TODO 是否隐藏该项目？
+                dest_local_project_uri="local/project/.cache",
             )
+            model_uri = Resource(f"local/project/.cache/{model_uri.name}/version/{model_uri.version}", typ=ResourceType.model)
         model_store = ModelStorage(model_uri)
         model_src_dir = model_store.src_dir
 
@@ -801,7 +802,12 @@ def _prepare_model_run_args(
         model_src_dir = Path(workdir)
 
     if runtime_uri.instance.is_cloud:
-
+        Runtime.copy(
+            src_uri=runtime_uri,
+            dest_uri=".",
+            dest_local_project_uri="local/project/.cache",
+        )
+        runtime_uri = Resource(f"local/project/.cache/{runtime_uri.name}/version/{runtime_uri.version}", typ=ResourceType.runtime)
 
     model_src_dir = model_src_dir.absolute().resolve()
     if model_yaml is None:

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import yaml
-import respx
 from click.testing import CliRunner
 from requests_mock import Mocker
 from pyfakefs.fake_filesystem_unittest import TestCase
@@ -808,7 +807,6 @@ class StandaloneModelTestCase(TestCase):
     @patch("starwhale.utils.config.load_swcli_config")
     @patch("starwhale.core.model.model.Model.copy")
     @patch("starwhale.core.runtime.model.Runtime.copy")
-    @respx.mock
     def test_prepare_model_run_args(
         self,
         rm: Mocker,

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import yaml
+import respx
 from click.testing import CliRunner
 from requests_mock import Mocker
 from pyfakefs.fake_filesystem_unittest import TestCase
@@ -798,12 +799,40 @@ class StandaloneModelTestCase(TestCase):
             )
             m_call.assert_called_once_with("hi", shell=True)
 
+    @Mocker()
     @patch("starwhale.core.model.model.ModelConfig.do_validate")
     @patch(
         "starwhale.base.uri.resource.Resource._refine_local_rc_info",
         MagicMock(),
     )
-    def test_prepare_model_run_args(self, *args: t.Any) -> None:
+    @patch("starwhale.utils.config.load_swcli_config")
+    @patch("starwhale.core.model.model.Model.copy")
+    @patch("starwhale.core.runtime.model.Runtime.copy")
+    @respx.mock
+    def test_prepare_model_run_args(
+        self,
+        rm: Mocker,
+        rt_cp: MagicMock,
+        m_cp: MagicMock,
+        m_conf: MagicMock,
+        *args: t.Any,
+    ) -> None:
+        m_conf.return_value = {
+            "instances": {
+                "server": {"uri": "http://localhost", "sw_token": "token"},
+                "local": {"uri": "local", "current_project": "self"},
+            },
+            "current_instance": "local",
+            "storage": {"root": self.sw.rootdir},
+        }
+        rm.get(
+            "http://localhost/api/v1/project/sw",
+            json={"data": {"id": 1, "name": "self"}},
+        )
+        rm.get(
+            "http://localhost/api/v1/project/1/model/model-test?versionUrl=1234",
+            json={"data": {"id": 1, "name": "model-test"}},
+        )
         user_workdir = Path("/home/user/workdir")
 
         ensure_file(
@@ -841,6 +870,31 @@ class StandaloneModelTestCase(TestCase):
             parents=True,
         )
 
+        model_cache_snapshot_dir = (
+            self.sw.rootdir / ".cache/model/model-test/12/1234.swmp"
+        )
+        model_cache_snapshot_src_dir = model_cache_snapshot_dir / "src"
+        model_cache_snapshot_manifest_path = model_cache_snapshot_dir / "_manifest.yaml"
+        model_cache_snapshot_model_yaml_path = (
+            model_cache_snapshot_src_dir / "model.yaml"
+        )
+
+        ensure_file(
+            model_cache_snapshot_model_yaml_path,
+            content=yaml.safe_dump(
+                ModelConfig(name="cache-model", run={"modules": ["x.y.z"]}).asdict()
+            ),
+            parents=True,
+        )
+
+        ensure_file(
+            model_cache_snapshot_manifest_path,
+            content=yaml.safe_dump(
+                {"packaged_runtime": {"name": "cache-packaged-runtime"}}
+            ),
+            parents=True,
+        )
+
         cases = [
             (
                 {
@@ -856,6 +910,8 @@ class StandaloneModelTestCase(TestCase):
                     "config_name": "default",
                     "config_modules": ["a.b.c"],
                     "runtime_uri": None,
+                    "model_copy_count": 0,
+                    "runtime_copy_count": 0,
                 },
             ),
             (
@@ -872,6 +928,8 @@ class StandaloneModelTestCase(TestCase):
                     "config_name": "default",
                     "config_modules": ["a.b.c"],
                     "runtime_uri": None,
+                    "model_copy_count": 0,
+                    "runtime_copy_count": 0,
                 },
             ),
             (
@@ -888,6 +946,8 @@ class StandaloneModelTestCase(TestCase):
                     "config_name": "custom",
                     "config_modules": ["a.b.c", "d.e.f"],
                     "runtime_uri": None,
+                    "model_copy_count": 0,
+                    "runtime_copy_count": 0,
                 },
             ),
             (
@@ -907,6 +967,8 @@ class StandaloneModelTestCase(TestCase):
                         "model-test/version/1234",
                         typ=ResourceType.model,
                     ),
+                    "model_copy_count": 0,
+                    "runtime_copy_count": 0,
                 },
             ),
             (
@@ -926,6 +988,8 @@ class StandaloneModelTestCase(TestCase):
                         "runtime-test/version/1234",
                         typ=ResourceType.runtime,
                     ),
+                    "model_copy_count": 0,
+                    "runtime_copy_count": 0,
                 },
             ),
             (
@@ -942,6 +1006,27 @@ class StandaloneModelTestCase(TestCase):
                     "config_name": "built-model",
                     "config_modules": ["x.y.z"],
                     "runtime_uri": None,
+                    "model_copy_count": 0,
+                    "runtime_copy_count": 0,
+                },
+            ),
+            (
+                {
+                    "model": "cloud://server/project/sw/model-test/version/1234",
+                    "runtime": "",
+                    "workdir": "",
+                    "modules": "",
+                    "model_yaml": None,
+                    "forbid_packaged_runtime": True,
+                },
+                {
+                    "model_src_dir": self.sw.rootdir
+                    / ".cache/model/model-test/12/1234.swmp/src",
+                    "config_name": "cache-model",
+                    "config_modules": ["x.y.z"],
+                    "runtime_uri": None,
+                    "model_copy_count": 1,
+                    "runtime_copy_count": 0,
                 },
             ),
         ]
@@ -951,6 +1036,8 @@ class StandaloneModelTestCase(TestCase):
             assert expect["model_src_dir"] == model_src_dir
             assert expect["config_name"] == config.name
             assert expect["config_modules"] == config.run.modules
+            assert m_cp.call_count == expect["model_copy_count"]
+            assert rt_cp.call_count == expect["runtime_copy_count"]
             if runtime_uri is None:
                 assert expect["runtime_uri"] is None
             else:

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -672,20 +672,19 @@ class TestDatasetSessionConsumption(TestCase):
         }
 
         os.environ[ENV_POD_NAME] = ""
-        with self.assertRaises(RuntimeError):
-            rm.request(
-                HTTPMethod.GET,
-                f"{instance_uri}/api/v1/project/p",
-                json={"data": {"id": 1, "name": "p"}},
-            )
-            CloudTDSC(
-                Resource(
-                    "mnist/version/latest",
-                    typ=ResourceType.dataset,
-                    project=Project("cloud://test/project/p"),
-                ),
-                "",
-            )
+        rm.request(
+            HTTPMethod.GET,
+            f"{instance_uri}/api/v1/project/p",
+            json={"data": {"id": 1, "name": "p"}},
+        )
+        CloudTDSC(
+            Resource(
+                "mnist/version/latest",
+                typ=ResourceType.dataset,
+                project=Project("cloud://test/project/p"),
+            ),
+            "",
+        )
 
         rm.request(
             HTTPMethod.GET,

--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -347,7 +347,12 @@ class TestCli:
                 run_handler=run_handler,
             )
             self.run_model_in_standalone(
-                dataset_uris=[dataset_uri],
+                dataset_uris=[
+                    Resource(
+                        f"{self.cloud_target_project_uri}/{dataset_uri.name}/version/{dataset_uri.version}",
+                        typ=ResourceType.dataset,
+                    )
+                ],
                 model_uri=Resource(
                     f"{self.cloud_target_project_uri}/{model_uri.name}/version/{model_uri.version}",
                     typ=ResourceType.model,

--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -25,7 +25,7 @@ from cmds.artifacts_cmd import Model, Dataset, Runtime
 from starwhale.utils import config
 from starwhale.base.type import DatasetChangeMode
 from starwhale.utils.debug import init_logger
-from starwhale.base.uri.resource import Resource
+from starwhale.base.uri.resource import Resource, ResourceType
 
 CURRENT_DIR = os.path.dirname(__file__)
 SCRIPT_DIR = os.path.abspath(os.path.join(CURRENT_DIR, os.pardir))
@@ -344,6 +344,20 @@ class TestCli:
                 runtime_uris=[conda_runtime_uri]
                 if "simple" not in BUILT_IN_EXAMPLES
                 else [None],
+                run_handler=run_handler,
+            )
+            self.run_model_in_standalone(
+                dataset_uris=[dataset_uri],
+                model_uri=Resource(
+                    f"{self.cloud_target_project_uri}/{model_uri.name}/version/{model_uri.version}",
+                    typ=ResourceType.model,
+                ),
+                runtime_uris=[
+                    Resource(
+                        f"{self.cloud_target_project_uri}/{venv_runtime_uri.name}/version/{venv_runtime_uri.version}",
+                        typ=ResourceType.runtime,
+                    )
+                ],
                 run_handler=run_handler,
             )
 


### PR DESCRIPTION
## Description

1. Model run and serve's uriArgs can pass remoteUri, such as model-uri: cloud://server/project/simple-test/version/123456, runtime-uri: cloud://server/project/simple-test/version/654321
2. entrypoint use the unify cmd

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
