### PR TITLE
enhance(dataset): expose exceptions from dataset copy threads

### DIFF
--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -1034,7 +1034,7 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
                 f":skull: failed to verify compatible dependencies for the {pybin} environment: \n{e.output.strip()}",
                 style="bold red",
             )
-            sys.exit(1)
+            raise
 
         python_version = get_python_version_by_bin(pybin)
         workdir = Path(tempfile.mkdtemp(suffix="starwhale-runtime-build-"))

--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import shutil
 import typing as t
 import platform

--- a/client/starwhale/utils/http.py
+++ b/client/starwhale/utils/http.py
@@ -12,7 +12,6 @@ from starwhale.utils import console
 def wrap_sw_error_resp(
     r: requests.Response,
     header: str,
-    exit: bool = False,
     use_raise: bool = False,
     silent: bool = False,
     ignore_status_codes: t.List[int] = [],
@@ -40,8 +39,6 @@ def wrap_sw_error_resp(
             return
 
         _print(Panel.fit(msg, title=":space_invader: error details"))  # type: ignore
-        if exit:
-            sys.exit(1)
 
         if use_raise:
             r.raise_for_status()

--- a/client/starwhale/utils/http.py
+++ b/client/starwhale/utils/http.py
@@ -1,4 +1,3 @@
-import sys
 import typing as t
 from http import HTTPStatus
 from functools import wraps

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -1338,7 +1338,7 @@ class StandaloneRuntimeTestCase(TestCase):
         m_check_call.side_effect = subprocess.CalledProcessError(
             1, "cmd", output="test"
         )
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(subprocess.CalledProcessError):
             sr.build_from_python_env(runtime_name=name, mode="conda")
 
     @patch("os.environ", {})

--- a/client/tests/sdk/test_dataset_sdk.py
+++ b/client/tests/sdk/test_dataset_sdk.py
@@ -1567,6 +1567,19 @@ class TestDatasetSDK(_DatasetSDKTestBase):
         assert make_version_req.call_count == 2
         assert upload_blob_req.call_count == 1
 
+        upload_blob_req = rm.register_uri(
+            HTTPMethod.POST,
+            re.compile(
+                f"http://1.1.1.1/api/v1/project/{project_id}/dataset/mnist/hashedBlob/"
+            ),
+            status_code=HTTPStatus.BAD_REQUEST,
+            json={"message": "error", "code": 400},
+        )
+        with self.assertRaisesRegex(
+            RuntimeError, "row updater threads raise exceptions"
+        ):
+            ds.copy("cloud://test/project/self", force=True)
+
     def test_commit_from_empty(self) -> None:
         dataset_name = "mnist"
         commit_msg = "test"


### PR DESCRIPTION
## Description
- issue:  When exceptions occur within the dataset copy threads, the main thread may fail to detect them.
  [![asciicast](https://asciinema.org/a/612774.svg)](https://asciinema.org/a/612774)
- remove some useless `sys.exit`

## Modules
- [x] Client
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
