### PR TITLE
feat(client): support `swcli runtime run` command

### DIFF
--- a/client/tests/utils/test_process.py
+++ b/client/tests/utils/test_process.py
@@ -22,3 +22,6 @@ class TestCheckCall(unittest.TestCase):
             log_check_call(["err"])
 
         assert len(save_logs) >= 1
+
+        rc = log_check_call(["date"], capture_stdout=False)
+        assert rc == 0


### PR DESCRIPTION
## Description
`swcli runtime activate` + `run command` + `deactivate` three commands -->  `swcli runtime run` 

```bash
❯ swcli runtime run --help
Usage: swcli runtime run [OPTIONS] URI

  Run a command in the Starwhale Runtime environment.

  For an existed Starwhale runtime, the command will restore and activate the
  runtime automatically.

  Positional arguments:

          URI: Starwhale Runtime URI in the standalone instance
          CMD: Executable command name, with additional arguments if needed.

  Examples:

          # run some python code in the starwhale runtime
          swcli runtime run pytorch python -c "import torch;print(torch.__version__)"

          # run python script in the starwhale runtime with verbose mode
          swcli -vvv runtime run --cwd example/helloworld helloworld python3 dataset.py

          # use the interactive Python shell
          swcli runtime run pytorch --live-stream ipython3

Options:
  --cwd TEXT     Working directory
  --live-stream  Do not capture stdout/stderr, when the is an interactive cmd,
                 like ipython, the option should be enabled
  --help         Show this message and exit.
```

[![asciicast](https://asciinema.org/a/626817.svg)](https://asciinema.org/a/626817)

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
