### PR TITLE
chore(db): change desc column's character set to utf8mb4

### DIFF
--- a/server/controller/src/main/resources/db/migration/v0_4_0/V0_4_0_027__update_character_set_for_desc_column.sql
+++ b/server/controller/src/main/resources/db/migration/v0_4_0/V0_4_0_027__update_character_set_for_desc_column.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+ALTER TABLE project_info MODIFY COLUMN project_description text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL;
+ALTER TABLE report MODIFY COLUMN description varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL;
+ALTER TABLE report MODIFY COLUMN content longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;


### PR DESCRIPTION
## Description

Support save emoji in project desc and report desc/content column(Current character set = utf8mb3).

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
