### PR TITLE
feat(client): dump arguments to json file when model building

### DIFF
--- a/client/starwhale/consts/__init__.py
+++ b/client/starwhale/consts/__init__.py
@@ -21,6 +21,8 @@ SW_BUILT_IN = "starwhale-built-in"
 
 # evaluation related constants
 DEFAULT_JOBS_FILE_NAME = "jobs.yaml"
+# dump @starwhale.argument received dataclasses to json file
+ARGUMENTS_DUMPED_JSON_FILE_NAME = "arguments.json"
 # auto generated evaluation panel layout file name from yaml or local console
 EVALUATION_PANEL_LAYOUT_JSON_FILE_NAME = "eval_panel_layout.json"
 # user defined evaluation panel layout file name

--- a/client/starwhale/core/model/model.py
+++ b/client/starwhale/core/model/model.py
@@ -40,6 +40,7 @@ from starwhale.consts import (
     DEFAULT_RESOURCE_POOL,
     DEFAULT_JOBS_FILE_NAME,
     DEFAULT_STARWHALE_API_VERSION,
+    ARGUMENTS_DUMPED_JSON_FILE_NAME,
     EVALUATION_PANEL_LAYOUT_JSON_FILE_NAME,
     EVALUATION_PANEL_LAYOUT_YAML_FILE_NAME,
     DEFAULT_FILE_SIZE_THRESHOLD_TO_TAR_IN_MODEL,
@@ -286,6 +287,16 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
             service_spec=spec,
         )
         Handler._register(h, func)
+
+    def _gen_arguments_json(self) -> None:
+        from starwhale.api._impl.argument import ArgumentContext
+
+        ctx = ArgumentContext.get_current_context()
+        ensure_file(
+            self.store.src_dir / SW_AUTO_DIRNAME / ARGUMENTS_DUMPED_JSON_FILE_NAME,
+            json.dumps(ctx.asdict(), indent=4),
+            parents=True,
+        )
 
     def _render_eval_layout(self, workdir: Path) -> None:
         # render eval layout
@@ -663,6 +674,11 @@ class StandaloneModel(Model, LocalStorageBundleMixin):
                     / SW_AUTO_DIRNAME
                     / DEFAULT_JOBS_FILE_NAME,
                 ),
+            ),
+            (
+                self._gen_arguments_json,
+                5,
+                "generate arguments json",
             ),
             (
                 self._render_eval_layout,

--- a/client/tests/core/test_model.py
+++ b/client/tests/core/test_model.py
@@ -25,6 +25,7 @@ from starwhale.consts import (
     RESOURCE_FILES_NAME,
     DEFAULT_MANIFEST_NAME,
     DEFAULT_JOBS_FILE_NAME,
+    ARGUMENTS_DUMPED_JSON_FILE_NAME,
     EVALUATION_PANEL_LAYOUT_JSON_FILE_NAME,
     EVALUATION_PANEL_LAYOUT_YAML_FILE_NAME,
 )
@@ -234,6 +235,12 @@ class StandaloneModelTestCase(TestCase):
                 ),
             ],
         }
+
+        argument_json_path = (
+            bundle_path / "src" / SW_AUTO_DIRNAME / ARGUMENTS_DUMPED_JSON_FILE_NAME
+        )
+        assert argument_json_path.exists()
+        assert json.loads(argument_json_path.read_text()) == {}
 
         _manifest = load_yaml(bundle_path / DEFAULT_MANIFEST_NAME)
         assert "name" not in _manifest


### PR DESCRIPTION
## Description
depends on:  https://github.com/star-whale/starwhale/pull/3101

![image](https://github.com/star-whale/starwhale/assets/590748/69be886a-1ade-4826-897b-ebcfed977419)

argument json example:
```json
{
    "evaluation:predict_image": {
        "evaluation:EvaluationArguments": {
            "reshape": {
                "name": "reshape",
                "opts": [
                    "--reshape"
                ],
                "type": {
                    "name": "integer",
                    "param_type": "INT",
                    "choices": null,
                    "case_sensitive": false
                },
                "required": false,
                "multiple": false,
                "default": 64,
                "help": "reshape image size",
                "is_flag": false,
                "hidden": false
            }
        }
    }
}
```

## Modules
- [x] Client

## Checklist
- [x] run code format and lint check
- [x] add unit test
- [ ] add necessary doc
