### PR TITLE
chore(e2e): add jenkins e2e test case example

### DIFF
--- a/scripts/e2e_test/cases/api_test.sh
+++ b/scripts/e2e_test/cases/api_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x
+export CONTROLLER_HOST=${SWNAME//./-}.pre.intra.starwhale.ai
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_PATH=$( cd -- "$SCRIPT_DIR/../../.." &> /dev/null && pwd )
+export WORK_DIR=`mktemp -d`
+function cleanup {
+  rm -rf "$WORK_DIR"
+  echo "Deleted temp working directory $WORK_DIR"
+}
+trap cleanup EXIT
+pushd $WORK_DIR
+python3 -m venv venv && . venv/bin/activate && python3 -m pip install --upgrade pip
+popd
+pushd "$REPO_PATH"/scripts/apitest/pytest
+python3 -m pip install -r requirements.txt
+pytest --host ${CONTROLLER_HOST} --port 80 || exit 1
+popd

--- a/scripts/e2e_test/cases/install_swcli.sh
+++ b/scripts/e2e_test/cases/install_swcli.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -x
+export WORK_DIR=`mktemp -d`
+function cleanup {
+  rm -rf "$WORK_DIR"
+  echo "Deleted temp working directory $WORK_DIR"
+}
+trap cleanup EXIT
+pushd $WORK_DIR
+python3 -m venv venv && . venv/bin/activate && python3 -m pip install --upgrade pip
+pip install starwhale==$PYPI_RELEASE_VERSION
+swcli --version
+swcli instance list
+swcli ds list
+swcli dataset list
+swcli mp list
+swcli model list
+swcli rt list
+swcli runtime list
+popd

--- a/scripts/e2e_test/cases/install_swcli.sh
+++ b/scripts/e2e_test/cases/install_swcli.sh
@@ -8,6 +8,7 @@ function cleanup {
 }
 trap cleanup EXIT
 pushd $WORK_DIR
+export SW_LOCAL_STORAGE=$WORK_DIR
 python3 -m venv venv && . venv/bin/activate && python3 -m pip install --upgrade pip
 pip install starwhale==$PYPI_RELEASE_VERSION
 swcli --version


### PR DESCRIPTION
## Description
e2e case could be placed into a seperate file and re-run on Jenkins
## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
