### PR TITLE
update(console): editor bubble menu invalid when readonly & header dropdown zindex

### DIFF
--- a/console/packages/starwhale-ui/src/GridTable/components/TableActions.tsx
+++ b/console/packages/starwhale-ui/src/GridTable/components/TableActions.tsx
@@ -33,7 +33,7 @@ const getPopoverOverrides = ({ left, top }) => {
                 },
             },
             style: {
-                zIndex: 999,
+                zIndex: 99,
             },
         },
     }

--- a/console/packages/starwhale-ui/src/TiptapEditor/index.tsx
+++ b/console/packages/starwhale-ui/src/TiptapEditor/index.tsx
@@ -97,7 +97,7 @@ export default function TiptapEditor({ id = '', initialContent, editable, onSave
             // tabIndex={0}
             className='relative self-center min-h-[500px] w-full h-full bg-white sm:mb-[calc(10px)] sm:rounded-lg'
         >
-            {editor && <EditorBubbleMenu editor={editor} />}
+            {editor && editable && <EditorBubbleMenu editor={editor} />}
             <EditorContent editor={editor} />
         </div>
     )


### PR DESCRIPTION
## Description

## Modules
- [x] UI
- [ ] Controller
- [ ] Agent
- [ ] Client
- [ ] Python-SDK
- [ ] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
