### PR TITLE
fix(datastore): prevent npe while deal with map diff

### DIFF
--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/ColumnSchemaTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/ColumnSchemaTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.datastore;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.KeyValuePairSchema;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+class ColumnSchemaTest {
+
+    @Test
+    void testGetDiffAndUpdate() {
+        var spasePairSchemaDesc = new HashMap<Integer, KeyValuePairSchema>();
+        var pair = new KeyValuePairSchema(ColumnSchemaDesc.int16().build(), ColumnSchemaDesc.float32().build());
+        spasePairSchemaDesc.put(1, pair);
+        var baseSchemaDesc = ColumnSchemaDesc.mapOf(ColumnSchemaDesc.int8(), ColumnSchemaDesc.string()).build();
+        baseSchemaDesc.setSparseKeyValuePairSchema(spasePairSchemaDesc);
+
+        // generate new schema desc with the different sparse pair of key
+        var pairWithDiffValueType =
+                new KeyValuePairSchema(ColumnSchemaDesc.int16().build(), ColumnSchemaDesc.float64().build());
+        var newSparsePairSchemaDesc = new HashMap<Integer, KeyValuePairSchema>();
+        newSparsePairSchemaDesc.put(1, pairWithDiffValueType);
+        var newSchemaDesc = ColumnSchemaDesc.mapOf(ColumnSchemaDesc.int8(), ColumnSchemaDesc.string()).build();
+        newSchemaDesc.setSparseKeyValuePairSchema(newSparsePairSchemaDesc);
+
+        var colSchema = new ColumnSchema(baseSchemaDesc, 0);
+        var diff = colSchema.getDiff(newSchemaDesc);
+        var expect = Wal.ColumnSchema.newBuilder()
+                .setColumnType("MAP")
+                .putSparseKeyValueTypes(1, Wal.ColumnSchema.KeyValuePair.newBuilder()
+                        .setValue(Wal.ColumnSchema.newBuilder()
+                                .setColumnType("FLOAT64")
+                                .build())
+                        .build());
+        assertEquals(expect.build(), diff.build());
+
+
+        // update with diff, and check if the schema is updated to the desired one
+        colSchema.update(diff.build());
+        assertEquals(new ColumnSchema(newSchemaDesc, 0), colSchema);
+    }
+}


### PR DESCRIPTION
## Description

Fixes: https://cloud.starwhale.cn/projects/398/jobs/949/tasks

```
2023-11-01 08:25:29.940 ERROR [star-whale-controller,c7a5c62f919dc0e9,c7a5c62f919dc0e9] 7 --- [nio-8082-exec-4] a.s.m.c.CommonExceptionHandler           : handleInternalServerError /api/v1/datastore/updateTable


java.lang.NullPointerException: null
        at ai.starwhale.mlops.datastore.Wal$ColumnSchema$KeyValuePair$Builder.setKey(Wal.java:923) ~[classes/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.ColumnSchema.getDiff(ColumnSchema.java:331) ~[classes/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.ColumnSchema.getDiff(ColumnSchema.java:274) ~[classes/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.TableSchema.getDiff(TableSchema.java:134) ~[classes/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.impl.MemoryTableImpl.update(MemoryTableImpl.java:386) ~[classes/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.DataStore.update(DataStore.java:206) ~[classes/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.datastore.DataStore$$FastClassBySpringCGLIB$$8df74be8.invoke(<generated>) ~[classes/:0.1.0-SNAPSHOT]
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.adapter.MethodBeforeAdviceInterceptor.invoke(MethodBeforeAdviceInterceptor.java:58) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.24.jar:5.3.24]
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.24.jar:5.3.24]
        at ai.starwhale.mlops.datastore.DataStore$$EnhancerBySpringCGLIB$$81f741df.update(<generated>) ~[classes/:0.1.0-SNAPSHOT]
        at ai.starwhale.mlops.api.DataStoreController.updateTable(DataStoreController.java:132) ~[classes/:0.1.0-SNAPSHOT]
        at jdk.internal.reflect.GeneratedMethodAccessor714.invoke(Unknown Source) ~[na:na]
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
```

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
