### PR TITLE
fix(datastore): remove dup entry in data store manifest

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -2089,7 +2089,8 @@ class LocalDataStore:
                 if t.name == table_name:
                     table_root = Path(self.root_path) / t.dir
                     break
-            if table_root is None:
+            existing = table_root is not None
+            if table_root is None:  # make mypy happy
                 if not create:
                     return None
                 uuid = uuid4().hex
@@ -2103,13 +2104,14 @@ class LocalDataStore:
                 key_column=key_column and key_column.name or None,
                 create_if_missing=create,
             )
-            manifest.tables.append(
-                LocalTableDesc(
-                    name=table_name,
-                    dir=str(table_root.relative_to(self.root_path)),
-                    created_at=int(time.time() * 1000),
+            if not existing:
+                manifest.tables.append(
+                    LocalTableDesc(
+                        name=table_name,
+                        dir=str(table_root.relative_to(self.root_path)),
+                        created_at=int(time.time() * 1000),
+                    )
                 )
-            )
             self._dump_manifest(manifest)
             self.tables[table_name] = table
             return table

--- a/client/tests/sdk/test_data_store.py
+++ b/client/tests/sdk/test_data_store.py
@@ -1155,6 +1155,13 @@ class TestLocalDataStore(BaseTestCase):
             "k", [data_store.ColumnSchema("k", data_store.INT64)]
         )
         ds.update_table(f"{prefix}/labels", schema, [{"k": 0}])
+        assert ds.list_tables([prefix]) == [f"{prefix.strip('/')}/labels"]
+
+        # release tables in memory and reload
+        ds.tables.clear()
+        ds.update_table(f"{prefix}/labels", schema, [{"k": 1}])
+        assert ds.list_tables([prefix]) == [f"{prefix.strip('/')}/labels"]
+
         ds.update_table(f"{prefix}/results", schema, [{"k": 0}])
 
         for i in range(0, 3):


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
