### PR TITLE
feat(sdk): support Image type to accept numpy and pillow image types

### DIFF
--- a/client/starwhale/api/_impl/dataset/model.py
+++ b/client/starwhale/api/_impl/dataset/model.py
@@ -1774,7 +1774,7 @@ class Dataset:
                     record["caption"] = caption_path.read_text().strip()
 
                 record["file"] = file_cls(
-                    fp=p,
+                    p,
                     display_name=p.name,
                     mime_type=MIMEType.create_by_file_suffix(p),
                 )

--- a/client/starwhale/integrations/huggingface/dataset.py
+++ b/client/starwhale/integrations/huggingface/dataset.py
@@ -36,17 +36,13 @@ def _transform_to_starwhale(data: t.Any, feature: t.Any) -> t.Any:
         from PIL import Image as PILImage
 
         if isinstance(data, PILImage.Image):
-            img_io = io.BytesIO()
-            data.save(img_io, format=data.format or "PNG")
-            img_fp = img_io.getvalue()
-
             try:
                 data_mimetype = data.get_format_mimetype()
                 mime_type = MIMEType(data_mimetype)
             except (ValueError, AttributeError):
                 mime_type = MIMEType.PNG
             return Image(
-                fp=img_fp,
+                data,
                 shape=(data.height, data.width, len(data.getbands())),
                 mime_type=mime_type,
             )

--- a/client/tests/core/test_dataset.py
+++ b/client/tests/core/test_dataset.py
@@ -477,7 +477,7 @@ class StandaloneDatasetTestCase(BaseTestCase):
             (
                 "label-0",
                 {
-                    "img": GrayscaleImage(fp=b"123"),
+                    "img": GrayscaleImage(b"123"),
                     "label": 0,
                 },
             )
@@ -486,7 +486,7 @@ class StandaloneDatasetTestCase(BaseTestCase):
             (
                 "label-1",
                 {
-                    "img": GrayscaleImage(fp=b"456"),
+                    "img": GrayscaleImage(b"456"),
                     "label": 1,
                 },
             )

--- a/client/tests/sdk/test_loader.py
+++ b/client/tests/sdk/test_loader.py
@@ -638,7 +638,7 @@ class TestDataLoader(TestCase):
         assert dr < dr_another
         assert dr != dr_another
 
-        dr_third = DataRow(index=1, features={"data": Image(fp=b""), "label": 10})
+        dr_third = DataRow(index=1, features={"data": Image(b""), "label": 10})
         assert dr >= dr_third
 
     def test_data_row_exceptions(self) -> None:

--- a/scripts/example/src/util.py
+++ b/scripts/example/src/util.py
@@ -5,7 +5,7 @@ import string
 from starwhale import Image
 
 
-def random_image() -> bytes:
+def random_image() -> Image:
     try:
         return _random_image_from_pillow()
     except ImportError:


### PR DESCRIPTION
## Description

## Modules
- [x] Python-SDK

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
