### PR TITLE
fix(client): model serving handler can not run

### DIFF
--- a/client/starwhale/base/scheduler/task.py
+++ b/client/starwhale/base/scheduler/task.py
@@ -111,7 +111,7 @@ class TaskExecutor:
         from starwhale.api._impl.evaluation import PipelineHandler
 
         module = load_module(self.step.module_name, self.workdir)
-        cls_ = getattr(module, self.step.cls_name, None)
+        cls_ = self.step.cls_name and getattr(module, self.step.cls_name, None) or None
 
         if cls_ is None:
             # for internal function


### PR DESCRIPTION
## Description

related to 
- #2639

```
[2023-10-30 04:14:51.260742] ✈ change current dir to /root/.starwhale/.cache/model/mnist/jb/jbck7jh2lh75nffokiqhfrpvlljgp6kjz7vzz3sc.swmp/src
[2023-10-30 04:14:51.261419] ⏳ start to run model, handler:serving ...
[2023-10-30 04:14:51.271811] 🏦 runnable handlers:
[2023-10-30 04:14:51.272348]        [0]: mnist.evaluator:MNISTInference.evaluate
[2023-10-30 04:14:51.273061]        [1]: mnist.evaluator:MNISTInference.predict
[2023-10-30 04:14:51.273683]     *  [2]: serving
[2023-10-30 04:14:51.274412] 💡 |INFO| start to execute task: context(step:serving, index:0/1) step(Step: handler-starwhale.core.model.model:None.StandaloneModel._serve_handler, {'name': 'serving', 'show_name': 'virtual handler for model serving', 'module_name': 'starwhale.core.model.model', 'cls_name': None, 'func_name': 'StandaloneModel._serve_handler', 'resources': [], 'task_num': 1, 'needs': [], 'extra_args': [], 'extra_kwargs': {'search_modules': ['mnist.evaluator:MNISTInference']}, 'expose': 8080, 'virtual': True, 'require_dataset': None})
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /root/.starwhale/.cache/workdir/runtime/pytorch-cn-mirror/co/couqzxt6etn6n2hpol4jkuestfneorqgxou │
│                                                                                                  │
│   179 │   │   try:                                                                               │
│   180 │   │   │   self.__status = RunStatus.RUNNING                                              │
│   181 │   │   │   Context.set_runtime_context(self.context)                                      │
│ ❱ 182 │   │   │   self._do_execute()                                                             │
│   183 │   │   except Exception as e:                                                             │
│   184 │   │   │   console.print_exception()                                                      │
│   185 │   │   │   self.exception = e                                                             │
│                                                                                                  │
│ /root/.starwhale/.cache/workdir/runtime/pytorch-cn-mirror/co/couqzxt6etn6n2hpol4jkuestfneorqgxou │
│                                                                                                  │
│   111 │   │   from starwhale.api._impl.evaluation import PipelineHandler                         │
│   112 │   │                                                                                      │
│   113 │   │   module = load_module(self.step.module_name, self.workdir)                          │
│ ❱ 114 │   │   cls_ = getattr(module, self.step.cls_name, None)                                   │
│   115 │   │                                                                                      │
│   116 │   │   if cls_ is None:                                                                   │
│   117 │   │   │   # for internal function                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: getattr(): attribute name must be string
[2023-10-30 04:14:51.356449] 💡 |INFO| finish step:serving, index:0/1, status:failed, error:getattr(): attribute name must be string
```

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
