### PR TITLE
chore(client): remove redunancy atexit for data_store

### DIFF
--- a/client/starwhale/api/_impl/data_store.py
+++ b/client/starwhale/api/_impl/data_store.py
@@ -7,7 +7,6 @@ import sys
 import copy
 import json
 import time
-import atexit
 import base64
 import shutil
 import struct
@@ -688,7 +687,7 @@ class SwMapType(SwCompositeType):
 
             pair_counts: Dict[PairSchema, int] = {}
             # update the main and sparse types
-            for (kt, vt) in key_value_types:
+            for kt, vt in key_value_types:
                 p = PairSchema(key=kt, value=vt)
                 if p in pair_counts:
                     pair_counts[p] += 1
@@ -2357,7 +2356,6 @@ class LocalDataStore:
                 ds_path = SWCliConfigMixed().datastore_dir
                 ensure_dir(ds_path)
                 LocalDataStore._instance = LocalDataStore(str(ds_path))
-                atexit.register(LocalDataStore._instance.dump)
             return LocalDataStore._instance
 
     def __init__(self, root_path: str) -> None:
@@ -2834,7 +2832,6 @@ class TableWriter(threading.Thread):
 
         self.daemon = True
         self.start()
-        atexit.register(self.close)
 
     def __enter__(self) -> Any:
         return self
@@ -2846,7 +2843,6 @@ class TableWriter(threading.Thread):
         self.flush()
         with self._cond:
             if not self._stopped:
-                atexit.unregister(self.close)
                 self._stopped = True
                 self._cond.notify()
         self.join()

--- a/client/starwhale/base/artifact/base.py
+++ b/client/starwhale/base/artifact/base.py
@@ -152,6 +152,7 @@ class AsyncArtifactWriterBase(ABC):
         self._rows_put_thread.join()
 
     def close(self) -> None:
+        atexit.unregister(self.close)
         self._rows_put_queue.put(None)
         self._threads_join()
 

--- a/client/tests/__init__.py
+++ b/client/tests/__init__.py
@@ -27,7 +27,7 @@ class BaseTestCase(unittest.TestCase):
         self.datastore_root = str(sw_config.SWCliConfigMixed().datastore_dir)
         ensure_dir(self.datastore_root)
 
-        self.mock_atexit = patch("starwhale.api._impl.data_store.atexit", MagicMock())
+        self.mock_atexit = patch("starwhale.base.artifact.base.atexit", MagicMock())
         self.mock_atexit.start()
 
     def tearDown(self) -> None:

--- a/client/tests/core/test_eval.py
+++ b/client/tests/core/test_eval.py
@@ -79,12 +79,9 @@ class StandaloneEvaluationJobTestCase(TestCase):
             == "/path/to/.starwhale/self/job/xx/xxyy/snapshot"
         )
 
-    @patch("starwhale.api._impl.data_store.atexit")
     @patch("starwhale.api._impl.wrapper.Evaluation.get")
     @patch("starwhale.api._impl.wrapper.Evaluation.get_summary_metrics")
-    def test_info(
-        self, m_get_metrics: MagicMock, m_get: MagicMock, m_atexit: MagicMock
-    ):
+    def test_info(self, m_get_metrics: MagicMock, m_get: MagicMock):
         m_get.return_value = {}
         m_get_metrics.return_value = {"kind": "multi_classification"}
 


### PR DESCRIPTION
## Description
The DatasetMapperBuilder and Evaluation components automatically register atexit handlers to close related resources. This includes calling TableWriter.close() to close any open table writers and forcing a dump of the LocalDatastore before the program exits.

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
