### PR TITLE
enhance(console): support embedded online eval page

### DIFF
--- a/console/src/domain/job/services/job.ts
+++ b/console/src/domain/job/services/job.ts
@@ -18,7 +18,7 @@ export async function listJobs(projectId: string, query: IListQuerySchema): Prom
     return resp.data
 }
 
-export async function fetchJob(projectId: string, jobId: string): Promise<any> {
+export async function fetchJob(projectId: string, jobId: string): Promise<IJobDetailSchema> {
     const resp = await axios.get<IJobDetailSchema>(`/api/v1/project/${projectId}/job/${jobId}`)
     return resp.data
 }

--- a/console/src/i18n/locales.ts
+++ b/console/src/i18n/locales.ts
@@ -1574,6 +1574,10 @@ const locales0 = {
         en: 'Tasks',
         zh: '任务',
     },
+    'Servings': {
+        en: 'Servings',
+        zh: '服务',
+    },
     'Results': {
         en: 'Results',
         zh: '结果',

--- a/console/src/pages/Job/JobOverviewLayout.tsx
+++ b/console/src/pages/Job/JobOverviewLayout.tsx
@@ -7,6 +7,7 @@ import { INavItem } from '@/components/BaseSidebar'
 import { fetchJob } from '@job/services/job'
 import BaseSubLayout from '@/pages/BaseSubLayout'
 import JobActionGroup from '@/domain/job/components/JobActionGroup'
+import { JobStatusType } from '@job/schemas/job'
 
 export interface IJobLayoutProps {
     children: React.ReactNode
@@ -64,8 +65,15 @@ function JobOverviewLayout({ children }: IJobLayoutProps) {
                 pattern: '/\\/tasks\\/?',
             },
         ]
+        if (job?.exposedLinks?.length && job?.jobStatus === JobStatusType.RUNNING) {
+            items.push({
+                title: t('Servings'),
+                path: `/projects/${projectId}/jobs/${jobId}/servings`,
+                pattern: '/\\/servings\\/?',
+            })
+        }
         return items
-    }, [projectId, jobId, t])
+    }, [projectId, jobId, t, job?.exposedLinks, job?.jobStatus])
 
     return (
         <BaseSubLayout

--- a/console/src/pages/Job/JobServings.tsx
+++ b/console/src/pages/Job/JobServings.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import { useQuery } from 'react-query'
+import { fetchJob } from '@job/services/job'
+import { ExposedLinkType, IExposedLinkSchema } from '@job/schemas/job'
+
+export default function JobServings() {
+    const { jobId, projectId } = useParams<{ jobId: string; projectId: string }>()
+    const jobInfo = useQuery(['fetchJob', projectId, jobId], () => fetchJob(projectId, jobId))
+    const [serving, setServing] = React.useState<IExposedLinkSchema>()
+    React.useEffect(() => {
+        if (jobInfo.isSuccess) {
+            const job = jobInfo.data
+            if (job) {
+                const links = job?.exposedLinks ?? []
+                links.forEach((link) => {
+                    if (link.type === ExposedLinkType.WEB_HANDLER) {
+                        setServing(link)
+                    }
+                })
+            }
+        }
+    }, [jobInfo.data, jobInfo.isSuccess])
+
+    return (
+        <div>
+            {serving && (
+                <iframe
+                    title='job-servings'
+                    src={serving.link}
+                    style={{ position: 'absolute', height: '100%', width: '100%', border: 'none' }}
+                />
+            )}
+        </div>
+    )
+}

--- a/console/src/pages/Job/JobServings.tsx
+++ b/console/src/pages/Job/JobServings.tsx
@@ -27,8 +27,13 @@ export default function JobServings() {
             {serving && (
                 <iframe
                     title='job-servings'
-                    src={serving.link}
-                    style={{ position: 'absolute', height: '100%', width: '100%', border: 'none' }}
+                    src={`${serving.link}?__theme=light`}
+                    style={{
+                        position: 'absolute',
+                        height: '100%',
+                        width: '100%',
+                        border: 'none',
+                    }}
                 />
             )}
         </div>

--- a/console/src/routes.tsx
+++ b/console/src/routes.tsx
@@ -59,6 +59,7 @@ import ReportEdit from '@/pages/Report/ReportEdit'
 import JobOverview from './pages/Job/JobOverview'
 import EvaluationOverview from './pages/Evaluation/EvaluationOverview'
 import ClientLogin from '@/pages/Auth/ClientLogin'
+import JobServings from '@/pages/Job/JobServings'
 
 const useStyles = createUseStyles({
     root: ({ theme }: IThemedStyleProps) => ({
@@ -191,6 +192,11 @@ const Routes = () => {
                                             exact
                                             path='/projects/:projectId/jobs/:jobId/results'
                                             component={EvaluationWidgetResults}
+                                        />
+                                        <Route
+                                            exact
+                                            path='/projects/:projectId/jobs/:jobId/servings'
+                                            component={JobServings}
                                         />
                                         <Redirect
                                             from='/projects/:projectId/jobs/:jobId'


### PR DESCRIPTION
## Description

online demo: http://jialei.pre.intra.starwhale.ai/projects/1/jobs/26/servings

(It does not need the gradio~=3.15.0, any version is ok)

Note that the broken example preview is a bug of gradio, it does not allow the file access with any part starting with dot.
https://github.com/gradio-app/gradio/blob/ba4c6d9e65138c97062d1757d2a588c4fc449daa/gradio/routes.py#L361-L365
The main branch has removed the logic.

cc @tianweidut @lijing-susan @weijie00123 

![image](https://github.com/star-whale/starwhale/assets/3217223/8c9ed3fe-5127-4430-bdfb-75d200bd6bad)


## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
