### PR TITLE
refactor(client): refactor handler args with `@starwhale.argument` decorator

### DIFF
--- a/client/starwhale/__init__.py
+++ b/client/starwhale/__init__.py
@@ -1,15 +1,5 @@
 from starwhale.api import model, track, evaluation
-from starwhale.api.job import (
-    Job,
-    Handler,
-    IntInput,
-    BoolInput,
-    ListInput,
-    FloatInput,
-    ContextInput,
-    DatasetInput,
-    HandlerInput,
-)
+from starwhale.api.job import Job, Handler
 from starwhale.version import STARWHALE_VERSION as __version__
 from starwhale.api.metric import multi_classification
 from starwhale.api.dataset import Dataset
@@ -72,13 +62,6 @@ __all__ = [
     "Text",
     "Line",
     "Point",
-    "DatasetInput",
-    "HandlerInput",
-    "ListInput",
-    "BoolInput",
-    "IntInput",
-    "FloatInput",
-    "ContextInput",
     "Polygon",
     "Audio",
     "Video",

--- a/client/starwhale/api/_impl/evaluation/__init__.py
+++ b/client/starwhale/api/_impl/evaluation/__init__.py
@@ -108,7 +108,6 @@ def _register_predict(
             predict_log_dataset_features=log_dataset_features,
             dataset_uris=datasets,
         ),
-        built_in=True,
     )(func)
 
 
@@ -172,7 +171,6 @@ def _register_evaluate(
         extra_kwargs=dict(
             predict_auto_log=use_predict_auto_log,
         ),
-        built_in=True,
     )(func)
 
 

--- a/client/starwhale/api/_impl/experiment.py
+++ b/client/starwhale/api/_impl/experiment.py
@@ -138,7 +138,6 @@ def _register_ft(
         extra_kwargs=dict(
             auto_build_model=auto_build_model,
         ),
-        built_in=True,
         fine_tune=FineTune(
             require_train_datasets=require_train_datasets,
             require_validation_datasets=require_validation_datasets,

--- a/client/starwhale/api/job.py
+++ b/client/starwhale/api/job.py
@@ -1,22 +1,3 @@
 from ._impl.job import Job, Handler
-from ._impl.job.handler import (
-    IntInput,
-    BoolInput,
-    ListInput,
-    FloatInput,
-    ContextInput,
-    DatasetInput,
-    HandlerInput,
-)
 
-__all__ = [
-    "Handler",
-    "Job",
-    "DatasetInput",
-    "HandlerInput",
-    "ListInput",
-    "BoolInput",
-    "IntInput",
-    "FloatInput",
-    "ContextInput",
-]
+__all__ = ["Handler", "Job"]

--- a/client/starwhale/base/scheduler/__init__.py
+++ b/client/starwhale/base/scheduler/__init__.py
@@ -22,7 +22,6 @@ class Scheduler:
         workdir: Path,
         dataset_uris: t.List[str],
         steps: t.List[Step],
-        handler_args: t.List[str] | None = None,
         run_project: t.Optional[Project] = None,
         log_project: t.Optional[Project] = None,
         dataset_head: int = 0,
@@ -36,7 +35,6 @@ class Scheduler:
         self.dataset_uris = dataset_uris
         self.workdir = workdir
         self.version = version
-        self.handler_args = handler_args or []
         self.dataset_head = dataset_head
         self.finetune_val_dataset_uris = finetune_val_dataset_uris
         self.model_name = model_name
@@ -80,7 +78,6 @@ class Scheduler:
                     dataset_uris=self.dataset_uris,
                     workdir=self.workdir,
                     version=self.version,
-                    handler_args=self.handler_args,
                     dataset_head=self.dataset_head,
                     finetune_val_dataset_uris=self.finetune_val_dataset_uris,
                     model_name=self.model_name,

--- a/client/starwhale/base/scheduler/step.py
+++ b/client/starwhale/base/scheduler/step.py
@@ -157,7 +157,6 @@ class StepExecutor:
         workdir: Path,
         dataset_uris: t.List[str],
         task_num: int = 0,
-        handler_args: t.List[str] | None = None,
         dataset_head: int = 0,
         finetune_val_dataset_uris: t.List[str] | None = None,
         model_name: str = "",
@@ -169,7 +168,6 @@ class StepExecutor:
         self.dataset_uris = dataset_uris
         self.workdir = workdir
         self.version = version
-        self.handler_args = handler_args or []
         self.dataset_head = dataset_head
         self.finetune_val_dataset_uris = finetune_val_dataset_uris
         self.model_name = model_name
@@ -199,7 +197,6 @@ class StepExecutor:
                     finetune_val_dataset_uris=self.finetune_val_dataset_uris,
                     model_name=self.model_name,
                 ),
-                handler_args=self.handler_args,
                 step=self.step,
                 workdir=self.workdir,
             )

--- a/client/starwhale/base/scheduler/task.py
+++ b/client/starwhale/base/scheduler/task.py
@@ -32,7 +32,6 @@ class TaskExecutor:
         context: Context,
         workdir: Path,
         step: Step,
-        handler_args: t.List[str] | None = None,
     ):
         self.index = index
         self.context = context
@@ -40,7 +39,6 @@ class TaskExecutor:
         self.exception: t.Optional[Exception] = None
         self.step = step
         self.__status = RunStatus.INIT
-        self.handler_args = handler_args or []
         self._validate()
 
     def _validate(self) -> None:
@@ -128,10 +126,7 @@ class TaskExecutor:
                 elif getattr(func, DecoratorInjectAttr.Predict, False):
                     self._run_in_pipeline_handler_cls(func, "predict")
                 elif getattr(func, DecoratorInjectAttr.Step, False):
-                    if self.handler_args:
-                        func(**{"handler_args": self.handler_args})
-                    else:
-                        func()
+                    func()
                 else:
                     raise NoSupportError(
                         f"func({self.step.module_name}.{self.step.func_name}) should use @handler, @predict, @evaluate or @finetune decorator"
@@ -151,10 +146,7 @@ class TaskExecutor:
                     elif getattr(func, DecoratorInjectAttr.Predict, False):
                         self._run_in_pipeline_handler_cls(func, "predict")
                     else:
-                        if self.handler_args:
-                            func(**{"handler_args": self.handler_args})
-                        else:
-                            func()
+                        func()
             else:
                 func = getattr(cls_(), func_name)
                 if getattr(func, DecoratorInjectAttr.Evaluate, False):
@@ -162,10 +154,7 @@ class TaskExecutor:
                 elif getattr(func, DecoratorInjectAttr.Predict, False):
                     self._run_in_pipeline_handler_cls(func, "predict")
                 else:
-                    if self.handler_args:
-                        func(**{"handler_args": self.handler_args})
-                    else:
-                        func()
+                    func()
 
     def execute(self) -> TaskResult:
         console.info(

--- a/client/starwhale/core/model/cli.py
+++ b/client/starwhale/core/model/cli.py
@@ -729,7 +729,6 @@ def _run(
                 "task_num": override_task_num,
             },
             force_generate_jobs_yaml=uri is None,
-            handler_args=ctx.args,
         )
 
 

--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -362,7 +362,6 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
         forbid_snapshot: bool = False,
         cleanup_snapshot: bool = True,
         force_generate_jobs_yaml: bool = False,
-        handler_args: t.List[str] | None = None,
     ) -> Resource:
         dataset_uris = dataset_uris or []
         finetune_val_dataset_uris = finetune_val_dataset_uris or []
@@ -401,7 +400,6 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
             workdir=snapshot_dir,
             dataset_uris=dataset_uris,
             steps=steps,
-            handler_args=handler_args or [],
             dataset_head=dataset_head,
             finetune_val_dataset_uris=finetune_val_dataset_uris,
             model_name=model_config.name,

--- a/client/starwhale/core/model/view.py
+++ b/client/starwhale/core/model/view.py
@@ -263,7 +263,6 @@ class ModelTermView(BaseTermView, TagViewMixin):
         forbid_snapshot: bool = False,
         cleanup_snapshot: bool = True,
         force_generate_jobs_yaml: bool = False,
-        handler_args: t.List[str] | None = None,
     ) -> None:
         if runtime_uri:
             RuntimeProcess(uri=runtime_uri).run()
@@ -282,7 +281,6 @@ class ModelTermView(BaseTermView, TagViewMixin):
                 forbid_snapshot=forbid_snapshot,
                 cleanup_snapshot=cleanup_snapshot,
                 force_generate_jobs_yaml=force_generate_jobs_yaml,
-                handler_args=handler_args or [],
             )
 
     @classmethod

--- a/client/tests/sdk/test_job_handler.py
+++ b/client/tests/sdk/test_job_handler.py
@@ -13,11 +13,7 @@ from starwhale.base.scheduler import Step, Scheduler, TaskExecutor
 from starwhale.base.models.base import obj_to_model
 from starwhale.base.uri.project import Project
 from starwhale.base.models.model import JobHandlers, StepSpecClient
-from starwhale.base.client.models.models import (
-    FineTune,
-    RuntimeResource,
-    ParameterSignature,
-)
+from starwhale.base.client.models.models import FineTune, RuntimeResource
 
 
 class JobTestCase(unittest.TestCase):
@@ -248,8 +244,6 @@ def mock_predict_handler2(data, argument=None): ...
                 show_name="predict",
                 expose=0,
                 require_dataset=True,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
             StepSpecClient(
                 cls_name="",
@@ -263,8 +257,6 @@ def mock_predict_handler2(data, argument=None): ...
                 show_name="evaluate",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
         ]
 
@@ -288,8 +280,6 @@ def mock_predict_handler2(data, argument=None): ...
                 show_name="predict",
                 expose=0,
                 require_dataset=True,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
             StepSpecClient(
                 cls_name="",
@@ -303,8 +293,6 @@ def mock_predict_handler2(data, argument=None): ...
                 show_name="evaluate",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
         ]
 
@@ -352,8 +340,6 @@ def evaluate_handler(*args, **kwargs): ...
                     show_name="predict",
                     expose=0,
                     require_dataset=True,
-                    parameters_sig=[],
-                    ext_cmd_args="",
                 ),
                 StepSpecClient(
                     cls_name="",
@@ -367,8 +353,6 @@ def evaluate_handler(*args, **kwargs): ...
                     show_name="evaluate",
                     expose=0,
                     require_dataset=False,
-                    parameters_sig=[],
-                    ext_cmd_args="",
                 ),
             ],
             "mock_user_module:predict_handler": [
@@ -391,8 +375,6 @@ def evaluate_handler(*args, **kwargs): ...
                     show_name="predict",
                     expose=0,
                     require_dataset=True,
-                    parameters_sig=[],
-                    ext_cmd_args="",
                 )
             ],
         }
@@ -517,8 +499,6 @@ class MockHandler(PipelineHandler):
                 show_name="predict",
                 expose=0,
                 require_dataset=True,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
             StepSpecClient(
                 cls_name="MockHandler",
@@ -534,8 +514,6 @@ class MockHandler(PipelineHandler):
                 show_name="evaluate",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
         ]
         assert jobs_info["mock_user_module:MockHandler.predict"] == [
@@ -552,8 +530,6 @@ class MockHandler(PipelineHandler):
                 show_name="predict",
                 expose=0,
                 require_dataset=True,
-                parameters_sig=[],
-                ext_cmd_args="",
             )
         ]
         _, steps = Step.get_steps_from_yaml(
@@ -620,8 +596,6 @@ class MockHandler:
                 show_name="predict",
                 expose=0,
                 require_dataset=True,
-                parameters_sig=[],
-                ext_cmd_args="",
             )
         ]
 
@@ -645,8 +619,6 @@ class MockHandler:
                 show_name="predict",
                 expose=0,
                 require_dataset=True,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
             StepSpecClient(
                 cls_name="MockHandler",
@@ -660,8 +632,6 @@ class MockHandler:
                 show_name="evaluate",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
         ]
 
@@ -712,18 +682,22 @@ def run(): ...
                     show_name="run",
                     expose=0,
                     require_dataset=False,
-                    parameters_sig=[],
-                    ext_cmd_args="",
                 )
             ]
         }
 
     def test_handler_with_other_decorator(self) -> None:
         content = """
-from starwhale import handler
+import dataclasses
+from starwhale import handler, argument
 
+@dataclasses.dataclass
+class TestArgument:
+    epoch: int = dataclasses.field(default=1)
+
+@argument(TestArgument)
 @handler(replicas=2)
-def handle(context): ...
+def handle(argument): ...
         """
 
         self._ensure_py_script(content)
@@ -744,14 +718,6 @@ def handle(context): ...
                     show_name="handle",
                     expose=0,
                     require_dataset=False,
-                    parameters_sig=[
-                        ParameterSignature(
-                            name="context",
-                            required=True,
-                            multiple=False,
-                        )
-                    ],
-                    ext_cmd_args="--context",
                 )
             ]
         }
@@ -791,9 +757,7 @@ def ft2(): ...
                     expose=0,
                     replicas=1,
                     resources=[],
-                    parameters_sig=[],
                     cls_name="",
-                    ext_cmd_args="",
                     extra_kwargs={
                         "auto_build_model": True,
                     },
@@ -814,9 +778,7 @@ def ft2(): ...
                     expose=0,
                     replicas=1,
                     resources=[],
-                    parameters_sig=[],
                     cls_name="",
-                    ext_cmd_args="",
                     extra_kwargs={
                         "auto_build_model": True,
                     },
@@ -841,9 +803,7 @@ def ft2(): ...
                     replicas=1,
                     needs=["mock_user_module:ft1"],
                     expose=0,
-                    parameters_sig=[],
                     cls_name="",
-                    ext_cmd_args="",
                     extra_kwargs={
                         "auto_build_model": False,
                     },
@@ -914,9 +874,7 @@ class MockReport:
                 needs=[],
                 expose=0,
                 resources=[],
-                parameters_sig=[],
                 cls_name="",
-                ext_cmd_args="",
             )
             in report_handler
         )
@@ -932,9 +890,7 @@ class MockReport:
                 needs=["mock_user_module:prepare_handler"],
                 expose=0,
                 resources=[],
-                parameters_sig=[],
                 cls_name="",
-                ext_cmd_args="",
             )
             in report_handler
         )
@@ -950,9 +906,7 @@ class MockReport:
                 show_name="evaluate",
                 expose=0,
                 replicas=1,
-                parameters_sig=[],
                 cls_name="",
-                ext_cmd_args="",
             )
             in report_handler
         )
@@ -972,8 +926,6 @@ class MockReport:
                 show_name="report",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             )
             in report_handler
         )
@@ -989,8 +941,6 @@ class MockReport:
             show_name="predict",
             expose=0,
             require_dataset=False,
-            parameters_sig=[],
-            ext_cmd_args="",
         )
 
         assert jobs_info["mock_user_module:evaluate_handler"] == [
@@ -1005,8 +955,6 @@ class MockReport:
                 show_name="prepare",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
             StepSpecClient(
                 cls_name="",
@@ -1019,8 +967,6 @@ class MockReport:
                 show_name="evaluate",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
         ]
         assert jobs_info["mock_user_module:predict_handler"] == [
@@ -1035,8 +981,6 @@ class MockReport:
                 show_name="prepare",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
             StepSpecClient(
                 cls_name="",
@@ -1049,8 +993,6 @@ class MockReport:
                 show_name="predict",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             ),
         ]
         assert jobs_info["mock_user_module:prepare_handler"] == [
@@ -1065,8 +1007,6 @@ class MockReport:
                 show_name="prepare",
                 expose=0,
                 require_dataset=False,
-                parameters_sig=[],
-                ext_cmd_args="",
             )
         ]
 
@@ -1265,203 +1205,3 @@ def predict_handler(): ...
         yaml_path = self.workdir / "job.yaml"
         with self.assertRaisesRegex(RuntimeError, "dependency not found"):
             generate_jobs_yaml([self.module_name], self.workdir, yaml_path)
-
-    def test_handler_args(self) -> None:
-        content = """
-from starwhale import (
-    Context,
-    Dataset,
-    handler,
-    IntInput,
-    ListInput,
-    HandlerInput,
-    ContextInput,
-    DatasetInput,
-)
-
-class MyInput(HandlerInput):
-    def parse(self, user_input):
-
-        return f"MyInput {user_input}"
-
-class X:
-    def __init__(self) -> None:
-        self.a = 1
-
-    @handler()
-    def f(
-        self, x=ListInput(IntInput), y=2, mi=MyInput(), ds=DatasetInput(required=True), ctx=ContextInput()
-    ):
-        assert self.a + x[0] == 3
-        assert self.a + x[1] == 2
-        assert y == 2
-        assert mi == "MyInput blab-la"
-        assert isinstance(ds, Dataset)
-        assert isinstance(ctx, Context)
-
-
-@handler()
-def f(x=ListInput(IntInput()), y=2, mi=MyInput(),  ds=DatasetInput(required=True), ctx=ContextInput()):
-    assert x[0] == 2
-    assert x[1] == 1
-    assert y == 2
-    assert mi == "MyInput blab-la"
-
-    assert isinstance(ds, Dataset)
-    assert isinstance(ctx, Context)
-
-@handler()
-def f_no_args():
-    print("code here is executed")
-
-
-"""
-        self._ensure_py_script(content)
-        yaml_path = self.workdir / "job.yaml"
-        generate_jobs_yaml(
-            [f"{self.module_name}:X", self.module_name], self.workdir, yaml_path
-        )
-        jobs_info = obj_to_model(load_yaml(yaml_path), JobHandlers).data
-        assert jobs_info["mock_user_module:X.f"] == [
-            StepSpecClient(
-                name="mock_user_module:X.f",
-                cls_name="X",
-                func_name="f",
-                module_name="mock_user_module",
-                show_name="f",
-                parameters_sig=[
-                    ParameterSignature(
-                        name="x",
-                        required=False,
-                        multiple=True,
-                    ),
-                    ParameterSignature(
-                        name="y",
-                        required=False,
-                        multiple=False,
-                    ),
-                    ParameterSignature(
-                        name="mi",
-                        required=False,
-                        multiple=False,
-                    ),
-                    ParameterSignature(
-                        name="ds",
-                        required=True,
-                        multiple=False,
-                    ),
-                    ParameterSignature(
-                        name="ctx",
-                        required=False,
-                        multiple=False,
-                    ),
-                ],
-                ext_cmd_args="--ds",
-                needs=[],
-                resources=[],
-                expose=0,
-                require_dataset=False,
-            ),
-        ]
-        assert jobs_info["mock_user_module:f"] == [
-            StepSpecClient(
-                name="mock_user_module:f",
-                cls_name="",
-                func_name="f",
-                module_name="mock_user_module",
-                show_name="f",
-                parameters_sig=[
-                    ParameterSignature(
-                        name="x",
-                        required=False,
-                        multiple=True,
-                    ),
-                    ParameterSignature(
-                        name="y",
-                        required=False,
-                        multiple=False,
-                    ),
-                    ParameterSignature(
-                        name="mi",
-                        required=False,
-                        multiple=False,
-                    ),
-                    ParameterSignature(
-                        name="ds",
-                        required=True,
-                        multiple=False,
-                    ),
-                    ParameterSignature(
-                        name="ctx",
-                        required=False,
-                        multiple=False,
-                    ),
-                ],
-                ext_cmd_args="--ds",
-                needs=[],
-                resources=[],
-                expose=0,
-                require_dataset=False,
-            ),
-        ]
-        assert jobs_info["mock_user_module:f_no_args"] == [
-            StepSpecClient(
-                name="mock_user_module:f_no_args",
-                cls_name="",
-                func_name="f_no_args",
-                module_name="mock_user_module",
-                show_name="f_no_args",
-                parameters_sig=[],
-                ext_cmd_args="",
-                needs=[],
-                resources=[],
-                expose=0,
-                require_dataset=False,
-            ),
-        ]
-        _, steps = Step.get_steps_from_yaml("mock_user_module:X.f", yaml_path)
-        context = Context(
-            workdir=self.workdir,
-            run_project=Project("test"),
-            version="123",
-        )
-        task = TaskExecutor(
-            index=1,
-            context=context,
-            workdir=self.workdir,
-            step=steps[0],
-            handler_args=["--x", "2", "-x", "1", "--ds", "mnist", "-mi=blab-la"],
-        )
-        result = task.execute()
-        assert result.status == "success"
-        _, steps = Step.get_steps_from_yaml("mock_user_module:f", yaml_path)
-        context = Context(
-            workdir=self.workdir,
-            run_project=Project("test"),
-            version="123",
-        )
-        task = TaskExecutor(
-            index=1,
-            context=context,
-            workdir=self.workdir,
-            step=steps[0],
-            handler_args=["--x", "2", "-x", "1", "--ds", "mnist", "-mi=blab-la"],
-        )
-        result = task.execute()
-        assert result.status == "success"
-
-        _, steps = Step.get_steps_from_yaml("mock_user_module:f_no_args", yaml_path)
-        context = Context(
-            workdir=self.workdir,
-            run_project=Project("test"),
-            version="123",
-        )
-        task = TaskExecutor(
-            index=1,
-            context=context,
-            workdir=self.workdir,
-            step=steps[0],
-            handler_args=[],
-        )
-        result = task.execute()
-        assert result.status == "success"

--- a/client/tests/sdk/test_model.py
+++ b/client/tests/sdk/test_model.py
@@ -192,8 +192,6 @@ model.build(modules=[handle], workdir=ROOTDIR, name="inner")
                         show_name="handle",
                         expose=0,
                         require_dataset=False,
-                        parameters_sig=[],
-                        ext_cmd_args="",
                     )
                 ]
             }

--- a/scripts/client_test/cli_test.py
+++ b/scripts/client_test/cli_test.py
@@ -358,7 +358,23 @@ class TestCli:
         dataset_uri = self.build_dataset("simple", workdir, DatasetExpl("", ""))
 
         remote_job_ids = []
+        handler_args = [
+            "--learning_rate",
+            "0.1",
+            "--epoch",
+            "100",
+            "--labels",
+            "l1",
+            "--labels",
+            "l2",
+            "--labels",
+            "l3",
+            "--debug",
+            "--evaluation_strategy",
+            "steps",
+        ]
         if self.server_url:
+            # TODO: support to specify model run arguments to server instance
             remote_job_ids = self.run_model_in_server(
                 dataset_uris=[dataset_uri],
                 model_uri=model_uri,
@@ -380,26 +396,14 @@ class TestCli:
                     )
                 ],
                 run_handler=run_handler,
+                handler_args=handler_args,
             )
 
         self.run_model_in_standalone(
             dataset_uris=[dataset_uri],
             model_uri=model_uri,
             run_handler=run_handler,
-        )
-
-        self.run_model_in_standalone(
-            dataset_uris=[],
-            model_uri=model_uri,
-            run_handler="src.evaluator:f",
-            handler_args=["--x", "2", "-x", "1", "--ds", "simple", "-mi=blab-la"],
-        )
-
-        self.run_model_in_standalone(
-            dataset_uris=[],
-            model_uri=model_uri,
-            run_handler="src.evaluator:X.f",
-            handler_args=["--x", "2", "-x", "1", "--ds", "simple", "-mi=blab-la"],
+            handler_args=handler_args,
         )
 
         futures = [
@@ -597,18 +601,14 @@ class TestCli:
         assert set(ctx_handle_info["handlers"]) == {
             "src.evaluator:evaluate",
             "src.evaluator:predict",
-            "src.evaluator:f",
-            "src.evaluator:X.f",
             "src.sdk_model_build:context_handle",
             "src.sdk_model_build:ft",
-        }, ctx_handle_info["basic"]["handlers"]
+        }, ctx_handle_info["handlers"]
 
         ctx_handle_no_modules_info = self.model_api.info("ctx_handle_no_modules")
         assert set(ctx_handle_no_modules_info["handlers"]) == {
             "src.evaluator:evaluate",
             "src.evaluator:predict",
-            "src.evaluator:f",
-            "src.evaluator:X.f",
             "src.sdk_model_build:context_handle",
             "src.sdk_model_build:ft",
         }, ctx_handle_no_modules_info["handlers"]


### PR DESCRIPTION
## Description
depends on: https://github.com/star-whale/starwhale/pull/3095
Changes:
- Replace `IntInput, BoolInput...` with Python [typing hint](https://docs.python.org/3/library/typing.html)
- Expand the capability to customize argument mechanisms across all functions, as currently only the @handler decorator supports external arguments.
- Employ dataclasses for bundling arguments, leveraging a feature that is widely adopted in machine learning libraries.

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
