### PR TITLE
bug(entrypoint): fix external cmd args quote error

### DIFF
--- a/client/scripts/sw-docker-entrypoint
+++ b/client/scripts/sw-docker-entrypoint
@@ -75,7 +75,7 @@ run() {
         --uri="${SW_MODEL_URI}" --version="${SW_JOB_VERSION}" \
         --log-project="${SW_PROJECT_URI}" \
         --forbid-snapshot \
-        ${runtime_args} -- "${SW_TASK_EXTRA_CMD_ARGS}" || exit 1
+        ${runtime_args} -- ${SW_TASK_EXTRA_CMD_ARGS} || exit 1
 }
 
 serve() {


### PR DESCRIPTION
## Description

## Modules
- [x] Others

## Checklist
- [ ] run code format and lint check
- [ ] add unit test
- [ ] add necessary doc
