### PR TITLE
fix(client): make llm chat service works with pydantic v2

### DIFF
--- a/client/starwhale/api/_impl/service/service.py
+++ b/client/starwhale/api/_impl/service/service.py
@@ -149,7 +149,7 @@ class Service:
         app = FastAPI(title=title)
 
         @app.get("/api/spec")
-        def spec() -> ServiceSpec | None:
+        def spec() -> t.Union[ServiceSpec, None]:
             return self.get_spec()
 
         for _api in self.apis.values():

--- a/client/starwhale/api/_impl/service/types/llm.py
+++ b/client/starwhale/api/_impl/service/types/llm.py
@@ -18,11 +18,10 @@ class Message:
 class Query(BaseModel):
     user_input: str
     history: List[Message]
-    confidence: Optional[float]
-    top_k: Optional[float]
-    top_p: Optional[float]
-    temperature: Optional[float]
-    max_new_tokens: Optional[int]
+    top_k: Optional[int] = None
+    top_p: Optional[float] = None
+    temperature: Optional[float] = None
+    max_new_tokens: Optional[int] = None
 
 
 class LLMChat(ServiceType):
@@ -32,7 +31,7 @@ class LLMChat(ServiceType):
     arg_types = {
         "user_input": str,
         "history": list,  # list of Message
-        "top_k": float,
+        "top_k": int,
         "top_p": float,
         "temperature": float,
         "max_new_tokens": int,


### PR DESCRIPTION
## Description

- FastAPI uses return type annotation to generate router, the typing system does not support `|`
- Pydantic v2 optional field should specify `= None` if the construct function does not always contain the field.
- Top K to int

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
