### PR TITLE
enhance(client): online serving handler support the latest gradio

### DIFF
--- a/client/starwhale/api/_impl/service.py
+++ b/client/starwhale/api/_impl/service.py
@@ -164,8 +164,10 @@ class Service:
         :param title webpage title
         :return: None
         """
+        # change the root path when running in docker and proxied by the starwhale controller
+        root_path = os.getenv("SW_ONLINE_SERVING_ROOT_PATH", "").strip()
         server = self._gen_gradio_server(title=title)
-        server.launch(server_name=addr, server_port=port)
+        server.launch(server_name=addr, server_port=port, root_path=root_path)
 
 
 _svc = Service()

--- a/server/controller/src/main/java/ai/starwhale/mlops/common/proxy/WebServerInTask.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/common/proxy/WebServerInTask.java
@@ -19,6 +19,7 @@ package ai.starwhale.mlops.common.proxy;
 import ai.starwhale.mlops.configuration.FeaturesProperties;
 import ai.starwhale.mlops.domain.job.cache.HotJobHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * proxy the request to the task
@@ -74,5 +75,14 @@ public class WebServerInTask implements Service {
         } else {
             return String.format("http://%s:%d", taskIp, port);
         }
+    }
+
+    public String generateServiceRoot(Long taskId, int port) {
+        if (featuresProperties.isJobProxyEnabled()) {
+            var root = String.format(TASK_GATEWAY_PATTERN, taskId, port);
+            // remove the last "/"
+            return StringUtils.trimTrailingCharacter(root, '/');
+        }
+        return "";
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/impl/SwCliModelHandlerContainerSpecification.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/impl/SwCliModelHandlerContainerSpecification.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.schedule.impl.container.impl;
 
+import ai.starwhale.mlops.common.proxy.WebServerInTask;
 import ai.starwhale.mlops.configuration.RunTimeProperties;
 import ai.starwhale.mlops.configuration.security.TaskTokenValidator;
 import ai.starwhale.mlops.domain.job.bo.Job;
@@ -42,6 +43,8 @@ public class SwCliModelHandlerContainerSpecification implements ContainerSpecifi
     final RunTimeProperties runTimeProperties;
     final TaskTokenValidator taskTokenValidator;
 
+    private final WebServerInTask webServerInTask;
+
     final Task task;
 
     public SwCliModelHandlerContainerSpecification(
@@ -50,6 +53,7 @@ public class SwCliModelHandlerContainerSpecification implements ContainerSpecifi
             @Value("${sw.dataset.load.batch-size}") int datasetLoadBatchSize,
             RunTimeProperties runTimeProperties,
             TaskTokenValidator taskTokenValidator,
+            WebServerInTask webServerInTask,
             Task task
     ) {
         this.instanceUri = instanceUri;
@@ -57,6 +61,7 @@ public class SwCliModelHandlerContainerSpecification implements ContainerSpecifi
         this.datasetLoadBatchSize = datasetLoadBatchSize;
         this.runTimeProperties = runTimeProperties;
         this.taskTokenValidator = taskTokenValidator;
+        this.webServerInTask = webServerInTask;
         this.task = task;
     }
 
@@ -152,6 +157,12 @@ public class SwCliModelHandlerContainerSpecification implements ContainerSpecifi
             coreContainerEnvs.put("SW_DEV_PORT", String.valueOf(devPort));
         }
         coreContainerEnvs.put("SW_POD_NAME", task.getId().toString());
+
+        // for online eval
+        if (task.getStep().getSpec() != null && task.getStep().getSpec().getExpose() != 0) {
+            coreContainerEnvs.put("SW_ONLINE_SERVING_ROOT_PATH",
+                    webServerInTask.generateServiceRoot(task.getId(), task.getStep().getSpec().getExpose()));
+        }
 
         return coreContainerEnvs;
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/impl/SwCliModelHandlerSpecificationFactory.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/impl/SwCliModelHandlerSpecificationFactory.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.schedule.impl.container.impl;
 
+import ai.starwhale.mlops.common.proxy.WebServerInTask;
 import ai.starwhale.mlops.configuration.RunTimeProperties;
 import ai.starwhale.mlops.configuration.security.TaskTokenValidator;
 import ai.starwhale.mlops.domain.task.bo.Task;
@@ -35,25 +36,35 @@ public class SwCliModelHandlerSpecificationFactory implements TaskContainerSpeci
     final RunTimeProperties runTimeProperties;
     final TaskTokenValidator taskTokenValidator;
 
+    private final WebServerInTask webServerInTask;
+
     public SwCliModelHandlerSpecificationFactory(
             @Value("${sw.instance-uri}") String instanceUri,
             @Value("${sw.task.dev-port}") int devPort,
             @Value("${sw.dataset.load.batch-size}") int datasetLoadBatchSize,
             RunTimeProperties runTimeProperties,
-            TaskTokenValidator taskTokenValidator
+            TaskTokenValidator taskTokenValidator,
+            WebServerInTask webServerInTask
     ) {
         this.instanceUri = instanceUri;
         this.devPort = devPort;
         this.datasetLoadBatchSize = datasetLoadBatchSize;
         this.runTimeProperties = runTimeProperties;
         this.taskTokenValidator = taskTokenValidator;
+        this.webServerInTask = webServerInTask;
     }
 
     @Override
     public ContainerSpecification containerSpecificationOf(Task task) {
-        return new SwCliModelHandlerContainerSpecification(instanceUri, devPort, datasetLoadBatchSize,
+        return new SwCliModelHandlerContainerSpecification(
+                instanceUri,
+                devPort,
+                datasetLoadBatchSize,
                 runTimeProperties,
-                taskTokenValidator, task);
+                taskTokenValidator,
+                webServerInTask,
+                task
+        );
     }
 
     @Override

--- a/server/controller/src/test/java/ai/starwhale/mlops/common/proxy/WebServerInTaskTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/common/proxy/WebServerInTaskTest.java
@@ -75,4 +75,15 @@ class WebServerInTaskTest {
         gatewayUrl = webServerInTask.generateGatewayUrl(1L, "1.1.1.1", 2);
         assertEquals("http://1.1.1.1:2", gatewayUrl);
     }
+
+    @Test
+    void testGenerateServiceRoot() {
+        when(featuresProperties.isJobProxyEnabled()).thenReturn(true);
+        var root = webServerInTask.generateServiceRoot(1L, 2);
+        assertEquals("/gateway/task/1/2", root);
+
+        when(featuresProperties.isJobProxyEnabled()).thenReturn(false);
+        root = webServerInTask.generateServiceRoot(1L, 2);
+        assertEquals("", root);
+    }
 }


### PR DESCRIPTION
## Description

The latest gradio will fetch `root/info` and `root/theme.css`
The service will be broken without the correct root path configured.

https://github.com/gradio-app/gradio/blob/93d28bc088f7154ecc00f79eb98119f6d4858fe3/client/js/src/client.ts#L803-L806

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
