### PR TITLE
bug(runtime): fix runtime.yaml arch field empty issue

### DIFF
--- a/client/starwhale/core/runtime/model.py
+++ b/client/starwhale/core/runtime/model.py
@@ -175,14 +175,14 @@ class DockerEnv(ASDictMixin):
 class Environment(ASDictMixin):
     def __init__(
         self,
-        arch: _t_mixed_str_list = "",
+        arch: _t_mixed_str_list | None = None,
         os: str = SupportOS.UBUNTU,
         python: str = "",
         cuda: str = "",
         cudnn: str = "",
         **kw: t.Any,
     ) -> None:
-        self.arch = _list(arch)
+        self.arch = _list(arch or [])
         self.os = os.lower()
 
         if not python:
@@ -2203,6 +2203,8 @@ class StandaloneRuntime(Runtime, LocalStorageBundleMixin):
 
     @staticmethod
     def _validate_environment(expected_arch: t.List[str]) -> None:
+        expected_arch = list(filter(None, map(str.strip, expected_arch)))
+
         # TODO: add os, cuda version, python version validator
         def _validate_arch() -> None:
             machine_map = {

--- a/client/tests/core/test_runtime.py
+++ b/client/tests/core/test_runtime.py
@@ -985,6 +985,7 @@ class StandaloneRuntimeTestCase(TestCase):
         assert _manifest["environment"]["mode"] == "venv"
         assert _manifest["environment"]["lock"]["shell"]["use_venv"]
         assert _manifest["environment"]["lock"]["starwhale_version"] == "0.0.0.dev0"
+        assert _manifest["environment"]["arch"] == []
         assert _manifest["artifacts"]["wheels"] == ["wheels/dummy.whl"]
         assert _manifest["artifacts"]["files"][0] == {
             "dest": "bin/../bin/prepare.sh",
@@ -1764,7 +1765,7 @@ class StandaloneRuntimeTestCase(TestCase):
                     "environment": {
                         "mode": "venv",
                         "python": "3.7",
-                        "arch": [SupportArch.AMD64],
+                        "arch": [],
                     },
                     "dependencies": {
                         "local_packaged_env": False,
@@ -2053,7 +2054,7 @@ class StandaloneRuntimeTestCase(TestCase):
                     "environment": {
                         "python": "3.7",
                         "mode": "conda",
-                        "arch": [SupportArch.ARM64],
+                        "arch": [""],
                         "lock": {"files": [".starwhale/lock/conda-sw-lock.yaml"]},
                     },
                     "dependencies": {

--- a/example/runtime/pytorch-e2e/runtime-3-10.yaml
+++ b/example/runtime/pytorch-e2e/runtime-3-10.yaml
@@ -8,7 +8,9 @@ dependencies:
       - echo "hello world"
 environment:
   python: "3.10"
-  arch: noarch
+  arch:
+    - amd64
+    - arm64
   os: ubuntu:20.04
 mode: venv
 name: pytorch310

--- a/example/runtime/pytorch-e2e/runtime-3-7.yaml
+++ b/example/runtime/pytorch-e2e/runtime-3-7.yaml
@@ -7,7 +7,6 @@ dependencies:
       - apt-get install libgl1
       - echo "hello world"
 environment:
-  arch: noarch
   os: ubuntu:20.04
   python: 3.7
 mode: venv

--- a/example/runtime/pytorch-e2e/runtime-3-9.yaml
+++ b/example/runtime/pytorch-e2e/runtime-3-9.yaml
@@ -8,7 +8,7 @@ dependencies:
       - echo "hello world"
 environment:
   python: 3.9
-  arch: noarch
+  arch: amd64
   os: ubuntu:20.04
 mode: venv
 name: pytorch39

--- a/scripts/example/runtime.yaml
+++ b/scripts/example/runtime.yaml
@@ -14,7 +14,9 @@ dependencies:
       - apt-get install -y libgl1
       - touch /tmp/runtime-command-run.flag
 environment:
-  arch: noarch
   os: ubuntu:20.04
+  arch:
+    - amd64
+    - arm64
 mode: venv
 name: simple-test

--- a/scripts/example/runtime_conda.yaml
+++ b/scripts/example/runtime_conda.yaml
@@ -11,7 +11,6 @@ dependencies:
   - commands:
       - echo "hello world"
 environment:
-  arch: noarch
   os: ubuntu:20.04
 mode: conda
 name: simple-test-conda


### PR DESCRIPTION
## Description
When we remove 'arch' field in the runtime.yaml, we will meet the following issue:
```bash
(starwhale) liutianwei@host005-bj01 ~/workdir/code/starwhale$ swcli runtime restore code-llama/v0                                                                                                                                                             example/code-llama 
🏌 try to restore python runtime environment: code-llama/v0 ...
⠋ validate environment condition... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0:00:00
╭───────────────────────────────────────────────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────────────────────────────────────────────╮
│ /home/liutianwei/.conda/envs/starwhale/bin/swcli:8 in <module>                                                                                                                                       │
│                                                                                                                                                                                                      │
│   5 from starwhale.cli import cli                                                                                                                                                                    │
│   6 if __name__ == '__main__':                                                                                                                                                                       │
│   7 │   sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])                                                                                                                             │
│ ❱ 8 │   sys.exit(cli())                                                                                                                                                                              │
│   9                                                                                                                                                                                                  │
│                                                                                                                                                                                                      │
│ /home/liutianwei/.conda/envs/starwhale/lib/python3.9/site-packages/click/core.py:1130 in __call__                                                                                                    │
│                                                                                                                                                                                                      │
│   1127 │                                                                                                                                                                                             │
│   1128 │   def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:                                                                                                                               │
│   1129 │   │   """Alias for :meth:`main`."""                                                                                                                                                         │
│ ❱ 1130 │   │   return self.main(*args, **kwargs)                                                                                                                                                     │
│   1131                                                                                                                                                                                               │
│   1132                                                                                                                                                                                               │
│   1133 class Command(BaseCommand):                                                                                                                                                                   │
│                                                                                                                                                                                                      │
│                                                                                       ... 11 frames hidden ...                                                                                       │
│                                                                                                                                                                                                      │
│ /mnt/data/tianwei/code/starwhale/client/starwhale/core/runtime/model.py:2230 in _validate_environment                                                                                                │
│                                                                                                                                                                                                      │
│   2227 │   │   │   │   )                                                                                                                                                                             │
│   2228 │   │                                                                                                                                                                                         │
│   2229 │   │   if expected_arch:                                                                                                                                                                     │
│ ❱ 2230 │   │   │   _validate_arch()                                                                                                                                                                  │
│   2231                                                                                                                                                                                               │
│   2232                                                                                                                                                                                               │
│   2233 class CloudRuntime(CloudBundleModelMixin, Runtime):                                                                                                                                           │
│                                                                                                                                                                                                      │
│ /mnt/data/tianwei/code/starwhale/client/starwhale/core/runtime/model.py:2225 in _validate_arch                                                                                                       │
│                                                                                                                                                                                                      │
│   2222 │   │   │   │   [a.lower() for a in expected_arch]                                                                                                                                            │
│   2223 │   │   │   )                                                                                                                                                                                 │
│   2224 │   │   │   if not _section:                                                                                                                                                                  │
│ ❱ 2225 │   │   │   │   raise UnExpectedConfigFieldError(                                                                                                                                             │
│   2226 │   │   │   │   │   f"machine arch: {machine}, expected arch: {expected_arch}"                                                                                                                │
│   2227 │   │   │   │   )                                                                                                                                                                             │
│   2228                                                                                                                                                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
UnExpectedConfigFieldError: machine arch: x86_64, expected arch: ['']
```

- fix the arch field issue
- add more tests

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
