### PR TITLE
chore(client): fix mypy lint

### DIFF
--- a/client/starwhale/web/server.py
+++ b/client/starwhale/web/server.py
@@ -9,7 +9,6 @@ from typing_extensions import Protocol
 from starlette.requests import Request
 from starlette.responses import Response, FileResponse, StreamingResponse
 from starlette.background import BackgroundTask
-from starlette.exceptions import HTTPException
 from starlette.staticfiles import StaticFiles
 
 from starwhale.web import user, panel, system, project, data_store
@@ -31,14 +30,14 @@ class Server(FastAPI):
 
     @classmethod
     def mount_static(cls, app: FastAPI) -> FastAPI:
-        def index() -> FileResponse:
+        def index(_: Request) -> FileResponse:
             return FileResponse(os.path.join(STATIC_DIR_DEV, "index.html"))
 
         app.add_route("/", index, methods=["GET"])
         app.mount("/", StaticFiles(directory=STATIC_DIR_DEV), name="assets")
 
         def not_found_exception_handler(
-            request: Request, exc: HTTPException
+            request: Request, exc: Exception
         ) -> FileResponse:
             return FileResponse(os.path.join(STATIC_DIR_DEV, "index.html"))
 


### PR DESCRIPTION
## Description

https://github.com/star-whale/starwhale/actions/runs/7334596840/job/19971841957?pr=3093

```
mypy . ../example/mnist ../scripts/client_test --show-traceback
starwhale/web/server.py:37:28: error: Argument 2 to "add_route" of "Starlette" has incompatible type "Callable[[], FileResponse]"; expected "Callable[[Request], Union[Awaitable[Response], Response]]"  [arg-type]
starwhale/web/server.py:45:40: error: Argument 2 to "add_exception_handler" of "Starlette" has incompatible type "Callable[[Request, HTTPException], FileResponse]"; expected "Union[Callable[[Request, Exception], Union[Response, Awaitable[Response]]], Callable[[WebSocket, Exception], Awaitable[None]]]"  [arg-type]
Found 2 errors in 1 file (checked 201 source files)
make: *** [Makefile:52: ci-mypy] Error 1
```

## Modules
- [ ] UI
- [ ] Controller
- [ ] Agent
- [x] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
