### PR TITLE
fix(controller): make online eval runable

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/ContainerSpecification.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/ContainerSpecification.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 public interface ContainerSpecification {
     String FORMATTER_URI_PROJECT = "%s/project/%s";
+    String FORMATTER_URI_ARTIFACT = "%s/project/%s/%s/%s/version/%s";
+    String FORMATTER_VERSION_ARTIFACT = "%s/version/%s";
 
     Map<String, String> getContainerEnvs();
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/impl/SwCliModelHandlerContainerSpecification.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/impl/SwCliModelHandlerContainerSpecification.java
@@ -36,9 +36,6 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class SwCliModelHandlerContainerSpecification implements ContainerSpecification {
 
-
-    static final String FORMATTER_URI_ARTIFACT = "%s/project/%s/%s/%s/version/%s";
-    static final String FORMATTER_VERSION_ARTIFACT = "%s/version/%s";
     final String instanceUri;
     final int devPort;
     final int datasetLoadBatchSize;


### PR DESCRIPTION
## Description

```
+ compatibility_check
+ '[' -z '' ']'
+ echo '-->[Error] The following variables are missing: SW_PROJECT_URI or SW_MODEL_URI or SW_RUNTIME_URI, possible reason: your server version is lower, please upgrade the server to at least 0.6.0, now will exit.'
+ exit 1
-->[Error] The following variables are missing: SW_PROJECT_URI or SW_MODEL_URI or SW_RUNTIME_URI, possible reason: your server version is lower, please upgrade the server to at least 0.6.0, now will exit.
```

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
