### PR TITLE
chore(ci): fix e2e no disk space and TableWriter close issue

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -105,6 +105,18 @@ jobs:
           cache: "maven"
           server-id: starwhale # Value of the distributionManagement/repository/id field of the pom.xml
 
+      # Github default free runner provides 14GB of disk space, we should release some useless files for workarounds.
+      - name: Release disk space
+        run: |
+            echo "cleanup useless files..."
+            df -hT
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf /opt/ghc
+            sudo rm -rf "/usr/local/share/boost"
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"/{CodeQL,Ruby,go,node}
+            echo "cleanup done."
+            df -hT
+
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -2671,8 +2671,8 @@ class TableWriter(threading.Thread):
         self._run_exceptions_limits = max(run_exceptions_limits, 0)
 
         self.daemon = True
-        atexit.register(self.close)
         self.start()
+        atexit.register(self.close)
 
     def __enter__(self) -> Any:
         return self
@@ -2681,6 +2681,7 @@ class TableWriter(threading.Thread):
         self.close()
 
     def close(self) -> None:
+        self.flush()
         with self._cond:
             if not self._stopped:
                 atexit.unregister(self.close)


### PR DESCRIPTION
## Description
- for github runner disk, we got 29GB free disk space.
  - before:
    ```
    Filesystem     Type   Size  Used Avail Use% Mounted on
    /dev/root      ext4    84G   68G   17G  81% /
    tmpfs          tmpfs  3.4G  172K  3.4G   1% /dev/shm
    tmpfs          tmpfs  1.4G  1.1M  1.4G   1% /run
    tmpfs          tmpfs  5.0M     0  5.0M   0% /run/lock
    /dev/sdb15     vfat   105M  6.1M   99M   6% /boot/efi
    /dev/sda1      ext4    14G  4.1G  9.0G  [31](https://github.com/star-whale/starwhale/actions/runs/6494737098/job/17638393083?pr=2854#step:6:32)% /mnt
    tmpfs          tmpfs  693M   12K  693M   1% /run/user/1001
    ```
  - after: 
    ```
    Filesystem     Type   Size  Used Avail Use% Mounted on
    /dev/root      ext4    84G   56G   29G  67% /
    tmpfs          tmpfs  3.4G  172K  3.4G   1% /dev/shm
    tmpfs          tmpfs  1.4G  1.1M  1.4G   1% /run
    tmpfs          tmpfs  5.0M     0  5.0M   0% /run/lock
    /dev/sdb15     vfat   105M  6.1M   99M   6% /boot/efi
    /dev/sda1      ext4    14G  4.1G  9.0G  31% /mnt
    tmpfs          tmpfs  693M   12K  693M   1% /run/user/1001
    ```

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
