### PR TITLE
fix(client): the online evaluation is accessible behind the proxy sub-path

### DIFF
--- a/console/client/ServingPage.tsx
+++ b/console/client/ServingPage.tsx
@@ -7,8 +7,11 @@ import { IApiSchema, InferenceType, ISpecSchema } from './schemas/api'
 import { useChatStore } from '@starwhale/ui/Serving/store/chat'
 import ChatGroup from './components/ChatGroup'
 
+// @ts-ignore
+const rootPath = window?.starwhaleConfig?.root ?? ''
+
 const fetchSpec = async () => {
-    const { data } = await axios.get<ISpecSchema>('/api/spec')
+    const { data } = await axios.get<ISpecSchema>(`${rootPath}/api/spec`)
     return data
 }
 
@@ -28,7 +31,7 @@ export default function ServingPage() {
             job: { id: 'client' } as any,
             type: apiSpec?.inference_type,
             exposedLink: {
-                link: '',
+                link: `${rootPath}/`,
                 type: 'WEB_HANDLER',
                 name: 'llm_chat',
             },

--- a/console/client/index.html
+++ b/console/client/index.html
@@ -14,6 +14,8 @@
             href="https://starwhale-examples.oss-cn-beijing.aliyuncs.com/ui/iconfont/iconfont.css?v=20230928"
         />
         <title>Starwhale Serving</title>
+        <!-- do not remove the following line -->
+        <!-- starwhale-client-placeholder -->
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Description

demo: http://jialei.pre.intra.starwhale.ai/projects/1/jobs/8/servings

Bug reason:  the front end can not access the assets and the APIs if the server is behind the proxy sub-path

I have implemented a simple string replacement on the client side to achieve the effects of injecting global variables and modifying asset paths. 
I did not use templates like Jinja2 because once templates are used, the client/index.html file can no longer be used for debugging and packaging with Vite.

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
