### PR TITLE
fix(example): fix ucf101 example error

### DIFF
--- a/example/ucf101/ucf101/evaluator.py
+++ b/example/ucf101/ucf101/evaluator.py
@@ -232,7 +232,7 @@ class UCF101PipelineHandler(PipelineHandler):
         return label, result, pr
 
     @api(
-        gradio.Video(type="filepath"),
+        gradio.Video(sources=["upload"]),
         gradio.Label(num_top_classes=5),
     )
     def online_eval(self, file: str):


### PR DESCRIPTION
## Description

ucf example fails for gradio version being 4.7.1
![image](https://github.com/star-whale/starwhale/assets/89630947/96df1b10-9c96-470c-8c34-3761c2d54343)


## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
