### PR TITLE
fix(example): make mnist mp build works

### DIFF
--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -265,9 +265,9 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
         svc = self._get_service(search_modules, workdir)
         file = self.store.hidden_sw_dir / EVALUATION_SVC_META_FILE_NAME
         spec = svc.get_spec()
-        ensure_file(file, json.dumps(spec.to_dict(), indent=4), parents=True)
-        if len(spec.apis) == 0:
+        if spec is None:
             return
+        ensure_file(file, json.dumps(spec.to_dict(), indent=4), parents=True)
 
         # make virtual handler to make the model serving can be used in model run
         func = self._serve_handler

--- a/client/tests/sdk/test_service.py
+++ b/client/tests/sdk/test_service.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests import ROOT_DIR, BaseTestCase
 from starwhale.core.model.model import StandaloneModel
+from starwhale.api._impl.service.service import Service
 from starwhale.api._impl.service.types.types import ComponentSpec
 
 
@@ -47,7 +48,7 @@ class ServiceTestCase(BaseTestCase):
 
     def test_class_without_api(self):
         svc = StandaloneModel._get_service(["no_api:NoApi"], self.root)
-        assert len(svc.get_spec().apis) == 0
+        assert svc.get_spec() is None
 
     @pytest.mark.skip("enable this test when handler supports custom service class")
     def test_custom_service(self):
@@ -60,3 +61,17 @@ class ServiceTestCase(BaseTestCase):
         x, y = json.loads(str(e.exception))
         assert x == "foo"
         assert y == 80
+
+    def test_duplicate_api(self):
+        svc = Service()
+
+        def fake_func(x):
+            return x
+
+        def another_fake_func(x):
+            return x
+
+        svc.add_api(fake_func, "foo", None, None)
+        with self.assertRaises(Exception) as e:
+            svc.add_api(another_fake_func, "foo", None, None)
+        assert "Duplicate" in str(e.exception)

--- a/example/mnist/mnist/custom_evaluator.py
+++ b/example/mnist/mnist/custom_evaluator.py
@@ -9,6 +9,7 @@ import torch
 import gradio
 from PIL import Image as PILImage
 from torchvision import transforms
+from pkg_resources import parse_version
 
 from starwhale import (
     Image,
@@ -25,6 +26,12 @@ from starwhale.base.uri.resource import Resource, ResourceType
 from .model import Net
 
 ROOTDIR = Path(__file__).parent.parent
+
+draw_input = (
+    parse_version(gradio.__version__) >= parse_version("4.5.0")
+    and gradio.Sketchpad(crop_size=(28, 28), image_mode="L")
+    or gradio.Sketchpad(shape=(28, 28), image_mode="L")
+)
 
 
 class CustomPipelineHandler:
@@ -114,9 +121,7 @@ class CustomPipelineHandler:
         output = self.model(data_tensor)
         return output.argmax(1).flatten().tolist(), np.exp(output.tolist()).tolist()
 
-    @api(
-        inputs=gradio.Sketchpad(shape=(28, 28), image_mode="L"), outputs=gradio.Label()
-    )
+    @api(inputs=draw_input, outputs=gradio.Label())
     def draw(self, data: np.ndarray) -> t.Any:
         _image_array = PILImage.fromarray(data.astype("int8"), mode="L")
         _image = transforms.Compose(

--- a/example/mnist/mnist/evaluator.py
+++ b/example/mnist/mnist/evaluator.py
@@ -6,6 +6,7 @@ import torch
 import gradio
 from PIL import Image as PILImage
 from torchvision import transforms
+from pkg_resources import parse_version
 
 from starwhale import Image, PipelineHandler, multi_classification
 from starwhale.api.service import api
@@ -16,6 +17,13 @@ except ImportError:
     from model import Net  # type: ignore
 
 ROOTDIR = Path(__file__).parent.parent
+
+
+draw_input = (
+    parse_version(gradio.__version__) >= parse_version("4.5.0")
+    and gradio.Sketchpad(crop_size=(28, 28), image_mode="L")
+    or gradio.Sketchpad(shape=(28, 28), image_mode="L")
+)
 
 
 class MNISTInference(PipelineHandler):
@@ -75,9 +83,7 @@ class MNISTInference(PipelineHandler):
         print("load mnist model, start to inference...")
         return model
 
-    @api(
-        inputs=gradio.Sketchpad(shape=(28, 28), image_mode="L"), outputs=gradio.Label()
-    )
+    @api(inputs=draw_input, outputs=gradio.Label())
     def draw(self, data: np.ndarray) -> t.Any:
         _image_array = PILImage.fromarray(data.astype("int8"), mode="L")
         _image = transforms.Compose(

--- a/example/mnist/requirements.txt
+++ b/example/mnist/requirements.txt
@@ -1,2 +1,3 @@
 torch
 torchvision
+gradio


### PR DESCRIPTION
## Description

Fixes:

- No module found
- gradio `Sketchpad` component init param breaking change
- duplicate API entry point when sw mp build

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
