### PR TITLE
feat(datastore): support checkpoint in server side

### DIFF
--- a/client/starwhale/base/client/models/models.py
+++ b/client/starwhale/base/client/models/models.py
@@ -423,6 +423,24 @@ class FlushRequest(SwBaseModel):
     pass
 
 
+class CreateCheckpointRequest(SwBaseModel):
+    table: str
+    user_data: Optional[str] = Field(None, alias='userData')
+
+
+class CheckpointVo(SwBaseModel):
+    id: str
+    created_time: int = Field(..., alias='createdTime')
+    row_count: int = Field(..., alias='rowCount')
+    user_data: Optional[str] = Field(None, alias='userData')
+
+
+class ResponseMessageCheckpointVo(SwBaseModel):
+    code: str
+    message: str
+    data: CheckpointVo
+
+
 class InitUploadBlobRequest(SwBaseModel):
     content_md5: str = Field(..., alias='contentMd5')
     content_length: int = Field(..., alias='contentLength')
@@ -1125,6 +1143,12 @@ class PanelPluginVo(SwBaseModel):
 
 class RuntimeSuggestionVo(SwBaseModel):
     runtimes: Optional[List[RuntimeVersionVo]] = None
+
+
+class ResponseMessageListCheckpointVo(SwBaseModel):
+    code: str
+    message: str
+    data: List[CheckpointVo]
 
 
 class UserRoleDeleteRequest(UserCheckPasswordRequest):

--- a/console/src/api/server/Api.ts
+++ b/console/src/api/server/Api.ts
@@ -33,6 +33,8 @@ import {
     ICompleteUploadBlobData,
     IConfigRequest,
     IConsumeNextDataData,
+    ICreateCheckpointData,
+    ICreateCheckpointRequest,
     ICreateJobData,
     ICreateJobTemplateRequest,
     ICreateModelServingData,
@@ -49,6 +51,7 @@ import {
     IDatasetBuildRequest,
     IDatasetTagRequest,
     IDatasetUploadRequest,
+    IDeleteCheckpointData,
     IDeleteDatasetData,
     IDeleteDatasetVersionTagData,
     IDeleteModelData,
@@ -72,6 +75,7 @@ import {
     IFineTuneSpaceCreateRequest,
     IFlushData,
     IFlushRequest,
+    IGetCheckpointsData,
     IGetCurrentUserData,
     IGetCurrentUserRolesData,
     IGetCurrentVersionData,
@@ -2813,6 +2817,81 @@ export class Api<SecurityDataType = unknown> {
         this.http.request<IFlushData, any>({
             path: `/api/v1/datastore/flush`,
             method: 'POST',
+            query: query,
+            secure: true,
+            ...params,
+        })
+
+    /**
+     * No description
+     *
+     * @tags data-store-controller
+     * @name GetCheckpoints
+     * @request GET:/api/v1/datastore/checkpoint
+     * @secure
+     * @response `200` `IGetCheckpointsData` OK
+     */
+    getCheckpoints = (
+        query: {
+            table: string
+        },
+        params: RequestParams = {}
+    ) =>
+        this.http.request<IGetCheckpointsData, any>({
+            path: `/api/v1/datastore/checkpoint`,
+            method: 'GET',
+            query: query,
+            secure: true,
+            ...params,
+        })
+
+    useGetCheckpoints = (
+        query: {
+            table: string
+        },
+        params: RequestParams = {}
+    ) =>
+        useQuery(qs.stringify(['getCheckpoints', query, params]), () => this.getCheckpoints(query, params), {
+            enabled: [query].every(Boolean),
+        })
+    /**
+     * No description
+     *
+     * @tags data-store-controller
+     * @name CreateCheckpoint
+     * @request POST:/api/v1/datastore/checkpoint
+     * @secure
+     * @response `200` `ICreateCheckpointData` OK
+     */
+    createCheckpoint = (data: ICreateCheckpointRequest, params: RequestParams = {}) =>
+        this.http.request<ICreateCheckpointData, any>({
+            path: `/api/v1/datastore/checkpoint`,
+            method: 'POST',
+            body: data,
+            secure: true,
+            type: ContentType.Json,
+            ...params,
+        })
+
+    /**
+     * No description
+     *
+     * @tags data-store-controller
+     * @name DeleteCheckpoint
+     * @request DELETE:/api/v1/datastore/checkpoint
+     * @secure
+     * @response `200` `IDeleteCheckpointData` OK
+     */
+    deleteCheckpoint = (
+        query: {
+            table: string
+            id: string
+        },
+        params: RequestParams = {}
+    ) =>
+        this.http.request<IDeleteCheckpointData, any>({
+            path: `/api/v1/datastore/checkpoint`,
+            method: 'DELETE',
             query: query,
             secure: true,
             ...params,

--- a/console/src/api/server/data-contracts.ts
+++ b/console/src/api/server/data-contracts.ts
@@ -566,6 +566,26 @@ export interface ITableNameListVo {
 
 export type IFlushRequest = object
 
+export interface ICreateCheckpointRequest {
+    table: string
+    userData?: string
+}
+
+export interface ICheckpointVo {
+    id: string
+    /** @format int64 */
+    createdTime: number
+    /** @format int64 */
+    rowCount: number
+    userData?: string
+}
+
+export interface IResponseMessageCheckpointVo {
+    code: string
+    message: string
+    data: ICheckpointVo
+}
+
 export interface IInitUploadBlobRequest {
     contentMd5: string
     /** @format int64 */
@@ -2145,6 +2165,12 @@ export interface IRuntimeSuggestionVo {
     runtimes?: IRuntimeVersionVo[]
 }
 
+export interface IResponseMessageListCheckpointVo {
+    code: string
+    message: string
+    data: ICheckpointVo[]
+}
+
 export interface IUserRoleDeleteRequest {
     currentUserPwd: string
 }
@@ -2362,6 +2388,12 @@ export type IQueryAndExportData = any
 export type IListTablesData = IResponseMessageTableNameListVo['data']
 
 export type IFlushData = IResponseMessageString['data']
+
+export type IGetCheckpointsData = IResponseMessageListCheckpointVo['data']
+
+export type ICreateCheckpointData = IResponseMessageCheckpointVo['data']
+
+export type IDeleteCheckpointData = IResponseMessageString['data']
 
 export type IInitUploadBlobData = IResponseMessageInitUploadBlobResult['data']
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/DataStoreController.java
@@ -321,7 +321,7 @@ public class DataStoreController {
             @RequestParam(name = "table") String table,
             @RequestParam(name = "id") String id
     ) {
-        this.dataStore.deleteCheckpoint(table, id);
+        this.dataStore.deleteCheckpoint(table, Long.parseLong(id));
         return ResponseEntity.ok(Code.success.asResponse("success"));
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CheckpointVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CheckpointVo.java
@@ -30,6 +30,9 @@ public class CheckpointVo {
     @NotNull
     private Long createdTime;
 
+    @NotNull
+    private Long count;
+
     private String userData;
 
     public static CheckpointVo from(Checkpoint checkpoint) {
@@ -37,6 +40,7 @@ public class CheckpointVo {
                 .id(String.valueOf(checkpoint.getRevision()))
                 .createdTime(checkpoint.getTimestamp())
                 .userData(checkpoint.getUserData())
+                .count(checkpoint.getCount())
                 .build();
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CheckpointVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CheckpointVo.java
@@ -31,7 +31,7 @@ public class CheckpointVo {
     private Long createdTime;
 
     @NotNull
-    private Long count;
+    private Long rowCount;
 
     private String userData;
 
@@ -40,7 +40,7 @@ public class CheckpointVo {
                 .id(String.valueOf(checkpoint.getRevision()))
                 .createdTime(checkpoint.getTimestamp())
                 .userData(checkpoint.getUserData())
-                .count(checkpoint.getCount())
+                .rowCount(checkpoint.getRowCount())
                 .build();
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CheckpointVo.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CheckpointVo.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.datastore;
+
+import ai.starwhale.mlops.datastore.Checkpoint;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CheckpointVo {
+    @NotNull
+    private String id;
+
+    @NotNull
+    private Long createdTime;
+
+    private String userData;
+
+    public static CheckpointVo from(Checkpoint checkpoint) {
+        return CheckpointVo.builder()
+                .id(String.valueOf(checkpoint.getRevision()))
+                .createdTime(checkpoint.getTimestamp())
+                .userData(checkpoint.getUserData())
+                .build();
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CreateCheckpointRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CreateCheckpointRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.api.protocol.datastore;
+
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CreateCheckpointRequest {
+    @NotNull
+    private String table;
+    private String userData;
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CreateCheckpointRequest.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/api/protocol/datastore/CreateCheckpointRequest.java
@@ -17,11 +17,15 @@
 package ai.starwhale.mlops.api.protocol.datastore;
 
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class CreateCheckpointRequest {
     @NotNull
     private String table;

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.datastore;
 
+import ai.starwhale.mlops.datastore.Wal.Checkpoint.OptionalUserDataCase;
 import lombok.Builder;
 import lombok.Data;
 
@@ -28,20 +29,26 @@ public class Checkpoint {
     private long rowCount;
 
     public static Checkpoint from(Wal.Checkpoint checkpoint) {
+        String userData = null;
+        if (checkpoint.getOptionalUserDataCase() == OptionalUserDataCase.USER_DATA) {
+            userData = checkpoint.getUserData();
+        }
         return Checkpoint.builder()
-                .userData(checkpoint.getUserData())
+                .userData(userData)
                 .revision(checkpoint.getRevision())
                 .timestamp(checkpoint.getTimestamp())
-                .rowCount(checkpoint.getCount())
+                .rowCount(checkpoint.getRowCount())
                 .build();
     }
 
     public Wal.Checkpoint toWalCheckpoint() {
-        return Wal.Checkpoint.newBuilder()
-                .setUserData(userData)
+        var cp = Wal.Checkpoint.newBuilder()
                 .setRevision(revision)
                 .setTimestamp(timestamp)
-                .setCount(rowCount)
-                .build();
+                .setRowCount(rowCount);
+        if (userData != null) {
+            cp.setUserData(userData);
+        }
+        return cp.build();
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
@@ -25,14 +25,14 @@ public class Checkpoint {
     private String userData;
     private long revision;
     private long timestamp;
-    private long count;
+    private long rowCount;
 
     public static Checkpoint from(Wal.Checkpoint checkpoint) {
         return Checkpoint.builder()
                 .userData(checkpoint.getUserData())
                 .revision(checkpoint.getRevision())
                 .timestamp(checkpoint.getTimestamp())
-                .count(checkpoint.getCount())
+                .rowCount(checkpoint.getCount())
                 .build();
     }
 
@@ -41,7 +41,7 @@ public class Checkpoint {
                 .setUserData(userData)
                 .setRevision(revision)
                 .setTimestamp(timestamp)
-                .setCount(count)
+                .setCount(rowCount)
                 .build();
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
@@ -28,7 +28,7 @@ public class Checkpoint {
     private long timestamp;
     private long rowCount;
 
-    // mark the very first checkpoint as virtual
+    // mark the first and the last checkpoints as virtual
     // prevent querying the garbage collected revisions
     @Builder.Default
     private boolean virtual = false;

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
@@ -28,6 +28,11 @@ public class Checkpoint {
     private long timestamp;
     private long rowCount;
 
+    // mark the very first checkpoint as virtual
+    // prevent querying the garbage collected revisions
+    @Builder.Default
+    private boolean virtual = false;
+
     public static Checkpoint from(Wal.Checkpoint checkpoint) {
         String userData = null;
         if (checkpoint.getOptionalUserDataCase() == OptionalUserDataCase.USER_DATA) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/Checkpoint.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Starwhale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.starwhale.mlops.datastore;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Checkpoint {
+    private String userData;
+    private long revision;
+    private long timestamp;
+    private long count;
+
+    public static Checkpoint from(Wal.Checkpoint checkpoint) {
+        return Checkpoint.builder()
+                .userData(checkpoint.getUserData())
+                .revision(checkpoint.getRevision())
+                .timestamp(checkpoint.getTimestamp())
+                .count(checkpoint.getCount())
+                .build();
+    }
+
+    public Wal.Checkpoint toWalCheckpoint() {
+        return Wal.Checkpoint.newBuilder()
+                .setUserData(userData)
+                .setRevision(revision)
+                .setTimestamp(timestamp)
+                .setCount(count)
+                .build();
+    }
+}

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
@@ -16,6 +16,7 @@
 
 package ai.starwhale.mlops.datastore;
 
+import ai.starwhale.mlops.api.protocol.datastore.CreateCheckpointRequest;
 import ai.starwhale.mlops.datastore.ParquetConfig.CompressionCodec;
 import ai.starwhale.mlops.datastore.impl.MemoryTableImpl;
 import ai.starwhale.mlops.datastore.impl.RecordEncoder;
@@ -86,7 +87,8 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
 
     private final int ossMaxAttempts;
 
-    public DataStore(StorageAccessService storageAccessService,
+    public DataStore(
+            StorageAccessService storageAccessService,
             @Value("${sw.datastore.wal-max-file-size}") int walMaxFileSize,
             @Value("#{T(java.nio.file.Paths).get('${sw.datastore.wal-local-cache-dir:wal_cache}')}")
             Path walLocalCacheDir,
@@ -98,7 +100,8 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
             @Value("${sw.datastore.parquet.compression-codec:SNAPPY}") String compressionCodec,
             @Value("${sw.datastore.parquet.row-group-size:128MB}") String rowGroupSize,
             @Value("${sw.datastore.parquet.page-size:1MB}") String pageSize,
-            @Value("${sw.datastore.parquet.page-row-count-limit:20000}") int pageRowCountLimit) {
+            @Value("${sw.datastore.parquet.page-row-count-limit:20000}") int pageRowCountLimit
+    ) {
         this.storageAccessService = storageAccessService;
         if (!dataRootPath.isEmpty() && !dataRootPath.endsWith("/")) {
             dataRootPath += "/";
@@ -185,9 +188,11 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
     }
 
     @WriteOperation
-    public String update(String tableName,
+    public String update(
+            String tableName,
             TableSchemaDesc schema,
-            List<Map<String, Object>> records) {
+            List<Map<String, Object>> records
+    ) {
         if (schema != null && schema.getColumnSchemaList() != null) {
             for (var col : schema.getColumnSchemaList()) {
                 if (col.getName() != null && !COLUMN_NAME_PATTERN.matcher(col.getName()).matches()) {
@@ -559,9 +564,9 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
         /**
          * Applies this function to the given arguments.
          *
-         * @param tables table meta data
+         * @param tables          table meta data
          * @param columnSchemaMap column schema map
-         * @param recordIter records iterator
+         * @param recordIter      records iterator
          * @return r the result
          */
         R apply(
@@ -892,6 +897,46 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
             } catch (InterruptedException e) {
                 log.error("interrupted", e);
             }
+        }
+    }
+
+    public Checkpoint createCheckpoint(CreateCheckpointRequest req) {
+        var table = this.getTable(req.getTable(), false, false);
+        //noinspection ConstantConditions
+        table.lock(false);
+        try {
+            var checkpoint = table.createCheckpoint(req.getUserData());
+            synchronized (this.dirtyTables) {
+                this.dirtyTables.add(table);
+            }
+            return checkpoint;
+        } finally {
+            table.unlock(false);
+        }
+    }
+
+    public List<Checkpoint> getCheckpoints(String tableName) {
+        var table = this.getTable(tableName, true, false);
+        if (table == null) {
+            return Collections.emptyList();
+        }
+        //noinspection ConstantConditions
+        table.lock(false);
+        try {
+            return table.getCheckpoints();
+        } finally {
+            table.unlock(false);
+        }
+    }
+
+    public void deleteCheckpoint(String tableName, String id) {
+        var table = this.getTable(tableName, false, false);
+        //noinspection ConstantConditions
+        table.lock(false);
+        try {
+            table.deleteCheckpoint(Long.parseLong(id));
+        } finally {
+            table.unlock(false);
         }
     }
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/DataStore.java
@@ -929,12 +929,12 @@ public class DataStore implements OrderedRollingUpdateStatusListener {
         }
     }
 
-    public void deleteCheckpoint(String tableName, String id) {
+    public void deleteCheckpoint(String tableName, long revision) {
         var table = this.getTable(tableName, false, false);
         //noinspection ConstantConditions
         table.lock(false);
         try {
-            table.deleteCheckpoint(Long.parseLong(id));
+            table.deleteCheckpoint(revision);
         } finally {
             table.unlock(false);
         }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
@@ -65,4 +65,10 @@ public interface MemoryTable {
     long getLastRevision();
 
     Map<String, ColumnStatistics> getColumnStatistics(Map<String, String> columnMapping);
+
+    Checkpoint createCheckpoint(String userData);
+
+    List<Checkpoint> getCheckpoints();
+
+    void deleteCheckpoint(long revision);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
@@ -35,11 +35,13 @@ public interface MemoryTable {
 
     long updateWithObject(TableSchemaDesc schema, List<Map<String, BaseValue>> records);
 
-    Iterator<RecordResult> query(long timestamp,
+    Iterator<RecordResult> query(
+            long timestamp,
             Map<String, String> columns,
             List<OrderByDesc> orderBy,
             TableQueryFilter filter,
-            boolean keepNone);
+            boolean keepNone
+    );
 
     Iterator<RecordResult> scan(
             long timestamp,
@@ -50,7 +52,8 @@ public interface MemoryTable {
             String end,
             String endType,
             boolean endInclusive,
-            boolean keepNone);
+            boolean keepNone
+    );
 
     void lock(boolean forRead);
 
@@ -66,9 +69,31 @@ public interface MemoryTable {
 
     Map<String, ColumnStatistics> getColumnStatistics(Map<String, String> columnMapping);
 
+    /**
+     * Create a checkpoint, the checkpoint means:
+     * 1. the data for the checkpoint is immutable
+     * 2. the data outside the checkpoint may be garbage collected (except the data behind the checkpoint)
+     * 3. getting the count of the checkpoint is constant time
+     * <p>
+     * It should throw SwValidationException if the checkpoint already exists (exists means the revision is the same)
+     *
+     * @param userData user data, nullable
+     * @return checkpoint
+     */
     Checkpoint createCheckpoint(String userData);
 
+    /**
+     * Get the checkpoint by revision
+     *
+     * @return checkpoint list or empty list if table has no checkpoint (without exception)
+     */
     List<Checkpoint> getCheckpoints();
 
+    /**
+     * Delete the checkpoint by revision
+     * It should throw SwNotFoundException if the checkpoint does not exist
+     *
+     * @param revision revision in checkpoint
+     */
     void deleteCheckpoint(long revision);
 }

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/MemoryTable.java
@@ -31,12 +31,13 @@ public interface MemoryTable {
     void updateFromWal(Wal.WalEntry entry);
 
     // update records, returns the timestamp in milliseconds
+    // TODO remove the return revision in the breaking change version
     long update(TableSchemaDesc schema, List<Map<String, Object>> records);
 
     long updateWithObject(TableSchemaDesc schema, List<Map<String, BaseValue>> records);
 
     Iterator<RecordResult> query(
-            long timestamp,
+            long revision,
             Map<String, String> columns,
             List<OrderByDesc> orderBy,
             TableQueryFilter filter,
@@ -44,7 +45,7 @@ public interface MemoryTable {
     );
 
     Iterator<RecordResult> scan(
-            long timestamp,
+            long revision,
             Map<String, String> columns,
             String start,
             String startType,
@@ -71,11 +72,12 @@ public interface MemoryTable {
 
     /**
      * Create a checkpoint, the checkpoint means:
-     * 1. the data for the checkpoint is immutable
-     * 2. the data outside the checkpoint may be garbage collected (except the data behind the checkpoint)
+     * 1. the version for the checkpoint is immutable
+     * 2. the versions outside the checkpoint may be garbage collected
      * 3. getting the count of the checkpoint is constant time
      * <p>
-     * It should throw SwValidationException if the checkpoint already exists (exists means the revision is the same)
+     * It should throw SwValidationException if the checkpoint already exists
+     * (exists means that the latest revision has checkpoint)
      *
      * @param userData user data, nullable
      * @return checkpoint

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
@@ -881,14 +881,7 @@ public class MemoryTableImpl implements MemoryTable {
                 .rowCount(this.getCount())
                 .build();
 
-        var walCp = Wal.Checkpoint.newBuilder()
-                .setOp(OP.CREATE)
-                .setTimestamp(timestamp)
-                .setRevision(revision)
-                .setRowCount(cp.getRowCount());
-        if (userData != null) {
-            walCp.setUserData(userData);
-        }
+        var walCp = cp.toWalCheckpoint();
         var entry = Wal.WalEntry.newBuilder()
                 .setEntryType(Wal.WalEntry.Type.CHECKPOINT)
                 .setTableName(this.tableName)

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
@@ -841,7 +841,7 @@ public class MemoryTableImpl implements MemoryTable {
                 .revision(revision)
                 .timestamp(timestamp)
                 .userData(userData)
-                .count(this.getCount())
+                .rowCount(this.getCount())
                 .build();
 
         var entry = Wal.WalEntry.newBuilder()
@@ -851,7 +851,7 @@ public class MemoryTableImpl implements MemoryTable {
                         .setOp(OP.CREATE)
                         .setTimestamp(timestamp)
                         .setRevision(revision)
-                        .setCount(cp.getCount())
+                        .setCount(cp.getRowCount())
                         .setUserData(userData));
         this.lastWalLogId = this.walManager.append(entry);
         if (this.firstWalLogId < 0) {

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
@@ -925,19 +925,13 @@ public class MemoryTableImpl implements MemoryTable {
             this.firstWalLogId = this.lastWalLogId;
         }
         var prevCp = this.checkpoints.lowerEntry(revision);
-        if (prevCp != null) {
+        var nextCp = this.checkpoints.higherEntry(revision);
+
+        if (prevCp != null && nextCp != null) {
             this.checkpoints.remove(revision);
+            this.garbageCollect(prevCp.getValue(), nextCp.getValue());
         } else {
             this.checkpoints.get(revision).setVirtual(true);
-        }
-
-        var nextCp = this.checkpoints.higherEntry(revision);
-        if (nextCp == null) {
-            // no next checkpoint, no need to garbage collect
-            return;
-        }
-        if (prevCp != null) {
-            this.garbageCollect(prevCp.getValue(), nextCp.getValue());
         }
     }
 

--- a/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/datastore/impl/MemoryTableImpl.java
@@ -948,6 +948,7 @@ public class MemoryTableImpl implements MemoryTable {
      * <pre>
      *     versions:   [v1, v2, v3, v5, v6]
      *     checkpoints: [-,  -, cp1, cp2, -]
+     * </pre>
      *
      * @param from the checkpoint to start garbage collection
      * @param to   the checkpoint to end garbage collection

--- a/server/controller/src/main/java/ai/starwhale/mlops/exception/SwNotFoundException.java
+++ b/server/controller/src/main/java/ai/starwhale/mlops/exception/SwNotFoundException.java
@@ -45,7 +45,8 @@ public class SwNotFoundException extends StarwhaleException {
         PROJECT("002", "Project"),
         BUNDLE("003", "Starwhale Bundle"),
         BUNDLE_VERSION("004", "Starwhale Bundle Version"),
-        FINE_TUNE("005", "Starwhale Finetune");
+        FINE_TUNE("005", "Starwhale Finetune"),
+        DATASTORE("006", "Starwhale Data Store");
         final String code;
         final String tipSubject;
 

--- a/server/controller/src/main/protobuf/table_meta.proto
+++ b/server/controller/src/main/protobuf/table_meta.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+import "wal.proto";
 
 option java_package = "ai.starwhale.mlops.datastore";
 
@@ -6,4 +7,5 @@ message MetaData {
   int64 last_wal_log_id = 1;
   int64 last_update_time = 2;
   int64 last_revision = 3;
+  repeated Checkpoint checkpoints = 4;
 }

--- a/server/controller/src/main/protobuf/wal.proto
+++ b/server/controller/src/main/protobuf/wal.proto
@@ -48,9 +48,29 @@ message Record {
   repeated Column columns = 1;
 }
 
+message Checkpoint {
+  enum OP {
+    CREATE = 0;
+    // if the op is DELETE, only the revision field is valid.
+    DELETE = 1;
+  }
+  OP op = 1;
+  int64 revision = 2;
+  string user_data = 3;
+  int64 timestamp = 4;
+  int64 count = 5;
+}
+
+message Tombstone {
+  // TODO add more biz fields
+}
+
 message WalEntry {
   enum Type {
     UPDATE = 0;
+    // if the entry is a checkpoint, only the id, table_name and checkpoint fields are valid.
+    CHECKPOINT = 1;
+    TOMBSTONE = 2;
   }
   Type entry_type = 1;
   string table_name = 2;
@@ -58,4 +78,8 @@ message WalEntry {
   repeated Record records = 4;
   int64 id = 5;
   int64 revision = 6;
+  oneof payload {
+    Checkpoint checkpoint = 7;
+    Tombstone tombstone = 8;
+  }
 }

--- a/server/controller/src/main/protobuf/wal.proto
+++ b/server/controller/src/main/protobuf/wal.proto
@@ -56,9 +56,11 @@ message Checkpoint {
   }
   OP op = 1;
   int64 revision = 2;
-  string user_data = 3;
+  oneof optional_user_data {
+    string user_data = 3;
+  }
   int64 timestamp = 4;
-  int64 count = 5;
+  int64 row_count = 5;
 }
 
 message Tombstone {

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
@@ -3178,7 +3178,8 @@ public class MemoryTableImplTest {
         // get the row in revision t1
         result = memoryTable.query(t1, Map.of("a", "a"), null, null, false);
         // the t1 version can't be garbage collected because there is no previous checkpoint
-        assertThat(ImmutableList.copyOf(result), is(List.of(new RecordResult(BaseValue.valueOf(0), false, Map.of("a", BaseValue.valueOf(1))))));
+        assertThat(ImmutableList.copyOf(result),
+                is(List.of(new RecordResult(BaseValue.valueOf(0), false, Map.of("a", BaseValue.valueOf(1))))));
 
         // get the row in revision t2
         result = memoryTable.query(t2, Map.of("a", "a"), null, null, false);

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
@@ -3173,7 +3173,7 @@ public class MemoryTableImplTest {
         // |  t1  |  t2  |
         // |  1   |  2   |
         //           ^
-        //           cp1
+        //          cp1
 
         // get the row in revision t1
         result = memoryTable.query(t1, Map.of("a", "a"), null, null, false);
@@ -3207,7 +3207,7 @@ public class MemoryTableImplTest {
         // |  t1  |  t2  |  t3  |
         // |  1   |  2   |  3   |
         //           ^      ^
-        //           cp1    cp2
+        //          cp1    cp2
 
         // add checkpoint without new version added, will throw exception
         assertThrows(SwValidationException.class, () -> memoryTable.createCheckpoint("baz"));
@@ -3229,7 +3229,7 @@ public class MemoryTableImplTest {
         // |  t1  |  t3  |  t4  |
         // |  1   |  3   |  4   |
         //           ^
-        //           cp1
+        //          cp1
 
         // get the row in revision t2 will throw exception(t2 has been garbage collected)
         assertThrows(SwNotFoundException.class, () -> memoryTable.query(t2, Map.of("a", "a"), null, null, false));
@@ -3272,10 +3272,12 @@ public class MemoryTableImplTest {
         cps = reloadedMemoryTable.getCheckpoints();
         assertEquals(0, cps.size());
 
+        // |  t1  |  t4  |
+        // |  1   |  4   |
+
         // get t3
-        result = reloadedMemoryTable.query(t3, Map.of("a", "a"), null, null, false);
-        assertThat(ImmutableList.copyOf(result),
-                is(List.of(new RecordResult(BaseValue.valueOf(0), false, Map.of("a", BaseValue.valueOf(3))))));
+        assertThrows(SwNotFoundException.class,
+                () -> reloadedMemoryTable.query(t3, Map.of("a", "a"), null, null, false));
 
         // get t4
         result = reloadedMemoryTable.query(t4, Map.of("a", "a"), null, null, false);

--- a/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
+++ b/server/controller/src/test/java/ai/starwhale/mlops/datastore/impl/MemoryTableImplTest.java
@@ -3164,7 +3164,7 @@ public class MemoryTableImplTest {
         var cp1 = memoryTable.createCheckpoint("foo");
         assertEquals("foo", cp1.getUserData());
         assertEquals(t2, cp1.getRevision());
-        assertEquals(1, cp1.getCount());
+        assertEquals(1, cp1.getRowCount());
 
         var cps = memoryTable.getCheckpoints();
         assertEquals(1, cps.size());
@@ -3191,7 +3191,7 @@ public class MemoryTableImplTest {
         var cp2 = memoryTable.createCheckpoint("bar");
         assertEquals("bar", cp2.getUserData());
         assertEquals(t3, cp2.getRevision());
-        assertEquals(1, cp2.getCount());
+        assertEquals(1, cp2.getRowCount());
 
         cps = memoryTable.getCheckpoints();
         assertEquals(2, cps.size());


### PR DESCRIPTION
## Description

Provides support for checkpoints, which later allows:
1. Only needing to save the data version indicated by the checkpoint, effectively reducing the disk and memory space occupied by the data
2. Fetch the statistical information of the data pointed by a checkpoint with constant complexity, including data row count, minimum key, maximum key, etc.

Issues to be considered: #3098 
1. It is necessary to support old versions of data, and a migration logic is needed to ensure that all historical data checkpoints can be correctly processed.
2. Consider whether a Controller can rollback after an upgrade (data versions might have been garbage collected due to the checkpoint function).



## Modules
- [ ] UI
- [x] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
