### PR TITLE
refactor(client): use auto generated arg_types

### DIFF
--- a/client/starwhale/api/_impl/service/types/llm.py
+++ b/client/starwhale/api/_impl/service/types/llm.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Dict, List, Callable, Optional
+from typing import Any, List, Callable, Optional
 
 from pydantic import BaseModel
 
 from starwhale.base.client.models.models import (
     ComponentValueSpecInt,
-    ComponentSpecValueType,
     ComponentValueSpecFloat,
 )
 
-from .types import ServiceType
+from .types import ServiceType, generate_type_definition
 
 
 class MessageItem(BaseModel):
@@ -31,17 +30,7 @@ class Query(BaseModel):
 class LLMChat(ServiceType):
     name = "llm_chat"
     args = {}
-
-    # TODO use pydantic model annotations generated arg_types
-    arg_types: Dict[str, ComponentSpecValueType] = {
-        "user_input": ComponentSpecValueType.string,
-        "history": ComponentSpecValueType.list,  # list of Message
-        "top_k": ComponentSpecValueType.int,
-        "top_p": ComponentSpecValueType.float,
-        "temperature": ComponentSpecValueType.float,
-        "max_new_tokens": ComponentSpecValueType.int,
-    }
-
+    arg_types = generate_type_definition(Query)
     Message = MessageItem
 
     def __init__(

--- a/client/starwhale/api/_impl/service/types/text_to_img.py
+++ b/client/starwhale/api/_impl/service/types/text_to_img.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Dict, Callable, Optional
+from typing import Any, Callable, Optional
 
 from pydantic import BaseModel
 
 from starwhale.base.client.models.models import (
     ComponentValueSpecInt,
-    ComponentSpecValueType,
     ComponentValueSpecFloat,
 )
-from starwhale.api._impl.service.types.types import ServiceType
+from starwhale.api._impl.service.types.types import (
+    ServiceType,
+    generate_type_definition,
+)
 
 
 class Query(BaseModel):
@@ -28,18 +30,7 @@ class Query(BaseModel):
 class TextToImage(ServiceType):
     name = "text_to_image"
     args = {}
-
-    arg_types: Dict[str, ComponentSpecValueType] = {
-        "prompt": ComponentSpecValueType.string,
-        "negative_prompt": ComponentSpecValueType.string,
-        "sampling_steps": ComponentSpecValueType.int,
-        "width": ComponentSpecValueType.int,
-        "height": ComponentSpecValueType.int,
-        "seed": ComponentSpecValueType.int,
-        "batch_size": ComponentSpecValueType.int,
-        "batch_count": ComponentSpecValueType.int,
-        "guidance_scale": ComponentSpecValueType.float,
-    }
+    arg_types = generate_type_definition(Query)
 
     def __init__(
         self,

--- a/client/tests/sdk/test_types.py
+++ b/client/tests/sdk/test_types.py
@@ -1,10 +1,14 @@
+from typing import List, Optional
+
 import pytest
+from pydantic import BaseModel
 
 from starwhale.api._impl.service.types import all_components_are_gradio
 from starwhale.base.client.models.models import (
     ComponentValueSpecInt,
     ComponentSpecValueType,
 )
+from starwhale.api._impl.service.types.types import generate_type_definition
 from starwhale.api._impl.service.types.text_to_img import TextToImage
 
 
@@ -54,4 +58,34 @@ def test_text_to_image():
 
     assert t.args == {
         "sampling_steps": ComponentValueSpecInt(default_val=1),
+    }
+
+
+def test_generate_type_definition():
+    class MyType(BaseModel):
+        a: int
+        b: str
+        c: float
+        d: bool
+        e: Optional[int] = None
+        f: Optional[str] = None
+        g: Optional[float] = None
+        h: Optional[bool] = None
+        i: List[int]
+        j: List[str]
+        k: Optional[List[int]] = None
+
+    types = generate_type_definition(MyType)
+    assert types == {
+        "a": ComponentSpecValueType.int,
+        "b": ComponentSpecValueType.string,
+        "c": ComponentSpecValueType.float,
+        "d": ComponentSpecValueType.bool,
+        "e": ComponentSpecValueType.int,
+        "f": ComponentSpecValueType.string,
+        "g": ComponentSpecValueType.float,
+        "h": ComponentSpecValueType.bool,
+        "i": ComponentSpecValueType.list,
+        "j": ComponentSpecValueType.list,
+        "k": ComponentSpecValueType.list,
     }


### PR DESCRIPTION
## Description

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
