### PR TITLE
enhance(datastore): support updating table with schema embedded records

### DIFF
--- a/client/starwhale/base/client/models/models.py
+++ b/client/starwhale/base/client/models/models.py
@@ -384,6 +384,23 @@ class RecordValueDesc(SwBaseModel):
     value: Optional[Dict[str, Any]] = None
 
 
+class DataStoreValueType(Enum):
+    unknown = 'UNKNOWN'
+    bool = 'BOOL'
+    int8 = 'INT8'
+    int16 = 'INT16'
+    int32 = 'INT32'
+    int64 = 'INT64'
+    float32 = 'FLOAT32'
+    float64 = 'FLOAT64'
+    string = 'STRING'
+    bytes = 'BYTES'
+    list = 'LIST'
+    tuple = 'TUPLE'
+    map = 'MAP'
+    object = 'OBJECT'
+
+
 class ColumnDesc(SwBaseModel):
     column_name: Optional[str] = Field(None, alias='columnName')
     alias: Optional[str] = None
@@ -1763,6 +1780,34 @@ class UpdateTableRequest(SwBaseModel):
     records: Optional[List[RecordDesc]] = None
 
 
+class RecordCellDesc(SwBaseModel):
+    data_store_value_type: DataStoreValueType = Field(..., alias='dataStoreValueType')
+    scalar_value: Optional[str] = Field(None, alias='scalarValue')
+    list_value: Optional[List[RecordCellDesc]] = Field(None, alias='listValue')
+    map_value: Optional[List[RecordCellMapItem]] = Field(None, alias='mapValue')
+    object_value: Optional[RecordCellObject] = Field(None, alias='objectValue')
+
+
+class RecordCellMapItem(SwBaseModel):
+    key: Optional[RecordCellDesc] = None
+    value: Optional[RecordCellDesc] = None
+
+
+class RecordCellObject(SwBaseModel):
+    attrs: Optional[Dict[str, RecordCellDesc]] = None
+    python_type: Optional[str] = Field(None, alias='pythonType')
+
+
+class RecordRowDesc(SwBaseModel):
+    cells: Dict[str, RecordCellDesc]
+
+
+class UpdateTableEmbeddedRequest(SwBaseModel):
+    table_name: str = Field(..., alias='tableName')
+    key_column: str = Field(..., alias='keyColumn')
+    rows: List[RecordRowDesc]
+
+
 class RecordListVo(SwBaseModel):
     column_types: Optional[List[ColumnSchemaDesc]] = Field(None, alias='columnTypes')
     column_hints: Optional[Dict[str, ColumnHintsDesc]] = Field(
@@ -1812,5 +1857,6 @@ class TableQueryOperandDesc(SwBaseModel):
 
 ColumnHintsDesc.update_forward_refs()
 ColumnSchemaDesc.update_forward_refs()
+RecordCellDesc.update_forward_refs()
 QueryTableRequest.update_forward_refs()
 TableQueryFilterDesc.update_forward_refs()

--- a/console/src/api/server/Api.ts
+++ b/console/src/api/server/Api.ts
@@ -213,6 +213,8 @@ import {
     IUpdateSettingData,
     IUpdateSpaceData,
     IUpdateTableData,
+    IUpdateTableEmbeddedData,
+    IUpdateTableEmbeddedRequest,
     IUpdateTableRequest,
     IUpdateUserPwdData,
     IUpdateUserStateData,
@@ -2693,6 +2695,25 @@ export class Api<SecurityDataType = unknown> {
     updateTable = (data: IUpdateTableRequest, params: RequestParams = {}) =>
         this.http.request<IUpdateTableData, any>({
             path: `/api/v1/datastore/updateTable`,
+            method: 'POST',
+            body: data,
+            secure: true,
+            type: ContentType.Json,
+            ...params,
+        })
+
+    /**
+     * No description
+     *
+     * @tags data-store-controller
+     * @name UpdateTableEmbedded
+     * @request POST:/api/v1/datastore/updateTable/embedded
+     * @secure
+     * @response `200` `IUpdateTableEmbeddedData` OK
+     */
+    updateTableEmbedded = (data: IUpdateTableEmbeddedRequest, params: RequestParams = {}) =>
+        this.http.request<IUpdateTableEmbeddedData, any>({
+            path: `/api/v1/datastore/updateTable/embedded`,
             method: 'POST',
             body: data,
             secure: true,

--- a/console/src/api/server/data-contracts.ts
+++ b/console/src/api/server/data-contracts.ts
@@ -459,6 +459,48 @@ export interface IUpdateTableRequest {
     records?: IRecordDesc[]
 }
 
+export interface IRecordCellDesc {
+    dataStoreValueType:
+        | 'UNKNOWN'
+        | 'BOOL'
+        | 'INT8'
+        | 'INT16'
+        | 'INT32'
+        | 'INT64'
+        | 'FLOAT32'
+        | 'FLOAT64'
+        | 'STRING'
+        | 'BYTES'
+        | 'LIST'
+        | 'TUPLE'
+        | 'MAP'
+        | 'OBJECT'
+    scalarValue?: string
+    listValue?: IRecordCellDesc[]
+    mapValue?: IRecordCellMapItem[]
+    objectValue?: IRecordCellObject
+}
+
+export interface IRecordCellMapItem {
+    key?: IRecordCellDesc
+    value?: IRecordCellDesc
+}
+
+export interface IRecordCellObject {
+    attrs?: Record<string, IRecordCellDesc>
+    pythonType?: string
+}
+
+export interface IRecordRowDesc {
+    cells: Record<string, IRecordCellDesc>
+}
+
+export interface IUpdateTableEmbeddedRequest {
+    tableName: string
+    keyColumn: string
+    rows: IRecordRowDesc[]
+}
+
 export interface IColumnDesc {
     columnName?: string
     alias?: string
@@ -2350,6 +2392,8 @@ export type IInstallPluginData = IResponseMessageString['data']
 export type ISignLinks2Data = IResponseMessageMapStringString['data']
 
 export type IUpdateTableData = IResponseMessageString['data']
+
+export type IUpdateTableEmbeddedData = IResponseMessageString['data']
 
 export type IScanTableData = IResponseMessageRecordListVo['data']
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
@@ -27,6 +27,7 @@ import ai.starwhale.mlops.api.protocol.datastore.ScanTableRequest;
 import ai.starwhale.mlops.api.protocol.datastore.TableNameListVo;
 import ai.starwhale.mlops.api.protocol.datastore.TableQueryFilterDesc;
 import ai.starwhale.mlops.api.protocol.datastore.TableQueryOperandDesc;
+import ai.starwhale.mlops.api.protocol.datastore.UpdateTableEmbeddedRequest;
 import ai.starwhale.mlops.api.protocol.datastore.UpdateTableRequest;
 import ai.starwhale.mlops.datastore.ColumnSchema;
 import ai.starwhale.mlops.datastore.ColumnType;
@@ -134,6 +135,15 @@ public class DataStoreController {
         } catch (SwValidationException e) {
             throw new SwValidationException(SwValidationException.ValidSubject.DATASTORE, "request=" + request, e);
         }
+    }
+
+    @PostMapping(value = "/datastore/updateTable/embedded")
+    @PreAuthorize("hasAnyRole('OWNER', 'MAINTAINER')")
+    ResponseEntity<ResponseMessage<String>> updateTableEmbedded(
+            @Valid @RequestBody UpdateTableEmbeddedRequest request
+    ) {
+        var revision = this.dataStore.updateWithTypeEmbed(request);
+        return ResponseEntity.ok(Code.success.asResponse(revision));
     }
 
     @PostMapping(value = "/datastore/flush")

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/RecordCellDesc.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/RecordCellDesc.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.datastore;
+
+import ai.starwhale.mlops.datastore.ColumnType;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecordCellDesc {
+    /**
+     * The record value type.
+     */
+    // this long name definition is for swagger to generate the schema without naming with number extension
+    @NotNull
+    ColumnType dataStoreValueType;
+
+    /**
+     * This field can not be null when dataStoreValueType is scalar,
+     * e.g. INT8, INT16, INT32, INT64, FLOAT32, FLOAT64, STRING, BOOL
+     * and the value must be encoded scalar in string.
+     */
+    String scalarValue;
+
+    /**
+     * This field can not be null when dataStoreValueType is list or tuple,
+     */
+    // this annotation is for swagger to generate the schema
+    @ArraySchema(schema = @Schema(implementation = RecordCellDesc.class))
+    List<RecordCellDesc> listValue;
+
+    /**
+     * This field can not be null when dataStoreValueType is map,
+     */
+    // OpenAPI do not support Map<RecordWithType, RecordWithType> directly, (json or yaml only support string key)
+    // so we use a wrapper class
+    List<RecordCellMapItem> mapValue;
+
+    /**
+     * This field can not be null when dataStoreValueType is object,
+     */
+    RecordCellObject objectValue;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RecordCellMapItem {
+        RecordCellDesc key;
+        RecordCellDesc value;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RecordCellObject {
+        Map<String, RecordCellDesc> attrs;
+        String pythonType;
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/RecordRowDesc.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/RecordRowDesc.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.datastore;
+
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecordRowDesc {
+
+    @NotNull
+    private Map<String, RecordCellDesc> cells;
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/UpdateTableEmbeddedRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/UpdateTableEmbeddedRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.datastore;
+
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateTableEmbeddedRequest {
+
+    @NotNull
+    private String tableName;
+
+    @NotNull
+    private String keyColumn;
+
+    @NotNull
+    private List<RecordRowDesc> rows;
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchemaDesc.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/ColumnSchemaDesc.java
@@ -29,15 +29,17 @@ import javax.validation.constraints.Null;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 /**
  * This class describes the schema of a column or an attribute of an object, including its name and type.
  */
 @Data
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 @JsonInclude(Include.NON_NULL)
 public class ColumnSchemaDesc {
 
@@ -185,9 +187,14 @@ public class ColumnSchemaDesc {
     }
 
     public static ColumnSchemaDescBuilder objectOf(String pythonType, ColumnSchemaDescBuilder... attributes) {
+        var attrs = Stream.of(attributes).map(ColumnSchemaDescBuilder::build).collect(Collectors.toList());
+        return objectOf(pythonType, attrs);
+    }
+
+    public static ColumnSchemaDescBuilder objectOf(String pythonType, List<ColumnSchemaDesc> attributes) {
         return ColumnSchemaDesc.builder()
                 .type(ColumnType.OBJECT.name())
                 .pythonType(pythonType)
-                .attributes(Stream.of(attributes).map(ColumnSchemaDescBuilder::build).collect(Collectors.toList()));
+                .attributes(attributes);
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
@@ -33,13 +33,23 @@ public interface MemoryTable {
     // update records, returns the timestamp in milliseconds
     long update(TableSchemaDesc schema, List<Map<String, Object>> records);
 
+    /**
+     * update records, returns the timestamp in milliseconds
+     *
+     * @param schema  table schema, DO NOT RELY ON THE COLUMN SCHEMA FROM THIS PARAMETER
+     *                you can rely on the column name, index and the key column name
+     * @param records records to update
+     * @return timestamp in milliseconds
+     */
     long updateWithObject(TableSchemaDesc schema, List<Map<String, BaseValue>> records);
 
-    Iterator<RecordResult> query(long timestamp,
+    Iterator<RecordResult> query(
+            long timestamp,
             Map<String, String> columns,
             List<OrderByDesc> orderBy,
             TableQueryFilter filter,
-            boolean keepNone);
+            boolean keepNone
+    );
 
     Iterator<RecordResult> scan(
             long timestamp,
@@ -50,7 +60,8 @@ public interface MemoryTable {
             String end,
             String endType,
             boolean endInclusive,
-            boolean keepNone);
+            boolean keepNone
+    );
 
     void lock(boolean forRead);
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/BaseValue.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/BaseValue.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import java.nio.ByteBuffer;
@@ -28,12 +29,15 @@ public interface BaseValue extends Comparable<BaseValue> {
 
     ColumnType getColumnType();
 
+
     static ColumnType getColumnType(BaseValue value) {
         if (value == null) {
             return ColumnType.UNKNOWN;
         }
         return value.getColumnType();
     }
+
+    ColumnSchemaDescBuilder generateColumnSchemaDesc();
 
     Object encode(boolean rawResult, boolean encodeWithType);
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/BoolValue.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/BoolValue.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import lombok.EqualsAndHashCode;
@@ -38,6 +40,11 @@ public class BoolValue implements ScalarValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.BOOL;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.bool();
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/BytesValue.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/BytesValue.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import com.google.protobuf.ByteString;
@@ -37,6 +39,11 @@ public class BytesValue implements ScalarValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.BYTES;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.bytes();
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Float32Value.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Float32Value.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import lombok.AllArgsConstructor;
@@ -34,6 +36,11 @@ public class Float32Value implements FloatValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.FLOAT32;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.float32();
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Float64Value.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Float64Value.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import lombok.AllArgsConstructor;
@@ -34,6 +36,11 @@ public class Float64Value implements FloatValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.FLOAT64;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.float64();
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Int16Value.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Int16Value.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import lombok.AllArgsConstructor;
@@ -34,6 +36,11 @@ public class Int16Value implements IntValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.INT16;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.int16();
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Int32Value.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Int32Value.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import lombok.AllArgsConstructor;
@@ -34,6 +36,11 @@ public class Int32Value implements IntValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.INT32;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.int32();
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Int64Value.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Int64Value.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import java.math.BigDecimal;
@@ -35,6 +37,11 @@ public class Int64Value implements IntValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.INT64;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.int64();
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Int8Value.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/Int8Value.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import lombok.AllArgsConstructor;
@@ -34,6 +36,11 @@ public class Int8Value implements IntValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.INT8;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.int8();
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/ObjectValue.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/ObjectValue.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import java.util.HashMap;
@@ -48,6 +50,15 @@ public class ObjectValue extends HashMap<String, BaseValue> implements BaseValue
     @Override
     public ColumnType getColumnType() {
         return ColumnType.OBJECT;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        var attrs = this.entrySet()
+                .stream()
+                .map(entry -> entry.getValue().generateColumnSchemaDesc().name(entry.getKey()).build())
+                .collect(Collectors.toList());
+        return ColumnSchemaDesc.objectOf(this.pythonType, attrs);
     }
 
     @Override

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/StringValue.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/type/StringValue.java
@@ -16,6 +16,8 @@
 
 package ai.starwhale.mlops.datastore.type;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc.ColumnSchemaDescBuilder;
 import ai.starwhale.mlops.datastore.ColumnType;
 import ai.starwhale.mlops.datastore.Wal;
 import lombok.AllArgsConstructor;
@@ -33,6 +35,11 @@ public class StringValue implements ScalarValue {
     @Override
     public ColumnType getColumnType() {
         return ColumnType.STRING;
+    }
+
+    @Override
+    public ColumnSchemaDescBuilder generateColumnSchemaDesc() {
+        return ColumnSchemaDesc.string();
     }
 
     @Override

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/BaseValueTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/BaseValueTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
 import ai.starwhale.mlops.datastore.ColumnType;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -640,5 +641,21 @@ public class BaseValueTest {
         assertThat(BaseValue.valueOf(Map.of("0", 0)).equals(
                         ObjectValue.valueOf("t", Map.of("0", 0))),
                 is(false));
+    }
+
+    @Test
+    public void testScalarGenerateColumnSchemaDesc() {
+        assertThat(BaseValue.valueOf(false).generateColumnSchemaDesc().build(), is(ColumnSchemaDesc.bool().build()));
+        assertThat(BaseValue.valueOf((byte) 0).generateColumnSchemaDesc().build(),
+                is(ColumnSchemaDesc.int8().build()));
+        assertThat(BaseValue.valueOf((short) 0).generateColumnSchemaDesc().build(),
+                is(ColumnSchemaDesc.int16().build()));
+        assertThat(BaseValue.valueOf(0).generateColumnSchemaDesc().build(), is(ColumnSchemaDesc.int32().build()));
+        assertThat(BaseValue.valueOf(0L).generateColumnSchemaDesc().build(), is(ColumnSchemaDesc.int64().build()));
+        assertThat(BaseValue.valueOf(0.f).generateColumnSchemaDesc().build(), is(ColumnSchemaDesc.float32().build()));
+        assertThat(BaseValue.valueOf(0.).generateColumnSchemaDesc().build(), is(ColumnSchemaDesc.float64().build()));
+        assertThat(BaseValue.valueOf("0").generateColumnSchemaDesc().build(), is(ColumnSchemaDesc.string().build()));
+        assertThat(BaseValue.valueOf(ByteBuffer.wrap(new byte[0])).generateColumnSchemaDesc().build(),
+                is(ColumnSchemaDesc.bytes().build()));
     }
 }

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/ListValueTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/ListValueTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.datastore.type;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ListValueTest {
+    @Test
+    public void testGenerateColumnSchemaDesc() {
+        // empty
+        var val = new ListValue();
+        var desc = val.generateColumnSchemaDesc();
+        assertEquals(ColumnSchemaDesc.builder().type("LIST").build(), desc.build());
+
+        // only one item type
+        val = new ListValue();
+        for (var i = 0; i < 7; i++) {
+            val.add(new Int8Value((byte) 1));
+        }
+        desc = val.generateColumnSchemaDesc();
+        var expected = ColumnSchemaDesc.builder()
+                .type("LIST")
+                .elementType(ColumnSchemaDesc.int8().name("element").build())
+                .build();
+        assertEquals(expected, desc.build());
+
+        // 3 item types
+        val = new ListValue();
+        for (var i = 0; i < 7; i++) {
+            val.add(new Int8Value((byte) 1));
+        }
+        val.add(new Int32Value(1));
+        val.add(new Float32Value(1.0f));
+
+        desc = val.generateColumnSchemaDesc();
+        expected = ColumnSchemaDesc.builder()
+                .type("LIST")
+                .elementType(ColumnSchemaDesc.int8().name("element").build())
+                .attributes(List.of(
+                        ColumnSchemaDesc.int32().name("element").index(7).build(),
+                        ColumnSchemaDesc.float32().name("element").index(8).build()))
+                .build();
+        assertEquals(expected, desc.build());
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/MapValueTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/MapValueTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.datastore.type;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import org.junit.jupiter.api.Test;
+
+class MapValueTest {
+
+    @Test
+    void testGenerateColumnSchemaDesc() {
+        // empty
+        var val = new MapValue();
+        var desc = val.generateColumnSchemaDesc();
+        assertEquals(ColumnSchemaDesc.builder().type("MAP").build(), desc.build());
+
+        // only one entry type
+        val = new MapValue();
+        for (var i = 0; i < 7; i++) {
+            val.put(new Int8Value((byte) 1), new Int8Value((byte) 1));
+        }
+        desc = val.generateColumnSchemaDesc();
+        var expected = ColumnSchemaDesc.builder()
+                .type("MAP")
+                .keyType(ColumnSchemaDesc.int8().name("key").build())
+                .valueType(ColumnSchemaDesc.int8().name("value").build())
+                .build();
+        assertEquals(expected, desc.build());
+
+        // 3 entry types
+        val = new MapValue();
+        for (var i = 0; i < 7; i++) {
+            val.put(new Int8Value((byte) i), new Int8Value((byte) 1));
+        }
+        val.put(new Int32Value(1), new Float32Value(1.f));
+        val.put(new Float64Value(1.0), new StringValue("foo"));
+
+        desc = val.generateColumnSchemaDesc();
+        expected = ColumnSchemaDesc.builder()
+                .type("MAP")
+                .keyType(ColumnSchemaDesc.int8().name("key").build())
+                .valueType(ColumnSchemaDesc.int8().name("value").build())
+                .build();
+        var actual = desc.build();
+        // the order in sparseKeyValuePairSchema is not stable
+        assertEquals(expected.getType(), actual.getType());
+        assertEquals(expected.getKeyType(), actual.getKeyType());
+        assertEquals(expected.getValueType(), actual.getValueType());
+        assertEquals(2, actual.getSparseKeyValuePairSchema().size());
+        assertThat(actual.getSparseKeyValuePairSchema().values(), containsInAnyOrder(
+                new ColumnSchemaDesc.KeyValuePairSchema(
+                        ColumnSchemaDesc.int32().build(),
+                        ColumnSchemaDesc.float32().build()),
+                new ColumnSchemaDesc.KeyValuePairSchema(
+                        ColumnSchemaDesc.float64().build(),
+                        ColumnSchemaDesc.string().build())
+        ));
+    }
+}

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/ObjectValueTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/type/ObjectValueTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.datastore.type;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.starwhale.mlops.datastore.ColumnSchemaDesc;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ObjectValueTest {
+
+    @Test
+    void testGenerateColumnSchemaDesc() {
+        // empty
+        var val = new ObjectValue("foo");
+        var desc = val.generateColumnSchemaDesc();
+        var expected = ColumnSchemaDesc.builder().type("OBJECT").pythonType("foo").attributes(List.of()).build();
+        assertEquals(expected, desc.build());
+
+        // non-empty
+        val = ObjectValue.valueOf("bar", Map.of("a", new Int8Value((byte) 1), "b", new Int32Value(2)));
+        desc = val.generateColumnSchemaDesc();
+        expected = ColumnSchemaDesc.builder()
+                .type("OBJECT")
+                .pythonType("bar")
+                .attributes(List.of(
+                        ColumnSchemaDesc.int8().name("a").build(),
+                        ColumnSchemaDesc.int32().name("b").build()))
+                .build();
+        assertEquals(expected, desc.build());
+    }
+}


### PR DESCRIPTION
## Description

Added a new API: `/datastore/updateTable/embedded` to support update requests for embedded types in each cell.

The following issues were resolved: 
1. Scanned data could not be used directly for update.
2. Clients previously had to build a batch based on the schema, but with the new API, they only need to concern themselves with the batch size.
3. The datastore migration doesn't need to be built-in to the datastore, any external business logic can manage it.

## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
