### PR TITLE
enhance(client): remove `clear_cache` operation for data types

### DIFF
--- a/client/starwhale/api/_impl/dataset/builder/mapping_builder.py
+++ b/client/starwhale/api/_impl/dataset/builder/mapping_builder.py
@@ -84,10 +84,6 @@ class MappingDatasetBuilder(AsyncArtifactWriterBase):
                 )
                 self._stash_uri_rows_map[_path].append((artifact, td_row))
 
-            # TODO: find a graceful cleanup method
-            # forbid to write cache and fp contents into datastore table
-            artifact.clear_cache()
-
         self._tabular_dataset.put(td_row)
 
     def _handle_bin_sync(self, bin_path: Path) -> None:

--- a/client/starwhale/api/_impl/evaluation/log.py
+++ b/client/starwhale/api/_impl/evaluation/log.py
@@ -177,7 +177,6 @@ class Evaluation(AsyncArtifactWriterBase):
                 bin_offset=_meta.offset,
                 bin_size=_meta.size,
             )
-            v.clear_cache()
             _metrics = {k: v}
 
             _record: _TRecord
@@ -226,12 +225,12 @@ class Evaluation(AsyncArtifactWriterBase):
             Text(encoded) -> string
             Binary(encoded) -> bytes
         """
-        if isinstance(data, Text) and data.auto_convert_to_str:
-            # TODO: remove the owner assignment
+        if isinstance(data, BaseArtifact):
             data.owner = self._resource
+
+        if isinstance(data, Text) and data.auto_convert_to_str:
             return data.content
         elif isinstance(data, Binary) and data.auto_convert_to_bytes:
-            data.owner = self._resource
             return data.to_bytes()
         elif isinstance(data, dict):
             return {k: self._auto_decode_types(v) for k, v in data.items()}

--- a/client/starwhale/api/_impl/evaluation/pipeline.py
+++ b/client/starwhale/api/_impl/evaluation/pipeline.py
@@ -23,7 +23,7 @@ from starwhale.base.data_type import JsonDict
 from starwhale.core.job.store import JobStorage
 from starwhale.api._impl.dataset import Dataset
 from starwhale.base.uri.resource import Resource, ResourceType
-from starwhale.core.dataset.tabular import TabularDatasetRow, TabularDatasetInfo
+from starwhale.core.dataset.tabular import TabularDatasetInfo
 
 from .log import Evaluation
 
@@ -436,10 +436,6 @@ class PipelineHandler(metaclass=ABCMeta):
                 for k, v in features.items()
                 if k in self.predict_log_dataset_features
             }
-
-        for artifact in TabularDatasetRow.artifacts_of(_log_features):
-            if artifact.link:
-                artifact.clear_cache()
 
         input_features = {
             f"{self._INPUT_PREFIX}{k}": JsonDict.from_data(v)

--- a/client/tests/base/test_data_type.py
+++ b/client/tests/base/test_data_type.py
@@ -138,9 +138,9 @@ class TestDataType(TestCase):
         assert _asdict["display_name"] == "t"
         assert _asdict["shape"] == [28, 28, 3]
         assert json.loads(json.dumps(_asdict))["_type"] == "image"
-
-        with self.assertRaises(RuntimeError):
-            data_store._get_type(img)
+        t = data_store._get_type(img)
+        assert t.raw_type == Image
+        assert t.name == "object"
 
         img = Image(
             "path/to/file", display_name="t", shape=[28, 28, 3], mime_type=MIMEType.PNG
@@ -157,8 +157,6 @@ class TestDataType(TestCase):
         assert _asdict["_mime_type"] == MIMEType.GRAYSCALE.value
         assert _asdict["shape"] == [28, 28, 1]
         assert _asdict["_raw_base64_data"] == base64.b64encode(b"test").decode()
-        with self.assertRaises(RuntimeError):
-            data_store._get_type(img)
 
         self.fs.create_file("path/to/file", contents="")
         img = GrayscaleImage(Path("path/to/file"), shape=[28, 28, 1]).carry_raw_data()
@@ -238,7 +236,7 @@ class TestDataType(TestCase):
         _asdict = json.loads(json.dumps(text.asdict()))
         assert text.to_bytes() == b"test"
         assert "fp" not in _asdict
-        assert _asdict["_content"] == "test"
+        assert "_content" not in _asdict
         assert _asdict["_type"] == "text"
         assert _asdict["_mime_type"] == MIMEType.PLAIN.value
         assert text.to_str() == "test"
@@ -431,7 +429,6 @@ class TestJsonDict(TestCase):
                             "offset": data_store.INT64,
                             "size": data_store.INT64,
                             "data_type": data_store.UNKNOWN,
-                            "_signed_uri": data_store.STRING,
                             "extra_info": data_store.SwMapType(
                                 data_store.UNKNOWN, data_store.UNKNOWN
                             ),

--- a/client/tests/sdk/test_dataset.py
+++ b/client/tests/sdk/test_dataset.py
@@ -271,8 +271,6 @@ class TestDatasetCopy(BaseTestCase):
                     "attributes": [
                         {"name": "as_mask", "type": "BOOL"},
                         {"name": "mask_uri", "type": "STRING"},
-                        {"name": "fp", "type": "STRING"},
-                        {"name": "_BaseArtifact__cache_bytes", "type": "BYTES"},
                         {"name": "_type", "type": "STRING"},
                         {"name": "display_name", "type": "STRING"},
                         {"name": "_mime_type", "type": "STRING"},
@@ -292,7 +290,6 @@ class TestDatasetCopy(BaseTestCase):
                                 {"name": "offset", "type": "INT64"},
                                 {"name": "size", "type": "INT64"},
                                 {"name": "data_type", "type": "UNKNOWN"},
-                                {"name": "_signed_uri", "type": "STRING"},
                                 {
                                     "keyType": {"type": "UNKNOWN"},
                                     "name": "extra_info",
@@ -318,7 +315,7 @@ class TestDatasetCopy(BaseTestCase):
         for v in content["records"][0]["values"]:
             if v["key"] != "features/text":
                 continue
-            assert v["value"]["fp"] == ""
+            assert "fp" not in v["value"]
 
     @patch("os.environ", {})
     @Mocker()

--- a/client/tests/web/test_server.py
+++ b/client/tests/web/test_server.py
@@ -124,7 +124,6 @@ def test_datastore_query_table(mock_scan: MagicMock):
                 {"name": "offset", "type": "INT64"},
                 {"name": "size", "type": "INT64"},
                 {"name": "data_type", "type": "UNKNOWN"},
-                {"name": "_signed_uri", "type": "STRING"},
                 {
                     "keyType": {"type": "UNKNOWN"},
                     "name": "extra_info",
@@ -180,7 +179,6 @@ def test_datastore_query_table(mock_scan: MagicMock):
                 {"name": "offset", "type": "INT64"},
                 {"name": "size", "type": "INT64"},
                 {"name": "data_type", "type": "UNKNOWN"},
-                {"name": "_signed_uri", "type": "STRING"},
                 {
                     "keyType": {"type": "UNKNOWN"},
                     "name": "extra_info",
@@ -228,7 +226,6 @@ def test_datastore_query_table(mock_scan: MagicMock):
                 "type": "OBJECT",
                 "pythonType": "starwhale.base.data_type.Link",
                 "value": {
-                    "_signed_uri": {"type": "STRING", "value": ""},
                     "_type": {"type": "STRING", "value": "link"},
                     "data_type": {"type": "UNKNOWN", "value": "None"},
                     "extra_info": {"type": "MAP", "value": []},


### PR DESCRIPTION
## Description
- before change:
![image](https://github.com/star-whale/starwhale/assets/590748/e87c7410-69c7-4a6a-aeb3-102aadb8c623)

- after change:
![image](https://github.com/star-whale/starwhale/assets/590748/3993a959-353c-463a-bc90-720fd1ccf071)

no `fp`, `__cache_bytes`, `_signed_uri` fields.

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
