### PR TITLE
chore(console): use current web host in quickstart for model

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -67,6 +67,7 @@
     "d3": "^7.6.1",
     "date-fns": "^2.29.1",
     "dnd-core": "^16.0.1",
+    "ejs": "^3.1.9",
     "eventemitter3": "^4.0.7",
     "fast-deep-equal": "^3.1.3",
     "framer-motion": "4.1.17",

--- a/console/src/assets/docs/QuickStartNewModelEN.md.ejs
+++ b/console/src/assets/docs/QuickStartNewModelEN.md.ejs
@@ -16,13 +16,14 @@ sudo ln -s "$(which swcli)" /usr/local/bin/
 **Step2: Log in Starwhale Cloud Instance**
 
 ```
-swcli instance login --username <your username> --password <your password> --alias swcloud https://cloud.starwhale.cn
+swcli instance login --username <your username> --password <your password> --alias swcloud <%= consoleUrl %>
 ```
 
-**Step3: Build a new model**
+**Step3: Build and copy a new model**
 
-```
+```bash
 swcli model build . --model-yaml /path/to/model.yaml
+swcli model copy <model name> cloud://swcloud/project/<project name or ID>
 ```
 
 **Step4: See your model displayed here in Starwhale**

--- a/console/src/assets/docs/QuickStartNewModelZH.md.ejs
+++ b/console/src/assets/docs/QuickStartNewModelZH.md.ejs
@@ -16,13 +16,14 @@ sudo ln -s "$(which swcli)" /usr/local/bin/
 **第二步：登录云实例**
 
 ```
-swcli instance login --username <您的用户名> --password <您的密码> --alias swcloud https://cloud.starwhale.cn
+swcli instance login --username <您的用户名> --password <您的密码> --alias swcloud <%= consoleUrl %>
 ```
 
-**第三步：构建新模型**
+**第三步：构建并拷贝新模型**
 
-```
+```bash
 swcli model build . --model-yaml /path/to/model.yaml
+swcli model copy <模型名称> cloud://swcloud/project/<项目名称或ID>
 ```
 
 **第四步：在 UI 页面的模型列表页查看**

--- a/console/src/consts/index.ts
+++ b/console/src/consts/index.ts
@@ -1,5 +1,8 @@
-import QuickStartNewModelZH from '@/assets/docs/QuickStartNewModelZH.md?raw'
-import QuickStartNewModelEN from '@/assets/docs/QuickStartNewModelEN.md?raw'
+import ejs from 'ejs'
+
+import QuickStartNewModelZH from '@/assets/docs/QuickStartNewModelZH.md.ejs?raw'
+import QuickStartNewModelEN from '@/assets/docs/QuickStartNewModelEN.md.ejs?raw'
+import { getCurrentHost } from '@/utils'
 
 export const headerHeight = 50
 export const sidebarExpandedWidth = 200
@@ -29,15 +32,16 @@ export const languages = [
 export const cliMateServer = 'http://127.0.0.1:8007'
 export const docsZH = 'https://starwhale.cn/docs'
 export const docsEN = 'https://doc.starwhale.ai'
+
 export const localeConst = {
     zh: {
         quickstart: 'https://starwhale.cn/docs/getting-started/cloud',
         model: 'https://starwhale.cn/docs/model/',
-        quickStartNewModel: QuickStartNewModelZH,
+        quickStartNewModel: ejs.render(QuickStartNewModelZH, { consoleUrl: getCurrentHost() }),
     },
     en: {
         quickstart: 'https://doc.starwhale.ai/getting-started/cloud',
         model: 'https://doc.starwhale.ai/model/',
-        quickStartNewModel: QuickStartNewModelEN,
+        quickStartNewModel: ejs.render(QuickStartNewModelEN, { consoleUrl: getCurrentHost() }),
     },
 }

--- a/console/src/utils/index.ts
+++ b/console/src/utils/index.ts
@@ -369,3 +369,8 @@ export function expandMargin(top: string, right: string, bottom: string, left: s
         marginRight: right ?? undefined,
     }
 }
+
+export function getCurrentHost() {
+    const { hostname, port, protocol } = window.location
+    return `${protocol}//${hostname}${port ? `:${port}` : ''}`
+}

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -10989,6 +10989,13 @@ ejs@3.1.7, ejs@^3.1.7:
   dependencies:
     jake "^10.8.5"
 
+ejs@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
+  integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
+  dependencies:
+    jake "^10.8.5"
+
 electron-to-chromium@^1.4.431:
   version "1.4.469"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.469.tgz#c9cea85ab94031e239ca4ab03158726672d6f960"


### PR DESCRIPTION
## Description

![image](https://github.com/star-whale/starwhale/assets/3217223/da28778c-7297-4eab-9ba2-567e22ae9351)


## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
