### PR TITLE
chore(controller): prevent collecting duplicate scheduler events after controller restart

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/event/EventVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/event/EventVo.java
@@ -22,7 +22,7 @@ import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"id"})
 public class EventVo extends Event {
     Long id;
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/event/EventService.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/event/EventService.java
@@ -116,7 +116,9 @@ public class EventService {
 
         // order by created time asc
         return events.stream()
+                .distinct()
                 .map(eventConverter::toVo)
+                .distinct()
                 .sorted(Comparator.comparingLong(Event::getTimestamp))
                 .collect(Collectors.toList());
     }

--- a/server/controller/src/test/java/ai/starwhale/mlops/domain/event/EventServiceTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/domain/event/EventServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.starwhale.mlops.api.protocol.event.Event;
 import ai.starwhale.mlops.api.protocol.event.Event.EventResourceType;
 import ai.starwhale.mlops.api.protocol.event.Event.EventSource;
 import ai.starwhale.mlops.api.protocol.event.Event.EventType;
@@ -229,5 +230,23 @@ class EventServiceTest {
         assertEquals(event.getResourceType(), EventResourceType.JOB);
         assertEquals(event.getResourceId(), 1L);
         assertEquals(event.getMessage(), "foo");
+    }
+
+    @Test
+    void testDuplicateEvent() {
+        var eventBuilder = EventEntity.builder()
+                .type(EventType.INFO)
+                .source(EventSource.CLIENT)
+                .resourceType(EventResourceType.JOB)
+                .resourceId(2L)
+                .message("message")
+                .data("data")
+                .createdTime(new Date(123L));
+        var event1 = eventBuilder.id(1L).build();
+        var event2 = eventBuilder.id(2L).build();
+        when(eventMapper.listEventsOfResource(EventResourceType.JOB, 2L)).thenReturn(List.of(event1, event2));
+
+        var resp = eventService.getEvents(new Event.RelatedResource(EventResourceType.JOB, 2L));
+        assertEquals(resp.size(), 1);
     }
 }


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
