### PR TITLE
fix(datastore): prevent loading manifest in every insert

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -1649,7 +1649,7 @@ class LocalTable:
 
     @property
     def tombstones(self) -> List[TombstoneDesc]:
-        if not self._tombstones:
+        if self._tombstones is None:
             self._tombstones = self._load_manifest().get_tombstones(None)
         return self._tombstones
 


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
