### PR TITLE
chore(controller): add env for gradio root when web service uses proxy

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/impl/SwCliModelHandlerContainerSpecification.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/schedule/impl/container/impl/SwCliModelHandlerContainerSpecification.java
@@ -160,8 +160,12 @@ public class SwCliModelHandlerContainerSpecification implements ContainerSpecifi
 
         // for online eval
         if (task.getStep().getSpec() != null && task.getStep().getSpec().getExpose() != 0) {
-            coreContainerEnvs.put("SW_ONLINE_SERVING_ROOT_PATH",
-                    webServerInTask.generateServiceRoot(task.getId(), task.getStep().getSpec().getExpose()));
+            var root = webServerInTask.generateServiceRoot(task.getId(), task.getStep().getSpec().getExpose());
+            coreContainerEnvs.put("SW_ONLINE_SERVING_ROOT_PATH", root);
+
+            // hack for gradio
+            // https://github.com/gradio-app/gradio/blob/2780d067f9f801016c0254de679b56794859abed/gradio/blocks.py#L601
+            coreContainerEnvs.put("GRADIO_ROOT_PATH", root);
         }
 
         return coreContainerEnvs;

--- a/server/controller/src/test/java/ai/starwhale/mlops/schedule/impl/contianer/SwCliModelHandlerContainerSpecificationTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/schedule/impl/contianer/SwCliModelHandlerContainerSpecificationTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.Test;
 
 public class SwCliModelHandlerContainerSpecificationTest {
 
-    static final String CONDARC = "channels:\n"
+    static final String CONDA_RC = "channels:\n"
             + "  - defaults\n"
             + "show_channel_urls: true\n"
             + "default_channels:\n"
@@ -159,7 +159,7 @@ public class SwCliModelHandlerContainerSpecificationTest {
     @Test
     public void testEnvs() throws JsonProcessingException {
         RunTimeProperties runTimeProperties = new RunTimeProperties(
-                "", new RunConfig(), new RunConfig(), new Pypi("indexU", "extraU", "trustedH", 1, 2), CONDARC);
+                "", new RunConfig(), new RunConfig(), new Pypi("indexU", "extraU", "trustedH", 1, 2), CONDA_RC);
         TaskTokenValidator taskTokenValidator = mock(TaskTokenValidator.class);
         when(taskTokenValidator.getTaskToken(any(), any())).thenReturn("tt");
         var webServerInTask = mock(WebServerInTask.class);
@@ -191,13 +191,14 @@ public class SwCliModelHandlerContainerSpecificationTest {
 
         var envWithSourceRoot = new HashMap<>(expectedEnvsRun);
         envWithSourceRoot.put("SW_ONLINE_SERVING_ROOT_PATH", "/gateway/1/1234");
+        envWithSourceRoot.put("GRADIO_ROOT_PATH", "/gateway/1/1234");
         assertMapEquals(envWithSourceRoot, csWithExposed.getContainerEnvs());
     }
 
     @Test
     public void testDevMode() throws IOException {
         RunTimeProperties runTimeProperties = new RunTimeProperties(
-                "", new RunConfig(), new RunConfig(), new Pypi("indexU", "extraU", "trustedH", 1, 2), CONDARC);
+                "", new RunConfig(), new RunConfig(), new Pypi("indexU", "extraU", "trustedH", 1, 2), CONDA_RC);
         TaskTokenValidator taskTokenValidator = mock(TaskTokenValidator.class);
         when(taskTokenValidator.getTaskToken(any(), any())).thenReturn("tt");
         var webServerInTask = mock(WebServerInTask.class);


### PR DESCRIPTION
## Description

Related to:
- #2924

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
