### PR TITLE
fix(e2e): fix client test failure doesn't populate to parent script

### DIFF
--- a/scripts/e2e_test/start_test.sh
+++ b/scripts/e2e_test/start_test.sh
@@ -325,7 +325,7 @@ client_test() {
   if ! in_github_action; then
     unset http_proxy
     unset https_proxy
-    bash scripts/client_test/cli_test.sh all
+    bash scripts/client_test/cli_test.sh all || exit 1
   else
     timeout 20m bash scripts/client_test/cli_test.sh simple || exit 1
   fi


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
