### PR TITLE
chore(controller): datastore use read-write lock

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
@@ -201,7 +201,7 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
         this.updateHandle.offer(new Object());
         var table = this.getTable(tableName, true, true);
         //noinspection ConstantConditions
-        table.lock();
+        table.lock(false);
         try {
             var ts = table.update(schema, records);
             synchronized (this.dirtyTables) {
@@ -213,7 +213,7 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
             synchronized (updateHandle) {
                 updateHandle.notifyAll();
             }
-            table.unlock();
+            table.unlock(false);
         }
 
     }
@@ -227,7 +227,7 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
         if (table == null) {
             return new RecordList(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList(), null, null);
         }
-        table.lock();
+        table.lock(true);
         try {
             int skipCount = req.getStart();
             if (skipCount < 0) {
@@ -303,7 +303,7 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
                     lastKey,
                     lastKeyType);
         } finally {
-            table.unlock();
+            table.unlock(true);
         }
     }
 
@@ -327,7 +327,7 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
                         .collect(Collectors.toList());
 
         for (var table : tablesToLock) {
-            table.lock();
+            table.lock(true);
         }
         try {
             class TableMeta {
@@ -495,7 +495,7 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
                     BaseValue.getColumnType(lastKey).name());
         } finally {
             for (var table : tablesToLock) {
-                table.unlock();
+                table.unlock(true);
             }
         }
     }
@@ -625,13 +625,13 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
             if (table == null) {
                 continue;
             }
-            table.lock();
+            table.lock(false);
             try {
                 if (table.getFirstWalLogId() >= 0 && table.getFirstWalLogId() < minWalLogIdToRetain) {
                     minWalLogIdToRetain = table.getFirstWalLogId();
                 }
             } finally {
-                table.unlock();
+                table.unlock(false);
             }
         }
         try {

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
@@ -50,9 +50,9 @@ public interface MemoryTable {
             boolean endInclusive,
             boolean keepNone);
 
-    void lock();
+    void lock(boolean forRead);
 
-    void unlock();
+    void unlock(boolean forRead);
 
     void save() throws IOException;
 


### PR DESCRIPTION
## Description
Test case(use 200 thread to scan the same table which has 20w data)
![image](https://github.com/star-whale/starwhale/assets/24869618/1b229160-4b00-4232-9822-19ec6f4cee05)

Speed up the scan processing on multi scan request case.

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
