### PR TITLE
chore(client): workaround email-validator lib version in python3.7

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -44,6 +44,8 @@ install_requires = [
     "urllib3<1.27",
     "pydantic<2.0.0",  # current broker and fastapi lib code only work with pydantic < 2.0.0
     "sortedcontainers",
+    # workaround: email-validator 2.1.0 has a syntax error in python 3.7, but the email-validator is necessary for fastapi.
+    "email-validator <= 2.0.0; python_version < '3.8'",
 ]
 
 extras_require = {


### PR DESCRIPTION
## Description
- issue: https://github.com/star-whale/starwhale/actions/runs/6608203654/job/17946597295
- ![image](https://github.com/star-whale/starwhale/assets/590748/0d71f1a2-208e-4fdf-9e84-5ca334526f06)

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
