### PR TITLE
fix(controller): fix when explicit_defaults_for_timestamp is off, run table could not be created

### DIFF
--- a/server/controller/src/main/resources/db/migration/v0_4_0/V0_4_0_023__add_run_for_task.sql
+++ b/server/controller/src/main/resources/db/migration/v0_4_0/V0_4_0_023__add_run_for_task.sql
@@ -24,8 +24,8 @@ create table run
     `run_spec`      JSON         not null,
     `ip`            varchar(255),
     `failed_reason` text,
-    `start_time`    timestamp(6),
-    `finish_time`   timestamp(6),
+    `start_time`    timestamp(6) NULL DEFAULT NULL,
+    `finish_time`   timestamp(6) NULL DEFAULT NULL,
     `created_time`  datetime     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `modified_time` datetime     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX           `idx_run_task` (`task_id`) USING BTREE


### PR DESCRIPTION
fix when explicit_defaults_for_timestamp is off, run table could not be created

## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
