### PR TITLE
fix(console): prevent dead loop when list datastore tables

### DIFF
--- a/console/packages/starwhale-core/src/datastore/hooks/useFetchDatastoreAllTables.tsx
+++ b/console/packages/starwhale-core/src/datastore/hooks/useFetchDatastoreAllTables.tsx
@@ -22,8 +22,9 @@ export function useFetchDatastoreAllTables(
     const allTables = useListDatastoreTables(params, !!params)
 
     const tables = React.useMemo(() => {
-        return allTables.data?.tables?.sort((a, b) => (a > b ? 1 : -1)) ?? []
-    }, [allTables])
+        const _tables = allTables.data?.tables ?? []
+        return [..._tables].sort((a, b) => (a > b ? 1 : -1))
+    }, [allTables.data])
 
     return {
         isSuccess: allTables.isSuccess,


### PR DESCRIPTION
## Description

`react-query` uses deep equal to do the optimization
we can not change the cached data.

ref:  https://github.com/TanStack/query/blob/dd3f2a718bdeea282ae12db15e1733b48309cc62/src/core/query.ts#L241-L247

```ts
// Use prev data if an isDataEqual function is defined and returns `true`
if (this.options.isDataEqual?.(prevData, data)) {
  data = prevData as TData
} else if (this.options.structuralSharing !== false) {
  // Structurally share data between prev and new data if needed
  data = replaceEqualDeep(prevData, data)
}
```

The response contains many status fields we do not need, use `resp.data` as the dependency.

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
