### PR TITLE
refactor(controller): deprecate resource version url in job request

### DIFF
--- a/client/starwhale/base/client/models/models.py
+++ b/client/starwhale/base/client/models/models.py
@@ -206,8 +206,11 @@ class DevWay(Enum):
 
 
 class JobRequest(SwBaseModel):
+    model_version_id: Optional[int] = Field(None, alias='modelVersionId')
+    dataset_version_ids: Optional[List[int]] = Field(None, alias='datasetVersionIds')
+    runtime_version_id: Optional[int] = Field(None, alias='runtimeVersionId')
     time_to_live_in_sec: Optional[int] = Field(None, alias='timeToLiveInSec')
-    model_version_url: str = Field(..., alias='modelVersionUrl')
+    model_version_url: Optional[str] = Field(None, alias='modelVersionUrl')
     dataset_version_urls: Optional[str] = Field(None, alias='datasetVersionUrls')
     runtime_version_url: Optional[str] = Field(None, alias='runtimeVersionUrl')
     comment: Optional[str] = None

--- a/client/starwhale/base/uri/resource.py
+++ b/client/starwhale/base/uri/resource.py
@@ -231,7 +231,7 @@ class Resource:
                     raise NoMatchException(ver, list(m))
         else:
             # TODO use api to check if it is a name or version
-            # assume is is name for now
+            # assume it is name for now
             self.name = ver
 
     def _refine_remote_rc_info(self) -> None:

--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -24,7 +24,6 @@ from cmds.instance_cmd import Instance
 from cmds.artifacts_cmd import Model, Dataset, Runtime
 
 from starwhale.utils import config
-from starwhale.base.type import DatasetChangeMode
 from starwhale.utils.debug import init_logger
 from starwhale.base.uri.resource import Resource, ResourceType
 from starwhale.api._impl.data_store import TableDesc, LocalDataStore, RemoteDataStore
@@ -364,14 +363,6 @@ class TestCli:
         conda_runtime_uri = self.build_runtime(workdir, "runtime_conda.yaml")
         model_uri = self.build_model(workdir, "simple", runtime=str(venv_runtime_uri))
         dataset_uri = self.build_dataset("simple", workdir, DatasetExpl("", ""))
-
-        if self.server_url:
-            self.dataset_api.copy(
-                src_uri=dataset_uri.full_uri,
-                target_project=self.cloud_target_project_uri,
-                force=True,
-                mode=DatasetChangeMode.OVERWRITE,
-            )
 
         remote_job_ids = []
         if self.server_url:

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/JobRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/job/JobRequest.java
@@ -20,6 +20,7 @@ import ai.starwhale.mlops.domain.job.DevWay;
 import ai.starwhale.mlops.domain.job.JobType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
+import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.validation.annotation.Validated;
@@ -28,15 +29,21 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class JobRequest implements Serializable {
 
-    @NotNull
+    @Deprecated
     @JsonProperty("modelVersionUrl")
     private String modelVersionUrl;
 
+    @Deprecated
     @JsonProperty("datasetVersionUrls")
     private String datasetVersionUrls;
 
+    @Deprecated
     @JsonProperty("runtimeVersionUrl")
     private String runtimeVersionUrl;
+
+    private Long modelVersionId;
+    private List<Long> datasetVersionIds;
+    private Long runtimeVersionId;
 
     @JsonProperty("comment")
     private String comment;

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/DatasetService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/DatasetService.java
@@ -57,6 +57,7 @@ import ai.starwhale.mlops.domain.dataset.po.DatasetVersionViewEntity;
 import ai.starwhale.mlops.domain.job.JobCreator;
 import ai.starwhale.mlops.domain.job.JobType;
 import ai.starwhale.mlops.domain.job.bo.Job;
+import ai.starwhale.mlops.domain.job.bo.JobCreateRequest;
 import ai.starwhale.mlops.domain.job.spec.Env;
 import ai.starwhale.mlops.domain.job.spec.JobSpecParser;
 import ai.starwhale.mlops.domain.job.spec.StepSpec;
@@ -506,10 +507,15 @@ public class DatasetService {
             throw new SwProcessException(ErrorType.SYSTEM, "error occurs while writing ds build step specs to string",
                     e);
         }
-        Job job = jobCreator.createJob(project, null, null, null, null,
-                systemSettingService.getRunTimeProperties().getDatasetBuild().getResourcePool(), null,
-                stepSpecOverWrites,
-                JobType.BUILT_IN, null, false, null, null, userService.currentUserDetail());
+        var jobReq = JobCreateRequest.builder()
+                .project(project)
+                .resourcePool(systemSettingService.getRunTimeProperties().getDatasetBuild().getResourcePool())
+                .stepSpecOverWrites(stepSpecOverWrites)
+                .jobType(JobType.BUILT_IN)
+                .user(userService.currentUserDetail())
+                .build();
+        Job job = jobCreator.createJob(jobReq);
+
         var entity = BuildRecordEntity.builder()
                 .projectId(project.getId())
                 .taskId(job.getSteps().get(0).getTasks().get(0).getId())

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobServiceForWeb.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/JobServiceForWeb.java
@@ -24,6 +24,7 @@ import ai.starwhale.mlops.common.util.BatchOperateHelper;
 import ai.starwhale.mlops.common.util.PageUtil;
 import ai.starwhale.mlops.domain.event.EventService;
 import ai.starwhale.mlops.domain.job.bo.Job;
+import ai.starwhale.mlops.domain.job.bo.UserJobCreateRequest;
 import ai.starwhale.mlops.domain.job.cache.HotJobHolder;
 import ai.starwhale.mlops.domain.job.cache.JobLoader;
 import ai.starwhale.mlops.domain.job.converter.JobConverter;
@@ -43,7 +44,6 @@ import ai.starwhale.mlops.domain.trash.Trash.Type;
 import ai.starwhale.mlops.domain.trash.TrashService;
 import ai.starwhale.mlops.domain.upgrade.rollup.aspectcut.WriteOperation;
 import ai.starwhale.mlops.domain.user.UserService;
-import ai.starwhale.mlops.domain.user.bo.User;
 import ai.starwhale.mlops.exception.SwProcessException;
 import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
@@ -159,26 +159,8 @@ public class JobServiceForWeb {
     }
 
     @Transactional
-    public Long createJob(
-            String projectUrl,
-            String modelVersionUrl,
-            String datasetVersionUrls,
-            String runtimeVersionUrl,
-            String comment,
-            String resourcePool,
-            String handler,
-            String stepSpecOverWrites,
-            JobType type,
-            DevWay devWay,
-            boolean devMode,
-            String devPassword,
-            Long ttlInSec
-    ) {
-        User user = userService.currentUserDetail();
-        var project = projectService.findProject(projectUrl);
-        var jobId = jobCreator.createJob(project, modelVersionUrl, datasetVersionUrls, runtimeVersionUrl, comment,
-                resourcePool, handler, stepSpecOverWrites, type, devWay, devMode, devPassword, ttlInSec, user).getId();
-
+    public Long createJob(UserJobCreateRequest request) {
+        var jobId = jobCreator.createJob(request).getId();
         eventService.addInternalJobInfoEvent(jobId, "Job created");
         return jobId;
     }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/bo/JobCreateRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/bo/JobCreateRequest.java
@@ -14,17 +14,27 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.domain.bundle;
+package ai.starwhale.mlops.domain.job.bo;
 
-import ai.starwhale.mlops.domain.bundle.base.BundleVersionEntity;
+import ai.starwhale.mlops.domain.job.JobType;
+import ai.starwhale.mlops.domain.project.bo.Project;
+import ai.starwhale.mlops.domain.user.bo.User;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
-public interface BundleVersionAccessor<T extends BundleVersionEntity> {
+@Data
+@SuperBuilder
+public class JobCreateRequest {
+    @NotNull
+    Project project;
 
-    T findVersionById(Long bundleVersionId);
+    @NotNull
+    User user;
 
-    T findVersionByAliasAndBundleId(String alias, Long bundleId);
-
-    T findVersionByNameAndBundleId(String name, Long bundleId);
-
-    T findLatestVersionByBundleId(Long bundleId);
+    String comment;
+    String resourcePool;
+    String handler;
+    String stepSpecOverWrites;
+    JobType jobType;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/bo/UserJobCreateRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/bo/UserJobCreateRequest.java
@@ -14,17 +14,29 @@
  * limitations under the License.
  */
 
-package ai.starwhale.mlops.domain.bundle;
+package ai.starwhale.mlops.domain.job.bo;
 
-import ai.starwhale.mlops.domain.bundle.base.BundleVersionEntity;
+import ai.starwhale.mlops.domain.job.DevWay;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
 
-public interface BundleVersionAccessor<T extends BundleVersionEntity> {
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class UserJobCreateRequest extends JobCreateRequest {
+    @NotNull
+    Long modelVersionId;
 
-    T findVersionById(Long bundleVersionId);
+    @NotNull
+    Long runtimeVersionId;
 
-    T findVersionByAliasAndBundleId(String alias, Long bundleId);
+    List<Long> datasetVersionIds;
 
-    T findVersionByNameAndBundleId(String name, Long bundleId);
-
-    T findLatestVersionByBundleId(Long bundleId);
+    boolean devMode;
+    DevWay devWay;
+    String devPassword;
+    Long ttlInSec;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/UserJobConverter.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/converter/UserJobConverter.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.job.converter;
+
+
+import ai.starwhale.mlops.api.protocol.job.JobRequest;
+import ai.starwhale.mlops.common.Constants;
+import ai.starwhale.mlops.common.IdConverter;
+import ai.starwhale.mlops.domain.dataset.DatasetDao;
+import ai.starwhale.mlops.domain.dataset.bo.DatasetVersion;
+import ai.starwhale.mlops.domain.job.bo.UserJobCreateRequest;
+import ai.starwhale.mlops.domain.job.po.JobFlattenEntity;
+import ai.starwhale.mlops.domain.model.ModelDao;
+import ai.starwhale.mlops.domain.model.ModelService;
+import ai.starwhale.mlops.domain.project.ProjectService;
+import ai.starwhale.mlops.domain.runtime.RuntimeDao;
+import ai.starwhale.mlops.domain.user.UserService;
+import ai.starwhale.mlops.exception.SwValidationException;
+import ai.starwhale.mlops.exception.SwValidationException.ValidSubject;
+import ai.starwhale.mlops.exception.api.StarwhaleApiException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+public class UserJobConverter {
+    public static final String FORMATTER_URI_ARTIFACT = "project/%s/%s/%s/version/%s";
+
+    private final IdConverter idConvertor;
+    private final ProjectService projectService;
+    private final ModelService modelService;
+    private final UserService userService;
+    private final ModelDao modelDao;
+    private final RuntimeDao runtimeDao;
+    private final DatasetDao datasetDao;
+
+    public UserJobConverter(
+            IdConverter idConvertor,
+            ProjectService projectService,
+            ModelService modelService,
+            UserService userService,
+            ModelDao modelDao,
+            RuntimeDao runtimeDao,
+            DatasetDao datasetDao
+    ) {
+        this.idConvertor = idConvertor;
+        this.projectService = projectService;
+        this.modelService = modelService;
+        this.userService = userService;
+        this.modelDao = modelDao;
+        this.runtimeDao = runtimeDao;
+        this.datasetDao = datasetDao;
+    }
+
+    @NotNull
+    public UserJobCreateRequest convert(String projectUrl, JobRequest request) throws SwValidationException {
+        var project = projectService.findProject(projectUrl);
+
+        var modelVersionId = findId(request.getModelVersionId(), request.getModelVersionUrl(), "model version");
+        if (modelVersionId == null) {
+            this.badRequest("model version is required");
+        }
+        var runtimeVersionId = findId(request.getRuntimeVersionId(), request.getRuntimeVersionUrl(), "runtime version");
+        if (runtimeVersionId == null) {
+            // try builtin runtime
+            var modelVersion = modelDao.findVersionById(modelVersionId);
+            if (modelVersion == null) {
+                this.badRequest("model version %s not found", modelVersionId);
+            }
+            var model = modelDao.findById(modelVersion.getModelId());
+            if (model == null) {
+                this.badRequest("model %s not found", modelVersion.getModelId());
+            }
+
+            var runtime = runtimeDao.getRuntimeByName(Constants.SW_BUILT_IN_RUNTIME, model.getProjectId());
+            if (runtime == null) {
+                this.badRequest("builtin runtime of %s not found", model.getName());
+            }
+            var runtimeVersion =
+                    runtimeDao.findVersionByNameAndBundleId(modelVersion.getBuiltInRuntime(), runtime.getId());
+            if (runtimeVersion == null) {
+                this.badRequest("builtin runtime version %s not found", modelVersion.getBuiltInRuntime());
+            }
+            runtimeVersionId = runtimeVersion.getId();
+
+        }
+        var datasets = request.getDatasetVersionIds();
+        if (datasets == null) {
+            var datasetUrls = request.getDatasetVersionUrls();
+            if (StringUtils.hasText(datasetUrls)) {
+                // convert datasetUrls to datasetIds
+                var converted = new ArrayList<Long>();
+                for (var url : datasetUrls.split(",")) {
+                    var id = findId(null, url, "dataset version");
+                    if (id == null) {
+                        this.badRequest("dataset version %s not found", url);
+                    }
+                    converted.add(id);
+                }
+                datasets = converted;
+                log.warn("datasetVersionUrls is deprecated, please use datasetVersionIds instead");
+            }
+        }
+
+        return UserJobCreateRequest.builder()
+                .project(project)
+                .modelVersionId(modelVersionId)
+                .runtimeVersionId(runtimeVersionId)
+                .datasetVersionIds(datasets)
+                .comment(request.getComment())
+                .resourcePool(request.getResourcePool())
+                .handler(request.getHandler())
+                .stepSpecOverWrites(request.getStepSpecOverWrites())
+                .jobType(request.getType())
+                .devMode(request.isDevMode())
+                .devWay(request.getDevWay())
+                .devPassword(request.getDevPassword())
+                .ttlInSec(request.getTimeToLiveInSec())
+                .user(userService.currentUserDetail())
+                .build();
+    }
+
+    public JobFlattenEntity.JobFlattenEntityBuilder convert(UserJobCreateRequest request)
+            throws SwValidationException {
+        var modelVersion = modelDao.findVersionById(request.getModelVersionId());
+        if (null == modelVersion) {
+            this.badRequest("model version %s not found", request.getModelVersionId());
+        }
+
+        var runtimeVersion = runtimeDao.findVersionById(request.getRuntimeVersionId());
+        if (null == runtimeVersion) {
+            throw new StarwhaleApiException(
+                    new SwValidationException(ValidSubject.JOB, "runtime version not found"),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        var runtime = runtimeDao.findById(runtimeVersion.getRuntimeId());
+        var model = modelDao.findById(modelVersion.getModelId());
+
+        var datasetIds = request.getDatasetVersionIds();
+        List<DatasetVersion> datasets = datasetIds != null ? datasetIds.stream()
+                .map(datasetDao::getDatasetVersion)
+                .collect(Collectors.toList())
+                : List.of();
+        var datasetUrls = datasets.stream().map(version -> String.format(FORMATTER_URI_ARTIFACT,
+                version.getProjectId(),
+                "dataset",
+                version.getDatasetId(),
+                version.getId())).collect(Collectors.toList());
+        var datasetVersionIdMaps = datasets.isEmpty() ? new HashMap<Long, String>()
+                : datasets.stream().collect(Collectors.toMap(DatasetVersion::getId, DatasetVersion::getVersionName));
+
+        var datasetsForView = datasets.isEmpty() ? null
+                : datasets.stream()
+                .map(version -> String.format(FORMATTER_URI_ARTIFACT,
+                        projectService.findProject(version.getProjectId()).getName(),
+                        "dataset",
+                        version.getDatasetName(),
+                        version.getVersionName()))
+                .collect(Collectors.joining(","));
+        var releaseTime = request.getTtlInSec() == null ? null :
+                new Date(System.currentTimeMillis() + request.getTtlInSec() * 1000);
+
+        var devMode = request.isDevMode();
+
+        return JobFlattenEntity.builder()
+                .owner(request.getUser())
+                .runtimeUri(String.format(FORMATTER_URI_ARTIFACT, runtime.getProjectId(), "runtime", runtime.getId(),
+                        runtimeVersion.getId()))
+                .runtimeUriForView(String.format(FORMATTER_URI_ARTIFACT,
+                        projectService.findProject(runtime.getProjectId()).getName(),
+                        "runtime",
+                        runtime.getName(),
+                        runtimeVersion.getVersionName()))
+                .runtimeName(runtime.getName())
+                .runtimeVersionId(runtimeVersion.getId())
+                .runtimeVersionValue(runtimeVersion.getVersionName())
+                .modelName(model.getName())
+                .modelVersion(modelService.findModelVersion(modelVersion.getId()))
+                .modelVersionId(modelVersion.getId())
+                .modelVersionValue(modelVersion.getVersionName())
+                .modelUri(String.format(FORMATTER_URI_ARTIFACT, model.getProjectId(), "model", model.getId(),
+                        modelVersion.getId()))
+                .modelUriForView(String.format(FORMATTER_URI_ARTIFACT,
+                        projectService.findProject(model.getProjectId()).getName(),
+                        "model",
+                        model.getName(),
+                        modelVersion.getVersionName()))
+                .datasets(datasetUrls)
+                .datasetIdVersionMap(datasetVersionIdMaps)
+                .datasetsForView(datasetsForView)
+                .devMode(request.isDevMode())
+                .devWay(devMode ? request.getDevWay() : null)
+                .devPassword(devMode ? request.getDevPassword() : null)
+                .autoReleaseTime(releaseTime);
+    }
+
+    @Nullable
+    private Long findId(Long id, String url, String nameForMsg) throws SwValidationException {
+        if (id != null) {
+            return id;
+        }
+        if (StringUtils.hasText(url)) {
+            if (!idConvertor.isId(url)) {
+                this.badRequest("%s url must be an id, got %s", nameForMsg, url);
+            }
+            log.warn("{} url is deprecated, please use id instead", nameForMsg);
+            return idConvertor.revert(url);
+        }
+        return null;
+    }
+
+    private void badRequest(String fmt, Object... args) throws SwValidationException {
+        var msg = String.format(fmt, args);
+        throw new StarwhaleApiException(new SwValidationException(ValidSubject.JOB, msg), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/JobFlattenEntity.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/job/po/JobFlattenEntity.java
@@ -61,14 +61,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @EqualsAndHashCode
 @Data
-@SuperBuilder
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelDao.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/model/ModelDao.java
@@ -21,7 +21,6 @@ import ai.starwhale.mlops.common.VersionAliasConverter;
 import ai.starwhale.mlops.domain.bundle.BundleAccessor;
 import ai.starwhale.mlops.domain.bundle.BundleVersionAccessor;
 import ai.starwhale.mlops.domain.bundle.base.BundleEntity;
-import ai.starwhale.mlops.domain.bundle.base.BundleVersionEntity;
 import ai.starwhale.mlops.domain.bundle.recover.RecoverAccessor;
 import ai.starwhale.mlops.domain.bundle.remove.RemoveAccessor;
 import ai.starwhale.mlops.domain.bundle.revert.RevertAccessor;
@@ -36,7 +35,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-public class ModelDao implements BundleAccessor, BundleVersionAccessor,
+public class ModelDao implements BundleAccessor, BundleVersionAccessor<ModelVersionEntity>,
         RevertAccessor, RecoverAccessor, RemoveAccessor {
 
     private final ModelMapper modelMapper;
@@ -92,23 +91,23 @@ public class ModelDao implements BundleAccessor, BundleVersionAccessor,
     }
 
     @Override
-    public BundleVersionEntity findVersionById(Long bundleVersionId) {
+    public ModelVersionEntity findVersionById(Long bundleVersionId) {
         return versionMapper.find(bundleVersionId);
     }
 
     @Override
-    public BundleVersionEntity findVersionByAliasAndBundleId(String alias, Long bundleId) {
+    public ModelVersionEntity findVersionByAliasAndBundleId(String alias, Long bundleId) {
         Long versionOrder = versionAliasConvertor.revert(alias);
         return versionMapper.findByVersionOrder(versionOrder, bundleId);
     }
 
     @Override
-    public BundleVersionEntity findVersionByNameAndBundleId(String name, Long bundleId) {
+    public ModelVersionEntity findVersionByNameAndBundleId(String name, Long bundleId) {
         return versionMapper.findByNameAndModelId(name, bundleId);
     }
 
     @Override
-    public BundleVersionEntity findLatestVersionByBundleId(Long bundleId) {
+    public ModelVersionEntity findLatestVersionByBundleId(Long bundleId) {
         return versionMapper.findByLatest(bundleId);
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/project/ProjectService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/project/ProjectService.java
@@ -75,6 +75,7 @@ public class ProjectService implements ProjectAccessor, ApplicationContextAware 
     private final ProjectMapper projectMapper;
 
     private final ProjectVisitedMapper projectVisitedMapper;
+
     private final ProjectDao projectDao;
     private final RuntimeVersionMapper runtimeVersionMapper;
     private final ModelVersionMapper modelVersionMapper;
@@ -365,11 +366,9 @@ public class ProjectService implements ProjectAccessor, ApplicationContextAware 
         return res > 0;
     }
 
-    @Override
     public Long getProjectId(String projectUrl) {
         return findProject(projectUrl).getId();
     }
-
 
     private Boolean existProject(String projectName, Long userId) {
         ProjectEntity existProject = projectMapper.findExistingByNameAndOwner(projectName, userId);

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeDao.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeDao.java
@@ -21,7 +21,6 @@ import ai.starwhale.mlops.common.VersionAliasConverter;
 import ai.starwhale.mlops.domain.bundle.BundleAccessor;
 import ai.starwhale.mlops.domain.bundle.BundleVersionAccessor;
 import ai.starwhale.mlops.domain.bundle.base.BundleEntity;
-import ai.starwhale.mlops.domain.bundle.base.BundleVersionEntity;
 import ai.starwhale.mlops.domain.bundle.recover.RecoverAccessor;
 import ai.starwhale.mlops.domain.bundle.remove.RemoveAccessor;
 import ai.starwhale.mlops.domain.bundle.revert.RevertAccessor;
@@ -36,7 +35,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-public class RuntimeDao implements BundleAccessor, BundleVersionAccessor,
+public class RuntimeDao implements BundleAccessor, BundleVersionAccessor<RuntimeVersionEntity>,
         RevertAccessor, RecoverAccessor, RemoveAccessor {
 
     private final RuntimeMapper runtimeMapper;
@@ -106,23 +105,23 @@ public class RuntimeDao implements BundleAccessor, BundleVersionAccessor,
     }
 
     @Override
-    public BundleVersionEntity findVersionById(Long bundleVersionId) {
+    public RuntimeVersionEntity findVersionById(Long bundleVersionId) {
         return runtimeVersionMapper.find(bundleVersionId);
     }
 
     @Override
-    public BundleVersionEntity findVersionByAliasAndBundleId(String alias, Long bundleId) {
+    public RuntimeVersionEntity findVersionByAliasAndBundleId(String alias, Long bundleId) {
         Long versionOrder = versionAliasConvertor.revert(alias);
         return runtimeVersionMapper.findByVersionOrder(versionOrder, bundleId);
     }
 
     @Override
-    public BundleVersionEntity findVersionByNameAndBundleId(String name, Long bundleId) {
+    public RuntimeVersionEntity findVersionByNameAndBundleId(String name, Long bundleId) {
         return runtimeVersionMapper.findByNameAndRuntimeId(name, bundleId);
     }
 
     @Override
-    public BundleVersionEntity findLatestVersionByBundleId(Long bundleId) {
+    public RuntimeVersionEntity findLatestVersionByBundleId(Long bundleId) {
         return runtimeVersionMapper.findByLatest(bundleId);
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/runtime/RuntimeService.java
@@ -46,6 +46,7 @@ import ai.starwhale.mlops.domain.bundle.tag.po.BundleVersionTagEntity;
 import ai.starwhale.mlops.domain.job.JobCreator;
 import ai.starwhale.mlops.domain.job.JobType;
 import ai.starwhale.mlops.domain.job.bo.Job;
+import ai.starwhale.mlops.domain.job.bo.JobCreateRequest;
 import ai.starwhale.mlops.domain.job.bo.JobRuntime;
 import ai.starwhale.mlops.domain.job.cache.HotJobHolder;
 import ai.starwhale.mlops.domain.job.spec.Env;
@@ -725,20 +726,15 @@ public class RuntimeService {
                     e);
         }
         var project = projectService.findProject(projectUrl);
-        Job job = jobCreator.createJob(project,
-                null,
-                null,
-                null,
-                "runtime-dockerizing",
-                runTimeProperties.getImageBuild().getResourcePool(),
-                null,
-                stepSpecOverWrites,
-                JobType.BUILT_IN,
-                null,
-                false,
-                null,
-                null,
-                userService.currentUserDetail());
+        var jobReq = JobCreateRequest.builder()
+                .project(project)
+                .comment("runtime-dockerizing")
+                .resourcePool(runTimeProperties.getImageBuild().getResourcePool())
+                .stepSpecOverWrites(stepSpecOverWrites)
+                .jobType(JobType.BUILT_IN)
+                .user(userService.currentUserDetail())
+                .build();
+        Job job = jobCreator.createJob(jobReq);
         return new BuildImageResult(true, job.getId().toString());
 
     }

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/JobControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/JobControllerTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
@@ -54,6 +53,7 @@ import ai.starwhale.mlops.domain.job.DevWay;
 import ai.starwhale.mlops.domain.job.JobServiceForWeb;
 import ai.starwhale.mlops.domain.job.ModelServingService;
 import ai.starwhale.mlops.domain.job.RuntimeSuggestionService;
+import ai.starwhale.mlops.domain.job.converter.UserJobConverter;
 import ai.starwhale.mlops.domain.run.RunService;
 import ai.starwhale.mlops.domain.task.TaskService;
 import ai.starwhale.mlops.exception.api.StarwhaleApiException;
@@ -98,7 +98,9 @@ public class JobControllerTest {
                 dagQuerier,
                 featuresProperties,
                 mock(EventService.class),
-                mock(RunService.class));
+                mock(RunService.class),
+                mock(UserJobConverter.class)
+        );
     }
 
     @Test
@@ -155,9 +157,7 @@ public class JobControllerTest {
 
     @Test
     public void testCreatJob() {
-        given(jobServiceForWeb.createJob(anyString(), anyString(), anyString(), anyString(), anyString(),
-                anyString(), anyString(), any(), any(), eq(DevWay.VS_CODE), eq(false), anyString(),
-                any())).willReturn(1L);
+        given(jobServiceForWeb.createJob(any())).willReturn(1L);
         JobRequest jobRequest = new JobRequest();
         jobRequest.setHandler("eval");
         jobRequest.setComment("");
@@ -299,7 +299,8 @@ public class JobControllerTest {
                 dagQuerier,
                 featuresProperties,
                 mock(EventService.class),
-                mock(RunService.class)
+                mock(RunService.class),
+                mock(UserJobConverter.class)
         );
         assertThrows(StarwhaleApiException.class,
                 () -> controller.action("", "job1", "pause"));
@@ -321,7 +322,8 @@ public class JobControllerTest {
                 dagQuerier,
                 featuresProperties,
                 mock(EventService.class),
-                mock(RunService.class)
+                mock(RunService.class),
+                mock(UserJobConverter.class)
         );
         assertThrows(StarwhaleApiException.class,
                 () -> controller.action("", "job1", "resume"));

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/protocol/job/JobRequestTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/protocol/job/JobRequestTest.java
@@ -43,7 +43,7 @@ class JobRequestTest {
             assertEquals(0, violations.size());
 
             // missing required fields
-            json = "{\"resourcePool\":\"default\"}";
+            json = "{\"modelVersionUrl\":\"abc\"}";
             deserialized = Constants.objectMapper.readValue(json, JobRequest.class);
             violations = validator.validate(deserialized);
             assertEquals(1, violations.size());

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/dataset/DatasetServiceTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -190,22 +189,7 @@ public class DatasetServiceTest {
         bundleVersionTagDao = mock(BundleVersionTagDao.class);
 
         jobCreator = mock(JobCreator.class);
-        when(jobCreator.createJob(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                anyBoolean(),
-                any(),
-                any(),
-                any()
-        )).thenReturn(new JobMockHolder().mockJob());
+        when(jobCreator.createJob(any())).thenReturn(new JobMockHolder().mockJob());
         service = new DatasetService(
                 projectService,
                 datasetMapper,

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/job/converter/UserJobConverterTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/job/converter/UserJobConverterTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.domain.job.converter;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.starwhale.mlops.api.protocol.job.JobRequest;
+import ai.starwhale.mlops.common.Constants;
+import ai.starwhale.mlops.common.IdConverter;
+import ai.starwhale.mlops.domain.dataset.DatasetDao;
+import ai.starwhale.mlops.domain.dataset.bo.DatasetVersion;
+import ai.starwhale.mlops.domain.job.JobType;
+import ai.starwhale.mlops.domain.job.bo.UserJobCreateRequest;
+import ai.starwhale.mlops.domain.model.ModelDao;
+import ai.starwhale.mlops.domain.model.ModelService;
+import ai.starwhale.mlops.domain.model.po.ModelEntity;
+import ai.starwhale.mlops.domain.model.po.ModelVersionEntity;
+import ai.starwhale.mlops.domain.project.ProjectService;
+import ai.starwhale.mlops.domain.project.bo.Project;
+import ai.starwhale.mlops.domain.runtime.RuntimeDao;
+import ai.starwhale.mlops.domain.runtime.po.RuntimeEntity;
+import ai.starwhale.mlops.domain.runtime.po.RuntimeVersionEntity;
+import ai.starwhale.mlops.domain.user.UserService;
+import ai.starwhale.mlops.domain.user.bo.User;
+import ai.starwhale.mlops.exception.api.StarwhaleApiException;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UserJobConverterTest {
+    private UserJobConverter userJobConverter;
+
+    private final IdConverter idConverter = new IdConverter();
+    private ProjectService projectService;
+    private ModelService modelService;
+    private UserService userService;
+    private ModelDao modelDao;
+    private RuntimeDao runtimeDao;
+    private DatasetDao datasetDao;
+
+    @BeforeEach
+    void setUp() {
+        projectService = mock(ProjectService.class);
+        modelService = mock(ModelService.class);
+        userService = mock(UserService.class);
+        modelDao = mock(ModelDao.class);
+        runtimeDao = mock(RuntimeDao.class);
+        datasetDao = mock(DatasetDao.class);
+
+        userJobConverter = new UserJobConverter(
+                idConverter,
+                projectService,
+                modelService,
+                userService,
+                modelDao,
+                runtimeDao,
+                datasetDao
+        );
+    }
+
+    @Test
+    public void testConvertToUserJobRequest() {
+        var projectId = "1";
+        var req = new JobRequest();
+        req.setResourcePool("test");
+        req.setHandler("handler");
+        req.setDevMode(false);
+
+        // old version request
+        // invalid version url, this must be numeric
+        req.setModelVersionUrl("model url");
+        req.setRuntimeVersionUrl("2");
+        req.setDatasetVersionUrls("3,4");
+        assertThrowsExactly(StarwhaleApiException.class, () -> userJobConverter.convert(projectId, req));
+
+        // valid version url
+        req.setModelVersionUrl("1");
+        var resp = userJobConverter.convert(projectId, req);
+        assertEquals("test", resp.getResourcePool());
+        assertEquals("handler", resp.getHandler());
+        assertFalse(resp.isDevMode());
+
+        assertEquals(1L, resp.getModelVersionId());
+        assertEquals(2L, resp.getRuntimeVersionId());
+        assertEquals(List.of(3L, 4L), resp.getDatasetVersionIds());
+
+        // new version request
+        req.setModelVersionUrl(null);
+        req.setModelVersionId(1L);
+        req.setRuntimeVersionUrl(null);
+        req.setRuntimeVersionId(2L);
+        req.setDatasetVersionUrls(null);
+        req.setDatasetVersionIds(List.of(3L, 4L));
+
+        resp = userJobConverter.convert(projectId, req);
+        assertEquals("test", resp.getResourcePool());
+        assertEquals("handler", resp.getHandler());
+        assertFalse(resp.isDevMode());
+
+        assertEquals(1L, resp.getModelVersionId());
+        assertEquals(2L, resp.getRuntimeVersionId());
+        assertEquals(List.of(3L, 4L), resp.getDatasetVersionIds());
+
+        // test no runtime
+        req.setRuntimeVersionId(null);
+        req.setRuntimeVersionUrl(null);
+        assertThrows(StarwhaleApiException.class, () -> userJobConverter.convert(projectId, req));
+
+        // test built-in runtime
+        var modelVersionEntity = ModelVersionEntity.builder()
+                .id(1L)
+                .modelId(11L)
+                .builtInRuntime("the built-in runtime version name")
+                .build();
+        when(modelDao.findVersionById(1L)).thenReturn(modelVersionEntity);
+        when(modelDao.findById(11L)).thenReturn(ModelEntity.builder().projectId(42L).build());
+        when(runtimeDao.getRuntimeByName(Constants.SW_BUILT_IN_RUNTIME, 42L)).thenReturn(
+                RuntimeEntity.builder().id(12L).build());
+        when(runtimeDao.findVersionByNameAndBundleId("the built-in runtime version name", 12L)).thenReturn(
+                RuntimeVersionEntity.builder().id(7L).build());
+        resp = userJobConverter.convert(projectId, req);
+        assertEquals(7L, resp.getRuntimeVersionId());
+    }
+
+    @Test
+    public void testConvertToJobFlattenEntityBuilder() {
+        var req = UserJobCreateRequest.builder()
+                .devMode(false)
+                .jobType(JobType.EVALUATION)
+                .modelVersionId(1L)
+                .runtimeVersionId(2L)
+                .datasetVersionIds(List.of(3L, 4L))
+                .handler("handler")
+                .ttlInSec(100L)
+                .user(mock(User.class))
+                .build();
+
+        var modelVersionEntity = ModelVersionEntity.builder()
+                .id(1L)
+                .modelName("model")
+                .versionName("model version name")
+                .modelId(11L)
+                .build();
+        when(modelDao.findVersionById(1L)).thenReturn(modelVersionEntity);
+
+        var modelEntity = ModelEntity.builder()
+                .id(11L)
+                .modelName("model name")
+                .projectId(42L)
+                .build();
+        when(modelDao.findById(11L)).thenReturn(modelEntity);
+
+        var runtimeVersionEntity = RuntimeVersionEntity.builder()
+                .id(2L)
+                .versionName("runtime version name")
+                .runtimeId(12L)
+                .build();
+        when(runtimeDao.findVersionById(2L)).thenReturn(runtimeVersionEntity);
+
+        var runtimeEntity = RuntimeEntity.builder()
+                .id(12L)
+                .runtimeName("runtime name")
+                .projectId(42L)
+                .build();
+        when(runtimeDao.findById(12L)).thenReturn(runtimeEntity);
+
+        when(projectService.findProject(42L)).thenReturn(Project.builder().name("project42").build());
+        when(projectService.findProject(43L)).thenReturn(Project.builder().name("project43").build());
+
+        var datasetVersion1 = DatasetVersion.builder()
+                .id(3L)
+                .datasetName("dataset name 1")
+                .versionName("dataset version name 1")
+                .datasetId(13L)
+                .projectId(42L)
+                .build();
+        var datasetVersion2 = DatasetVersion.builder()
+                .id(4L)
+                .datasetName("dataset name 2")
+                .versionName("dataset version name 2")
+                .datasetId(14L)
+                .projectId(43L)
+                .build();
+
+        when(datasetDao.getDatasetVersion(3L)).thenReturn(datasetVersion1);
+        when(datasetDao.getDatasetVersion(4L)).thenReturn(datasetVersion2);
+
+        var flattenEntity = userJobConverter.convert(req).build();
+
+        assertEquals(req.getUser(), flattenEntity.getOwner());
+        assertEquals("project/42/runtime/12/version/2", flattenEntity.getRuntimeUri());
+        assertEquals("project/project42/runtime/runtime name/version/runtime version name",
+                flattenEntity.getRuntimeUriForView());
+        assertEquals("runtime name", flattenEntity.getRuntimeName());
+        assertEquals(2L, flattenEntity.getRuntimeVersionId());
+        assertEquals("runtime version name", flattenEntity.getRuntimeVersionValue());
+        assertEquals("model name", flattenEntity.getModelName());
+        assertEquals(1L, flattenEntity.getModelVersionId());
+        assertEquals("model version name", flattenEntity.getModelVersionValue());
+        assertEquals("project/42/model/11/version/1", flattenEntity.getModelUri());
+        assertEquals("project/project42/model/model name/version/model version name",
+                flattenEntity.getModelUriForView());
+        assertEquals(List.of("project/42/dataset/13/version/3", "project/43/dataset/14/version/4"),
+                flattenEntity.getDatasets());
+        assertEquals(Set.of(3L, 4L), flattenEntity.getDatasetIdVersionMap().keySet());
+        assertEquals("project/project42/dataset/dataset name 1/version/dataset version name 1,"
+                        + "project/project43/dataset/dataset name 2/version/dataset version name 2",
+                flattenEntity.getDatasetsForView());
+        assertFalse(flattenEntity.isDevMode());
+
+
+        // test without runtime
+        req.setRuntimeVersionId(null);
+        assertThrows(StarwhaleApiException.class, () -> userJobConverter.convert(req).build());
+    }
+}


### PR DESCRIPTION
## Description

Deprecate:
- modelVersionUrl
- runtimeVersionUrl
- datasetVersionUrls

Add:
- modelVersionId
- runtimeVersionId
- datasetVersionIds

TODO: change the console and client with the newly added fields. (This PR has not been modified for backward compatibility testing)

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
