### PR TITLE
chore(client): make unit test works after fastapi upgrade

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -65,8 +65,8 @@ jobs:
       - name: Install dependencies
         working-directory: ./client
         run: |
-          make install-sw
           make install-dev-req
+          make install-sw
 
       - name: Black Format Check
         working-directory: ./client

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -128,8 +128,8 @@ jobs:
       - name: Install dependencies
         working-directory: ./client
         run: |
-          make install-sw
           make install-dev-req
+          make install-sw
 
       - name: Git Config
         run: |


### PR DESCRIPTION
## Description

- FastApi==0.104.0 requires typing-extensions>=4.8.0
- TensorFlow requires typing-extensions<4.6.0

The unit test breaks when loading fastapi

```
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/fastapi/exceptions.py:6: in <module>
    from typing_extensions import Annotated, Doc  # type: ignore [attr-defined]
E   ImportError: cannot import name 'Doc' from 'typing_extensions' (/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/typing_extensions.py)
```

https://typing-extensions.readthedocs.io/en/latest/index.html#Doc

> New in version 4.8.0: See [PEP 727](https://peps.python.org/pep-0727/).

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
