### PR TITLE
fix(controller): assign wrong data to the consumer which was not exists after readtimeout 

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataLoader.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/DataLoader.java
@@ -51,14 +51,7 @@ public class DataLoader {
 
         dataReadManager.handleConsumerData(consumerId, request.getProcessedData(), session);
 
-        // this lock can be replaced by select fot update in future
-        var lock = new KeyLock<>(String.format("dl-assignment-%s", session.getId()));
-        try {
-            lock.lock();
-            return dataReadManager.assignmentData(consumerId, session);
-        } finally {
-            lock.unlock();
-        }
+        return dataReadManager.assignmentData(consumerId, session);
     }
 
     /**

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/dao/DataReadLogDao.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/dao/DataReadLogDao.java
@@ -54,8 +54,8 @@ public class DataReadLogDao {
         return mapper.updateToUnAssignedForConsumer(consumerId, Status.DataStatus.UNPROCESSED.name()) > 0;
     }
 
-    public List<DataReadLog> selectTopsUnAssignedData(Long sid, Integer limit) {
-        var entities = mapper.selectTopsUnAssigned(sid, Status.DataStatus.UNPROCESSED.name(), limit);
-        return entities.stream().map(converter::revert).collect(Collectors.toList());
+    public DataReadLog selectTop1UnAssignedData(Long sid) {
+        var entity = mapper.selectTop1UnAssigned(sid, Status.DataStatus.UNPROCESSED.name());
+        return entity == null ? null : converter.revert(entity);
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/mapper/DataReadLogMapper.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/dataloader/mapper/DataReadLogMapper.java
@@ -88,9 +88,8 @@ public interface DataReadLogMapper {
     @Select("SELECT * from dataset_read_log "
             + "WHERE session_id=#{sessionId} and (consumer_id is null or consumer_id = '') and status=#{status} "
             + "ORDER BY id "
-            + "LIMIT #{limit}")
-    List<DataReadLogEntity> selectTopsUnAssigned(
-            @Param("sessionId") Long sessionId, @Param("status") String status, @Param("limit") Integer limit);
+            + "LIMIT 1 FOR UPDATE")
+    DataReadLogEntity selectTop1UnAssigned(@Param("sessionId") Long sessionId, @Param("status") String status);
 
     @Select("SELECT * from dataset_read_log "
             + "WHERE session_id in "

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/MultiConsumerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/MultiConsumerTest.java
@@ -320,8 +320,8 @@ public class MultiConsumerTest extends MySqlContainerHolder {
         ));
 
         // select top 1 unassigned
-        var top1UnAssigned = dataReadLogMapper.selectTopsUnAssigned(
-                result.getId(), Status.DataStatus.UNPROCESSED.name(), 1).get(0);
+        var top1UnAssigned = dataReadLogMapper.selectTop1UnAssigned(
+                result.getId(), Status.DataStatus.UNPROCESSED.name());
 
         assertNotNull(top1UnAssigned.getId());
         assertEquals(dataReadLog1.getSessionId(), top1UnAssigned.getSessionId());

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/ReadRangeTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/dataloader/ReadRangeTest.java
@@ -45,7 +45,6 @@ public class ReadRangeTest {
     private static DataStore dataStore;
     private static SessionDao sessionDao;
     private static DataReadLogDao dataReadLogDao;
-    private final Integer cacheSize = 1;
 
     @BeforeEach
     public void setup() {
@@ -54,7 +53,7 @@ public class ReadRangeTest {
         dataReadLogDao = mock(DataReadLogDao.class);
         dataRangeProvider = new DataStoreIndexProvider(dataStore);
         DataReadManager dataReadManager = new DataReadManager(
-                sessionDao, dataReadLogDao, dataRangeProvider, cacheSize);
+                sessionDao, dataReadLogDao, dataRangeProvider);
         dataLoader = new DataLoader(dataReadManager);
     }
 
@@ -170,14 +169,14 @@ public class ReadRangeTest {
             session.setId(sid);
             return true;
         });
-        given(dataReadLogDao.selectTopsUnAssignedData(sid, cacheSize))
-                .willReturn(List.of(DataReadLog.builder()
+        given(dataReadLogDao.selectTop1UnAssignedData(sid))
+                .willReturn(DataReadLog.builder()
                         .id(1L)
                         .sessionId(sid)
                         .start("0000-000").startInclusive(true)
                         .end("0000-001").endInclusive(true)
                         .size(2)
-                        .build()));
+                        .build());
 
         given(dataStore.scan(
                 DataStoreScanRequest.builder()
@@ -247,15 +246,15 @@ public class ReadRangeTest {
                 .build();
 
         given(sessionDao.selectOne(sessionId, String.valueOf(datasetVersion))).willReturn(session);
-        given(dataReadLogDao.selectTopsUnAssignedData(sid, cacheSize))
-                .willReturn(List.of(DataReadLog.builder()
+        given(dataReadLogDao.selectTop1UnAssignedData(sid))
+                .willReturn(DataReadLog.builder()
                         .id(2L)
                         .sessionId(sid)
                         .start("0000-002").startInclusive(true)
                         .end("0000-003").endInclusive(true)
                         .size(2)
                         .assignedNum(0)
-                        .build()));
+                        .build());
 
         dataRange = dataLoader.next(request);
 


### PR DESCRIPTION
## Description
close #2836 
The keyLock don't resolve the case of timeout, so it will be queued a long time even the client has been killed by the timeout error.

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
