### PR TITLE
fix(ci): fix ci release dependency error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
 
   server-image-release:
     runs-on: ubuntu-latest
+    needs:
+      - pypi-release
 
     steps:
       - uses: actions/checkout@v3

--- a/docker/Dockerfile.dataset_build
+++ b/docker/Dockerfile.dataset_build
@@ -6,6 +6,6 @@ ARG SW_VERSION
 
 ENV SW_RUNTIME_PYTHON_VERSION=${PYTHON_VERSION:-3.10}
 ENV SW_VERSION=${SW_VERSION:-0.5.8}
-RUN /opt/starwhale.bin/base-entrypoint set_environment || true
+RUN /opt/starwhale.bin/base-entrypoint set_environment
 
 ENV SW_USER_RUNTIME_RESTORED=1

--- a/docker/Dockerfile.runtime_dockerizing
+++ b/docker/Dockerfile.runtime_dockerizing
@@ -14,7 +14,7 @@ COPY --from=kaniko /kaniko/docker-credential-acr-env /kaniko/docker-credential-a
 COPY --from=kaniko /kaniko/.docker /kaniko/.docker
 COPY --from=kaniko /kaniko/ssl/certs/ /kaniko/ssl/certs/
 COPY --from=kaniko /etc/nsswitch.conf /etc/nsswitch.conf
-RUN /opt/starwhale.bin/base-entrypoint set_environment || true
+RUN /opt/starwhale.bin/base-entrypoint set_environment
 
 ENV SW_USER_RUNTIME_RESTORED=1
 ENV PATH $PATH:/usr/local/bin:/kaniko


### PR DESCRIPTION
## Description

dataset build image and runtime dockerize image are released without cli installed :
https://github.com/star-whale/starwhale/actions/runs/6898786066/job/18769619272

![image](https://github.com/star-whale/starwhale/assets/89630947/f615ba14-c41e-467d-b5f4-360cf23aaf16)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
