### PR TITLE
feat(client): add `--push` argument for model/runtime/dataset build

### DIFF
--- a/client/starwhale/core/dataset/view.py
+++ b/client/starwhale/core/dataset/view.py
@@ -198,7 +198,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         name: str,
         project_uri: str,
         **kwargs: t.Any,
-    ) -> None:
+    ) -> Resource:
         dataset_uri = cls.prepare_build_bundle(
             project=project_uri,
             bundle_name=name,
@@ -207,12 +207,13 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         )
         ds = Dataset.get_dataset(dataset_uri)
         ds.build_from_huggingface(repo=repo, **kwargs)
+        return dataset_uri
 
     @classmethod
     @BaseTermView._only_standalone
     def build_from_csv_files(
         cls, paths: t.List[PathLike], name: str, project_uri: str, **kwargs: t.Any
-    ) -> None:
+    ) -> Resource:
         dataset_uri = cls.prepare_build_bundle(
             project=project_uri,
             bundle_name=name,
@@ -221,6 +222,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         )
         ds = Dataset.get_dataset(dataset_uri)
         ds.build_from_csv_files(paths, **kwargs)
+        return dataset_uri
 
     @classmethod
     @BaseTermView._only_standalone
@@ -230,7 +232,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         name: str,
         project_uri: str,
         **kwargs: t.Any,
-    ) -> None:
+    ) -> Resource:
         dataset_uri = cls.prepare_build_bundle(
             project=project_uri,
             bundle_name=name,
@@ -239,6 +241,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         )
         ds = Dataset.get_dataset(dataset_uri)
         ds.build_from_json_files(paths, **kwargs)
+        return dataset_uri
 
     @classmethod
     @BaseTermView._only_standalone
@@ -249,7 +252,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         name: str,
         project_uri: str,
         **kwargs: t.Any,
-    ) -> None:
+    ) -> Resource:
         dataset_uri = cls.prepare_build_bundle(
             project=project_uri,
             bundle_name=name,
@@ -258,6 +261,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         )
         ds = Dataset.get_dataset(dataset_uri)
         ds.build_from_folder(folder=folder, kind=kind, **kwargs)
+        return dataset_uri
 
     @classmethod
     @BaseTermView._only_standalone
@@ -267,9 +271,10 @@ class DatasetTermView(BaseTermView, TagViewMixin):
         config: DatasetConfig,
         mode: DatasetChangeMode = DatasetChangeMode.PATCH,
         tags: t.List[str] | None = None,
-    ) -> None:
+    ) -> Resource | None:
         if config.runtime_uri:
             RuntimeProcess(uri=config.runtime_uri).run()
+            return None
         else:
             dataset_uri = cls.prepare_build_bundle(
                 project=config.project_uri,
@@ -279,6 +284,7 @@ class DatasetTermView(BaseTermView, TagViewMixin):
             )
             ds = Dataset.get_dataset(dataset_uri)
             ds.build(workdir=Path(workdir), config=config, mode=mode, tags=tags)
+            return dataset_uri
 
     @classmethod
     def copy(

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -357,9 +357,10 @@ class ModelTermView(BaseTermView, TagViewMixin):
         package_runtime: bool = True,
         tags: t.List[str] | None = None,
         excludes: t.List[str] | None = None,
-    ) -> None:
+    ) -> Resource | None:
         if runtime_uri:
             RuntimeProcess(uri=Resource(runtime_uri, typ=ResourceType.runtime)).run()
+            return None
         else:
             model_uri = cls.prepare_build_bundle(
                 project=project,
@@ -378,6 +379,7 @@ class ModelTermView(BaseTermView, TagViewMixin):
                 tags=tags,
                 excludes=excludes,
             )
+            return model_uri
 
     @classmethod
     def copy(

--- a/client/starwhale/core/runtime/view.py
+++ b/client/starwhale/core/runtime/view.py
@@ -155,7 +155,7 @@ class RuntimeTermView(BaseTermView, TagViewMixin):
     @BaseTermView._only_standalone
     def build_from_docker_image(
         cls, image: str, runtime_name: str = "", project: str = ""
-    ) -> None:
+    ) -> Resource:
         runtime_name = runtime_name or image.split(":")[0].split("/")[-1]
         runtime_uri = cls.prepare_build_bundle(
             project=project, bundle_name=runtime_name, typ=ResourceType.runtime
@@ -163,6 +163,7 @@ class RuntimeTermView(BaseTermView, TagViewMixin):
 
         rt = Runtime.get_runtime(runtime_uri)
         rt.build_from_docker_image(image=image, runtime_name=runtime_name)
+        return runtime_uri
 
     @classmethod
     @BaseTermView._only_standalone


### PR DESCRIPTION
## Description

```bash
❯ swcli model build . --name helloworld -m evaluation --push http://e2e-20231219.pre.intra.starwhale.ai/project/starwhale
🚧 start to build model bundle...
👷 uri local/project/self/model/helloworld/version/5owht6nm44ftxnf5a7dd65fl4hwp2ywukw2zqd46
📁 workdir: /home/tianwei/.starwhale/.tmp/tmpdbcw6x8f
🦚 copy source code files: . -> /home/tianwei/.starwhale/.tmp/tmpdbcw6x8f/src
📁 source code files size: 237.98KiB
🚀 generate jobs yaml from modules: ('evaluation',) , package rootdir: .
  9 out of 9 steps finished ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:01
💯 finish gen resource @ /home/tianwei/.starwhale/self/model/helloworld/5o/5owht6nm44ftxnf5a7dd65fl4hwp2ywukw2zqd46.swmp
🚧 start to copy local/project/self/model/helloworld/version/5owht6nm44ftxnf5a7dd65fl4hwp2ywukw2zqd46 -> http://e2e-20231219.pre.intra.starwhale.ai/project/1/model/helloworld/version/5owht6nm44ftxnf5a7dd65fl4hwp2ywukw2zqd46
scanning 5owht6nm44ftxnf5a7dd65fl4hwp2ywukw2zqd46.swmp...
scan done
uploading metadata...
metadata uploaded
  ⬆ uploading 5owht6nm44ftxnf5a7dd65fl4hwp2ywukw2zqd46.swmp... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:16 249.3 kB 6.6 MB/s
🍵 console url of the remote bundle: http://e2e-20231219.pre.intra.starwhale.ai/projects/1/models/helloworld/versions/5owht6nm44ftxnf5a7dd65fl4hwp2ywukw2zqd46/overview
🍵 no tags to copy
👏 copy done.
```

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
