### PR TITLE
fix(controller): storage file service support put method

### DIFF
--- a/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/ObjectStoreController.java
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -95,6 +96,18 @@ public class ObjectStoreController {
             throw new SwProcessException(ErrorType.STORAGE, "download file from storage failed", e);
         }
 
+    }
+
+    @Operation(summary = "Put the content of an object or a file")
+    @PutMapping(value = "/" + URI_PREFIX + "/**", produces = MediaType.APPLICATION_JSON_VALUE)
+    void modifyObjectContent(HttpServletRequest httpServletRequest) throws IOException {
+        Tuple2<Long, String> info = extractInfoFromUri(httpServletRequest);
+        Long expTimeMillis = info._1();
+        String path = info._2();
+        if (expTimeMillis < System.currentTimeMillis()) {
+            throw new SwValidationException(ValidSubject.OBJECT_STORE, "link expired");
+        }
+        storageAccessService.put(path, httpServletRequest.getInputStream());
     }
 
     private Tuple2<Long, String> extractInfoFromUri(HttpServletRequest request) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/objectstore/StorageAccessParser.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/domain/dataset/objectstore/StorageAccessParser.java
@@ -97,7 +97,11 @@ public class StorageAccessParser implements SystemSettingListener {
                 case "fs":
                 case "file":
                     return StorageAccessService.getFileStorageAccessService(
-                            new FsConfig(token.getTokens().get("rootDir"), token.getTokens().get("serviceProvider")));
+                            new FsConfig(
+                                    token.getTokens().get("rootDir"),
+                                    token.getTokens().get("serviceProvider"),
+                                    token.getTokens().get("sigKey")
+                            ));
                 default:
                     return StorageAccessService.getS3LikeStorageAccessService(
                             token.getType(),

--- a/server/controller/src/main/resources/application.yaml
+++ b/server/controller/src/main/resources/application.yaml
@@ -91,6 +91,7 @@ sw:
     fs-config:
       root-dir: ${SW_STORAGE_FS_ROOT_DIR:/usr/local/starwhale}
       service-provider: ${SW_INSTANCE_URI}/obj-store
+      sig-key: ${SW_STORAGE_FS_SIG_KEY:starwhale}
     s3-config:
       bucket: ${SW_STORAGE_BUCKET:starwhale}
       access-key: ${SW_STORAGE_ACCESSKEY:starwhale}

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/ObjectStoreControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/ObjectStoreControllerTest.java
@@ -17,12 +17,17 @@
 package ai.starwhale.mlops.api;
 
 import static ai.starwhale.mlops.api.ObjectStoreController.URI_PREFIX;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.starwhale.mlops.exception.SwValidationException;
 import ai.starwhale.mlops.storage.LengthAbleInputStream;
 import ai.starwhale.mlops.storage.StorageAccessService;
+import ai.starwhale.mlops.storage.fs.FsStorageSignature;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -45,10 +50,14 @@ public class ObjectStoreControllerTest {
     private HttpServletRequest req;
     private DelegatingServletOutputStream outputStream;
 
+    private FsStorageSignature fsStorageSignature;
+
     @BeforeEach
     public void setUp() throws IOException {
         storageAccessService = mock(StorageAccessService.class);
-        objectStoreController = new ObjectStoreController(storageAccessService);
+        fsStorageSignature = mock(FsStorageSignature.class);
+        when(fsStorageSignature.valid(anyString(), anyLong(), anyString())).thenReturn(true);
+        objectStoreController = new ObjectStoreController(storageAccessService, fsStorageSignature);
         rsp = mock(HttpServletResponse.class);
         outputStream = new DelegatingServletOutputStream(new ByteArrayOutputStream());
         when(rsp.getOutputStream()).thenReturn(outputStream);
@@ -66,8 +75,15 @@ public class ObjectStoreControllerTest {
         LengthAbleInputStream inputStream = new LengthAbleInputStream(new ByteArrayInputStream(content.getBytes()),
                 content.length());
         when(storageAccessService.get(p, 0L, 101L)).thenReturn(inputStream);
-        objectStoreController.getObjectContent(r, req, rsp);
+        when(fsStorageSignature.valid(eq(p), anyLong(), eq("sign1"))).thenReturn(true);
+        objectStoreController.getObjectContent(r, "sign1", req, rsp);
         Assertions.assertEquals(content, outputStream.getTargetStream().toString());
+
+        when(fsStorageSignature.valid(eq(p), anyLong(), eq("sign2"))).thenReturn(false);
+        Assertions.assertThrows(
+                SwValidationException.class,
+                () -> objectStoreController.getObjectContent(r, "sign2", req, rsp)
+        );
 
     }
 
@@ -79,7 +95,7 @@ public class ObjectStoreControllerTest {
         LengthAbleInputStream inputStream = new LengthAbleInputStream(new ByteArrayInputStream(content.getBytes()),
                 content.length());
         when(storageAccessService.get(p)).thenReturn(inputStream);
-        objectStoreController.getObjectContent(r, req, rsp);
+        objectStoreController.getObjectContent(r, "", req, rsp);
         Assertions.assertEquals(content, outputStream.getTargetStream().toString());
 
     }
@@ -92,7 +108,7 @@ public class ObjectStoreControllerTest {
         LengthAbleInputStream inputStream = new LengthAbleInputStream(new ByteArrayInputStream(content.getBytes()),
                 content.length());
         when(storageAccessService.get(p)).thenReturn(inputStream);
-        objectStoreController.getObjectContent(r, req, rsp);
+        objectStoreController.getObjectContent(r, "", req, rsp);
         Assertions.assertEquals(content, outputStream.getTargetStream().toString());
 
     }
@@ -103,7 +119,7 @@ public class ObjectStoreControllerTest {
         String content = "content";
         ServletInputStream inputStream = new DelegatingServletInputStream(new ByteArrayInputStream(content.getBytes()));
         when(req.getInputStream()).thenReturn(inputStream);
-        objectStoreController.modifyObjectContent(req);
+        objectStoreController.modifyObjectContent(req, "");
         verify(storageAccessService).put(p, inputStream);
     }
 

--- a/server/controller/src/test/java/ai/starwhale/mlops/api/ObjectStoreControllerTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/api/ObjectStoreControllerTest.java
@@ -18,6 +18,7 @@ package ai.starwhale.mlops.api;
 
 import static ai.starwhale.mlops.api.ObjectStoreController.URI_PREFIX;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.starwhale.mlops.storage.LengthAbleInputStream;
@@ -25,11 +26,13 @@ import ai.starwhale.mlops.storage.StorageAccessService;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.DelegatingServletInputStream;
 import org.springframework.mock.web.DelegatingServletOutputStream;
 
 public class ObjectStoreControllerTest {
@@ -92,6 +95,16 @@ public class ObjectStoreControllerTest {
         objectStoreController.getObjectContent(r, req, rsp);
         Assertions.assertEquals(content, outputStream.getTargetStream().toString());
 
+    }
+
+    @Test
+    public void testPut() throws IOException {
+        var p = "p";
+        String content = "content";
+        ServletInputStream inputStream = new DelegatingServletInputStream(new ByteArrayInputStream(content.getBytes()));
+        when(req.getInputStream()).thenReturn(inputStream);
+        objectStoreController.modifyObjectContent(req);
+        verify(storageAccessService).put(p, inputStream);
     }
 
 }

--- a/server/storage-access-layer/pom.xml
+++ b/server/storage-access-layer/pom.xml
@@ -91,6 +91,14 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/FsConfig.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/FsConfig.java
@@ -38,4 +38,7 @@ public class FsConfig {
      * the service who is serving the pre-signed url
      */
     private String serviceProvider;
+
+    private String sigKey;
+
 }

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/FsStorageSignature.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/FsStorageSignature.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.storage.fs;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+@ConditionalOnProperty(prefix = "sw.storage", name = "type", havingValue = "fs")
+public class FsStorageSignature {
+
+    private static final String hmacSHA256 = "HmacSHA256";
+
+    final String privateKey;
+
+    public FsStorageSignature(@Value("${sw.storage.fs-config.sig-key}") String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public String sign(String path, Long expMilli) {
+        return generateHmacSignature(path + expMilli, privateKey);
+    }
+
+    public boolean valid(String path, Long expMilli, String sign) {
+        return sign.equals(generateHmacSignature(path + expMilli, privateKey));
+    }
+
+    private static String generateHmacSignature(String data, String key) {
+        SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), hmacSHA256);
+        Mac mac;
+        try {
+            mac = Mac.getInstance(hmacSHA256);
+            mac.init(secretKeySpec);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        } catch (InvalidKeyException e) {
+            throw new RuntimeException(e);
+        }
+        byte[] hash = mac.doFinal(data.getBytes());
+
+        // Convert byte array to hexadecimal string
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : hash) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+
+        return hexString.toString();
+    }
+}

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFile.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFile.java
@@ -50,12 +50,15 @@ public class StorageAccessServiceFile extends AbstractStorageAccessService {
 
     private final String serviceProvider;
 
+    private final FsStorageSignature fsStorageSignature;
+
     /**
-     * @param fsConfig fsConfig
+     * @param fsConfig           fsConfig
      */
     public StorageAccessServiceFile(FsConfig fsConfig) {
         this.rootDir = new File(fsConfig.getRootDir());
         this.serviceProvider = fsConfig.getServiceProvider();
+        this.fsStorageSignature = new FsStorageSignature(fsConfig.getSigKey());
         if (!this.rootDir.exists()) {
             throw new IllegalArgumentException(rootDir + " does not exist");
         }
@@ -171,12 +174,14 @@ public class StorageAccessServiceFile extends AbstractStorageAccessService {
 
     @Override
     public String signedUrl(String path, Long expTimeMillis) throws IOException {
-        return possibleServerUrl() + "/" + path + "/" + (System.currentTimeMillis() + expTimeMillis);
+        String sign = fsStorageSignature.sign(path, expTimeMillis);
+        return possibleServerUrl() + "/" + path + "/" + (System.currentTimeMillis() + expTimeMillis) + "?sign=" + sign;
     }
 
     @Override
     public String signedPutUrl(String path, String contentType, Long expTimeMillis) throws IOException {
-        return possibleServerUrl() + "/" + path + "/" + (System.currentTimeMillis() + expTimeMillis);
+        String sign = fsStorageSignature.sign(path, expTimeMillis);
+        return possibleServerUrl() + "/" + path + "/" + (System.currentTimeMillis() + expTimeMillis) + "?sign=" + sign;
     }
 
     private String possibleServerUrl() {

--- a/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFile.java
+++ b/server/storage-access-layer/src/main/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFile.java
@@ -174,14 +174,16 @@ public class StorageAccessServiceFile extends AbstractStorageAccessService {
 
     @Override
     public String signedUrl(String path, Long expTimeMillis) throws IOException {
-        String sign = fsStorageSignature.sign(path, expTimeMillis);
-        return possibleServerUrl() + "/" + path + "/" + (System.currentTimeMillis() + expTimeMillis) + "?sign=" + sign;
+        long expTime = System.currentTimeMillis() + expTimeMillis;
+        String sign = fsStorageSignature.sign(path, expTime);
+        return possibleServerUrl() + "/" + path + "/" + expTime + "?sign=" + sign;
     }
 
     @Override
     public String signedPutUrl(String path, String contentType, Long expTimeMillis) throws IOException {
-        String sign = fsStorageSignature.sign(path, expTimeMillis);
-        return possibleServerUrl() + "/" + path + "/" + (System.currentTimeMillis() + expTimeMillis) + "?sign=" + sign;
+        long expTime = System.currentTimeMillis() + expTimeMillis;
+        String sign = fsStorageSignature.sign(path, expTime);
+        return possibleServerUrl() + "/" + path + "/" + expTime + "?sign=" + sign;
     }
 
     private String possibleServerUrl() {

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/StorageAccessServiceTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/StorageAccessServiceTest.java
@@ -144,7 +144,7 @@ public class StorageAccessServiceTest {
 
     @Test
     public void testFile() throws Exception {
-        this.run(new StorageAccessServiceFile(new FsConfig(this.rootDir.getAbsolutePath(), "")), false);
+        this.run(new StorageAccessServiceFile(new FsConfig(this.rootDir.getAbsolutePath(), "", "")), false);
     }
 
     @Test

--- a/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFileTest.java
+++ b/server/storage-access-layer/src/test/java/ai/starwhale/mlops/storage/fs/StorageAccessServiceFileTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.when;
 import ai.starwhale.mlops.storage.LengthAbleInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -47,7 +49,7 @@ public class StorageAccessServiceFileTest {
     @BeforeEach
     public void setUp() {
         this.service = new StorageAccessServiceFile(
-                new FsConfig(this.rootDir.getAbsolutePath(), "http://localhost:8082"));
+                new FsConfig(this.rootDir.getAbsolutePath(), "http://localhost:8082", "abc"));
     }
 
     @Test
@@ -73,12 +75,14 @@ public class StorageAccessServiceFileTest {
     }
 
     @Test
-    public void testSignedUrl() throws IOException {
+    public void testSignedUrl() throws IOException, URISyntaxException {
         String path = "unit_test/x";
         String content = "hello word";
         service.put(path, content.getBytes(StandardCharsets.UTF_8));
         String signedUrl = service.signedUrl(path, 1000 * 60L);
         Assertions.assertTrue(signedUrl.startsWith("http://localhost:8082/unit_test/x"));
+        String signQuery = new URI(signedUrl).getQuery();
+        Assertions.assertTrue(signQuery.contains("sign="));
 
         try (MockedStatic<RequestContextHolder> requestContextHolderMockedStatic =
                      Mockito.mockStatic(RequestContextHolder.class)) {
@@ -96,12 +100,14 @@ public class StorageAccessServiceFileTest {
     }
 
     @Test
-    public void testSignedPutUrl() throws IOException {
+    public void testSignedPutUrl() throws IOException, URISyntaxException {
         String path = "unit_test/x";
         String content = "hello word";
         service.put(path, content.getBytes(StandardCharsets.UTF_8));
         String signedUrl = service.signedPutUrl(path, "text/plain", 1000 * 60L);
         Assertions.assertTrue(signedUrl.startsWith("http://localhost:8082/unit_test/x"));
+        String signQuery = new URI(signedUrl).getQuery();
+        Assertions.assertTrue(signQuery.contains("sign="));
 
         try (MockedStatic<RequestContextHolder> requestContextHolderMockedStatic =
                      Mockito.mockStatic(RequestContextHolder.class)) {


### PR DESCRIPTION
## Description

1. make file type object store support file type
2. server signed url are sourced from request server name
cc @tianweidut 

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
