### PR TITLE
enhance(client): support text to img infer type

### DIFF
--- a/client/starwhale/api/_impl/service/service.py
+++ b/client/starwhale/api/_impl/service/service.py
@@ -106,6 +106,9 @@ class Service:
             if old.__module__ != func.__module__ or old.__name__ != func.__name__:
                 raise ValueError(f"Duplicate api uri: {uri}")
 
+        if inference_type is not None:
+            inference_type.update_from_func(func)
+
         _api = Api(
             func=func,
             uri=f"{uri}",

--- a/client/starwhale/api/_impl/service/types/llm.py
+++ b/client/starwhale/api/_impl/service/types/llm.py
@@ -14,14 +14,14 @@ from starwhale.base.client.models.models import (
 from .types import ServiceType
 
 
-class Message(BaseModel):
+class MessageItem(BaseModel):
     content: str
-    role: str
+    bot: bool = False
 
 
 class Query(BaseModel):
     user_input: str
-    history: List[Message]
+    history: List[MessageItem]
     top_k: Optional[int] = None
     top_p: Optional[float] = None
     temperature: Optional[float] = None
@@ -30,6 +30,7 @@ class Query(BaseModel):
 
 class LLMChat(ServiceType):
     name = "llm_chat"
+    args = {}
 
     # TODO use pydantic model annotations generated arg_types
     arg_types: Dict[str, ComponentSpecValueType] = {
@@ -41,7 +42,7 @@ class LLMChat(ServiceType):
         "max_new_tokens": ComponentSpecValueType.int,
     }
 
-    args = {}
+    Message = MessageItem
 
     def __init__(
         self,
@@ -49,16 +50,12 @@ class LLMChat(ServiceType):
         top_p: ComponentValueSpecFloat | None = None,
         temperature: ComponentValueSpecFloat | None = None,
         max_new_tokens: ComponentValueSpecInt | None = None,
-        **kwargs: Any,
     ) -> None:
-        if top_k is not None:
-            self.args["top_k"] = top_k
-        if top_p is not None:
-            self.args["top_p"] = top_p
-        if temperature is not None:
-            self.args["temperature"] = temperature
-        if max_new_tokens is not None:
-            self.args["max_new_tokens"] = max_new_tokens
+        for k, v in locals().items():
+            if k == "self":
+                continue
+            if v is not None:
+                self.args[k] = v
 
     def router_fn(self, func: Callable) -> Callable:
         params = inspect.signature(func).parameters

--- a/client/starwhale/api/_impl/service/types/text_to_img.py
+++ b/client/starwhale/api/_impl/service/types/text_to_img.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, Dict, Callable, Optional
+
+from pydantic import BaseModel
+
+from starwhale.base.client.models.models import (
+    ComponentValueSpecInt,
+    ComponentSpecValueType,
+)
+from starwhale.api._impl.service.types.types import ServiceType
+
+
+class Query(BaseModel):
+    prompt: str
+    negative_prompt: Optional[str] = None
+    sampling_steps: Optional[int] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    seed: Optional[int] = None
+    batch_size: Optional[int] = None
+    batch_count: Optional[int] = None
+
+
+class TextToImage(ServiceType):
+    name = "text_to_image"
+    args = {}
+
+    arg_types: Dict[str, ComponentSpecValueType] = {
+        "prompt": ComponentSpecValueType.string,
+        "negative_prompt": ComponentSpecValueType.string,
+        "sampling_steps": ComponentSpecValueType.int,
+        "width": ComponentSpecValueType.int,
+        "height": ComponentSpecValueType.int,
+        "seed": ComponentSpecValueType.int,
+        "batch_size": ComponentSpecValueType.int,
+        "batch_count": ComponentSpecValueType.int,
+    }
+
+    def __init__(
+        self,
+        sampling_steps: ComponentValueSpecInt | None = None,
+        width: ComponentValueSpecInt | None = None,
+        height: ComponentValueSpecInt | None = None,
+        seed: ComponentValueSpecInt | None = None,
+        batch_size: ComponentValueSpecInt | None = None,
+        batch_count: ComponentValueSpecInt | None = None,
+    ) -> None:
+        for k, v in locals().items():
+            if k == "self":
+                continue
+            if v is not None:
+                self.args[k] = v
+
+    def router_fn(self, func: Callable) -> Callable:
+        params = inspect.signature(func).parameters
+
+        def wrapper(query: Query) -> Any:
+            return func(**{k: getattr(query, k) for k in params})
+
+        return wrapper

--- a/client/tests/data/sdk/service/default_class.py
+++ b/client/tests/data/sdk/service/default_class.py
@@ -23,5 +23,5 @@ class MyDefaultClass(PipelineHandler):
             max_new_tokens=ComponentValueSpecInt(default_val=64, max=1024),
         )
     )
-    def cmp(self, ppl_result: t.Iterator) -> t.Any:
+    def cmp(self, top_p: float = 0.9) -> t.Any:
         pass

--- a/client/tests/sdk/test_service.py
+++ b/client/tests/sdk/test_service.py
@@ -45,7 +45,7 @@ class ServiceTestCase(BaseTestCase):
         assert spec.apis[0].uri == "cmp"
         assert spec.apis[0].inference_type == "llm_chat"
         components = spec.apis[0].components
-        assert len(components) == 3
+        assert len(components) == 4
         for c in [
             ComponentSpec(
                 name="temperature",
@@ -63,6 +63,11 @@ class ServiceTestCase(BaseTestCase):
                 component_value_spec_int=ComponentValueSpecInt(
                     default_val=64, max=1024
                 ),
+            ),
+            ComponentSpec(
+                name="top_p",
+                component_spec_value_type=ComponentSpecValueType.float,
+                component_value_spec_float=ComponentValueSpecFloat(default_val=0.9),
             ),
         ]:
             assert c in components

--- a/client/tests/sdk/test_types.py
+++ b/client/tests/sdk/test_types.py
@@ -1,6 +1,11 @@
 import pytest
 
 from starwhale.api._impl.service.types import all_components_are_gradio
+from starwhale.base.client.models.models import (
+    ComponentValueSpecInt,
+    ComponentSpecValueType,
+)
+from starwhale.api._impl.service.types.text_to_img import TextToImage
 
 
 @pytest.mark.skip("enable this test when starwhale support pydantic 2.0+")
@@ -24,3 +29,28 @@ def test_all_components_are_gradio():
         all_components_are_gradio([gradio.inputs.Textbox()], [gradio.outputs.Label()])
         is True
     )
+
+
+def test_text_to_image():
+    t = TextToImage()
+
+    assert t.name == "text_to_image"
+    assert t.args == {}
+    assert t.arg_types == {
+        "prompt": ComponentSpecValueType.string,
+        "negative_prompt": ComponentSpecValueType.string,
+        "sampling_steps": ComponentSpecValueType.int,
+        "width": ComponentSpecValueType.int,
+        "height": ComponentSpecValueType.int,
+        "seed": ComponentSpecValueType.int,
+        "batch_size": ComponentSpecValueType.int,
+        "batch_count": ComponentSpecValueType.int,
+    }
+
+    t = TextToImage(
+        sampling_steps=ComponentValueSpecInt(default_val=1),
+    )
+
+    assert t.args == {
+        "sampling_steps": ComponentValueSpecInt(default_val=1),
+    }

--- a/example/web-handler/main.py
+++ b/example/web-handler/main.py
@@ -1,29 +1,19 @@
 from typing import List
 
 from starwhale.api.service import api, LLMChat
-from starwhale.base.client.models.models import (
-    ComponentValueSpecInt,
-    ComponentValueSpecFloat,
-)
 
 
-@api(
-    inference_type=LLMChat(
-        top_p=ComponentValueSpecFloat(defaultVal=0.9, max=1.0, min=0.1, step=0.1),
-        temperature=ComponentValueSpecFloat(defaultVal=0.5, step=0.01),
-        max_new_tokens=ComponentValueSpecInt(defaultVal=100, max=1000, min=10),
-    )
-)
+@api(inference_type=LLMChat())
 def fake_chat_bot(
     user_input: str,
-    history: List[dict],
-    temperature: float,
-    top_k: int,
-    top_p: float,
-    max_new_tokens: int,
+    history: List[LLMChat.Message],
+    temperature: float = 0.5,
+    top_p: float = 0.9,
+    top_k: int = 1,
+    max_new_tokens: int = 100,
 ) -> List[dict]:
     result = f"hello from chat bot with {user_input}, and temperature {temperature}, and top_k {top_k}, and top_p {top_p}, and max_new_tokens {max_new_tokens}"
     history.extend(
-        [{"content": user_input, "role": "user"}, {"content": result, "role": "bot"}]
+        [LLMChat.Message(content=user_input), LLMChat.Message(content=result, bot=True)]
     )
     return history


### PR DESCRIPTION
## Description

- Add `TextToImage` type
- Change `Message.role(str)` to `bot(bool)`
- Support getting arg spec from the func signature

Content of the web-handler's job.yaml:

```
serving:
- concurrency: 1
  expose: 8080
  extra_kwargs:
    search_modules:
    - main
  func_name: StandaloneModel._serve_handler
  module_name: starwhale.core.model.model
  name: serving
  replicas: 1
  service_spec:
    apis:
    - components:
      - component_spec_value_type: STRING
        name: user_input
      - component_spec_value_type: LIST
        name: history
      - componentValueSpecFloat:
          defaultVal: 0.5
        component_spec_value_type: FLOAT
        name: temperature
      - componentValueSpecFloat:
          defaultVal: 0.9
        component_spec_value_type: FLOAT
        name: top_p
      - componentValueSpecInt:
          defaultVal: 100
        component_spec_value_type: INT
        name: max_new_tokens
      inference_type: llm_chat
      uri: fake_chat_bot
    version: 0.0.2
  show_name: virtual handler for model serving
  virtual: true
```

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
